### PR TITLE
Add config models for ADR-003

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
 
     # Config paths
     "platformdirs>=4.5.1",
+
+    # TOML (preserves comments and formatting on round-trip)
+    "tomlkit>=0.14.0",
 ]
 
 [project.optional-dependencies]

--- a/src/kist/cli/app.py
+++ b/src/kist/cli/app.py
@@ -1,5 +1,7 @@
 """kist CLI entrypoint."""
 
+from pathlib import Path
+
 import typer
 
 from kist import __version__
@@ -29,9 +31,58 @@ def main(
 
 
 @app.command()
-def init() -> None:
-    """Initialise a kist parts library in the current directory."""
-    typer.echo("Not yet implemented.")
+def init(
+    path: Path = typer.Option(
+        ".", "--path", "-p", help="Directory to initialise (default: cwd)."
+    ),
+    symbols_dir: str | None = typer.Option(
+        None, "--symbols-dir", help="Symbol library directory name."
+    ),
+    footprints_dir: str | None = typer.Option(
+        None, "--footprints-dir", help="Footprint library directory name."
+    ),
+    models_dir: str | None = typer.Option(
+        None, "--models-dir", help="3D model directory name."
+    ),
+    blocks_dir: str | None = typer.Option(
+        None, "--blocks-dir", help="Design blocks directory name."
+    ),
+) -> None:
+    """Initialise a new kist parts library."""
+    from kist.core.library import init_library
+    from kist.errors import LibraryExistsError
+
+    try:
+        root = init_library(
+            path,
+            symbols_dir=symbols_dir,
+            footprints_dir=footprints_dir,
+            models_dir=models_dir,
+            blocks_dir=blocks_dir,
+        )
+        typer.echo(f"Initialised kist library at {root}")
+    except LibraryExistsError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from None
+
+
+@app.command()
+def link(
+    library: Path = typer.Argument(help="Path to an existing kist library."),
+    path: Path = typer.Option(
+        ".", "--path", "-p", help="Project directory to link from (default: cwd)."
+    ),
+) -> None:
+    """Link a project directory to an existing kist library."""
+    from kist.core.library import link_library
+    from kist.errors import LibraryExistsError, LibraryNotFoundError
+
+    try:
+        ref_path = link_library(path, library)
+        typer.echo(f"Linked to library via {ref_path}")
+    except (LibraryNotFoundError, LibraryExistsError) as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from None
 
 
 @app.command()

--- a/src/kist/core/config.py
+++ b/src/kist/core/config.py
@@ -1,0 +1,85 @@
+"""Configuration I/O and resolution."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import platformdirs
+import tomlkit
+import tomlkit.exceptions
+
+from kist.errors import ConfigError
+from kist.models.config import GlobalConfig, LibraryConfig, ProjectRef
+
+KIST_MARKER = ".kist"
+PROJECT_REF = "kist.toml"
+LIBRARY_CONFIG = "config.toml"
+
+
+def _get_config_dir() -> Path:
+    """Return the global config directory, respecting KIST_CONFIG_DIR."""
+    env = os.environ.get("KIST_CONFIG_DIR")
+    if env:
+        return Path(env)
+    return Path(platformdirs.user_config_dir("kist"))
+
+
+def load_global_config() -> GlobalConfig:
+    """Load global config, returning defaults if the file is absent."""
+    path = _get_config_dir() / LIBRARY_CONFIG
+    if not path.exists():
+        return GlobalConfig()
+    try:
+        data = tomlkit.loads(path.read_text())
+        return GlobalConfig.model_validate(dict(data))
+    except (OSError, tomlkit.exceptions.ParseError) as exc:
+        raise ConfigError(f"Failed to read global config {path}: {exc}") from exc
+
+
+def resolve_init_config(**overrides: str | list[str] | None) -> LibraryConfig:
+    """Merge built-in defaults, global config, and CLI overrides."""
+    global_cfg = load_global_config()
+    merged = global_cfg.model_dump()
+    for key, value in overrides.items():
+        if value is not None:
+            merged[key] = value
+    return LibraryConfig.model_validate(merged)
+
+
+def load_library_config(library_root: Path) -> LibraryConfig:
+    """Read .kist/config.toml from a library root."""
+    path = library_root / KIST_MARKER / LIBRARY_CONFIG
+    if not path.exists():
+        raise ConfigError(f"Library config not found: {path}")
+    try:
+        data = tomlkit.loads(path.read_text())
+        return LibraryConfig.model_validate(dict(data))
+    except (OSError, tomlkit.exceptions.ParseError) as exc:
+        raise ConfigError(f"Failed to read library config {path}: {exc}") from exc
+
+
+def save_library_config(library_root: Path, config: LibraryConfig) -> None:
+    """Write config to .kist/config.toml, creating .kist/ if needed."""
+    kist_dir = library_root / KIST_MARKER
+    kist_dir.mkdir(parents=True, exist_ok=True)
+    path = kist_dir / LIBRARY_CONFIG
+    doc = tomlkit.dumps(config.model_dump())
+    path.write_text(doc)
+
+
+def load_project_ref(path: Path) -> ProjectRef:
+    """Read a kist.toml project reference."""
+    if not path.exists():
+        raise ConfigError(f"Project reference not found: {path}")
+    try:
+        data = tomlkit.loads(path.read_text())
+        return ProjectRef.model_validate(dict(data))
+    except (OSError, tomlkit.exceptions.ParseError) as exc:
+        raise ConfigError(f"Failed to read project reference {path}: {exc}") from exc
+
+
+def save_project_ref(path: Path, ref: ProjectRef) -> None:
+    """Write a kist.toml project reference."""
+    doc = tomlkit.dumps(ref.model_dump())
+    path.write_text(doc)

--- a/src/kist/core/library.py
+++ b/src/kist/core/library.py
@@ -1,0 +1,145 @@
+"""Library operations: init, link, and discovery."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from kist.core.config import (
+    KIST_MARKER,
+    PROJECT_REF,
+    load_project_ref,
+    resolve_init_config,
+    save_library_config,
+    save_project_ref,
+)
+from kist.core.database import create_empty
+from kist.errors import LibraryExistsError, LibraryNotFoundError
+from kist.models.config import ProjectRef
+
+
+def init_library(
+    path: Path,
+    *,
+    symbols_dir: str | None = None,
+    footprints_dir: str | None = None,
+    models_dir: str | None = None,
+    blocks_dir: str | None = None,
+) -> Path:
+    """
+    Create a new kist library at *path*.
+
+    Returns the resolved path to the library root.
+    """
+    path = path.resolve()
+    kist_dir = path / KIST_MARKER
+
+    if kist_dir.exists():
+        raise LibraryExistsError(f"Already initialised: {path}")
+
+    config = resolve_init_config(
+        symbols_dir=symbols_dir,
+        footprints_dir=footprints_dir,
+        models_dir=models_dir,
+        blocks_dir=blocks_dir,
+    )
+    save_library_config(path, config)
+
+    parts_json = path / "parts.json"
+    if not parts_json.exists():
+        create_empty(parts_json)
+
+    for subdir in (
+        config.symbols_dir,
+        config.footprints_dir,
+        config.models_dir,
+        config.blocks_dir,
+    ):
+        (path / subdir).mkdir(parents=True, exist_ok=True)
+
+    return path
+
+
+def link_library(target: Path, library: Path) -> Path:
+    """
+    Connect a project directory to an existing kist library.
+
+    Returns the path to the created kist.toml.
+    """
+    target = target.resolve()
+    library = library.resolve()
+
+    if not (library / KIST_MARKER).is_dir():
+        raise LibraryNotFoundError(f"Not a kist library: {library}")
+
+    ref_path = target / PROJECT_REF
+    if ref_path.exists():
+        raise LibraryExistsError(f"Already linked: {ref_path}")
+
+    rel_path = os.path.relpath(library, target)
+    save_project_ref(ref_path, ProjectRef(library_path=rel_path))
+
+    _create_lib_link(target / "lib", rel_path)
+
+    return ref_path
+
+
+def _create_lib_link(link: Path, target: str) -> None:
+    """Create a lib/ link for KiCad's ${KIPRJMOD}/lib/ convention.
+
+    Uses a symlink on Unix. On Windows, uses a directory junction which
+    doesn't require admin privileges or Developer Mode.
+
+    Non-fatal -- kist itself only needs kist.toml to find the library;
+    the link is a convenience for KiCad path resolution.
+    """
+    if link.exists():
+        return
+    try:
+        if sys.platform == "win32":
+            # Junction: no elevation required, works for local directories
+            subprocess.run(
+                ["cmd", "/c", "mklink", "/J", str(link), target],
+                check=True,
+                capture_output=True,
+            )
+        else:
+            link.symlink_to(target)
+    except (OSError, subprocess.CalledProcessError):
+        pass
+
+
+def find_library(start: Path | None = None) -> Path:
+    """
+    Walk up from *start* to find the nearest kist library.
+
+    Returns the library root directory.
+    """
+    current = (start or Path.cwd()).resolve()
+
+    while True:
+        if (current / KIST_MARKER).is_dir():
+            return current
+
+        ref_path = current / PROJECT_REF
+        if ref_path.is_file():
+            ref = load_project_ref(ref_path)
+            library = (current / ref.library_path).resolve()
+            if (library / KIST_MARKER).is_dir():
+                return library
+            raise LibraryNotFoundError(
+                f"{ref_path} points to {ref.library_path}, "
+                f"but {library} is not a kist library."
+            )
+
+        parent = current.parent
+        if parent == current:
+            # Reached filesystem root (Path("/").parent == Path("/"))
+            raise LibraryNotFoundError(
+                f"Not a kist library (or any parent up to {current}).\n"
+                "Run 'kist init' to create a new library, or\n"
+                "'kist link <path>' to link to an existing one."
+            )
+        current = parent

--- a/src/kist/errors.py
+++ b/src/kist/errors.py
@@ -15,3 +15,15 @@ class DuplicatePartError(KistError):
 
 class DatabaseError(KistError):
     """Raised for JSON database read/write failures."""
+
+
+class LibraryNotFoundError(KistError):
+    """Raised when library discovery exhausts all parent directories."""
+
+
+class LibraryExistsError(KistError):
+    """Raised when initialising or linking in an already-configured directory."""
+
+
+class ConfigError(KistError):
+    """Raised for corrupt, missing, or invalid configuration files."""

--- a/src/kist/models/__init__.py
+++ b/src/kist/models/__init__.py
@@ -1,5 +1,11 @@
-"""Part data models."""
+"""Part and configuration data models."""
 
+from kist.models.config import (
+    DEFAULT_SUPPLIERS,
+    GlobalConfig,
+    LibraryConfig,
+    ProjectRef,
+)
 from kist.models.part import (
     CATEGORY_REFDES,
     Alternate,
@@ -20,11 +26,15 @@ __all__ = [
     "Alternate",
     "Category",
     "CATEGORY_REFDES",
+    "DEFAULT_SUPPLIERS",
+    "GlobalConfig",
     "Ipn",
     "JellybeanPart",
+    "LibraryConfig",
     "Mounting",
     "Part",
     "PartBase",
+    "ProjectRef",
     "ProprietaryPart",
     "RefDes",
     "SemiJellybeanPart",

--- a/src/kist/models/config.py
+++ b/src/kist/models/config.py
@@ -1,0 +1,39 @@
+"""Configuration models for library, global, and project-level config."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+DEFAULT_SUPPLIERS: list[str] = [
+    "digikey",
+    "mouser",
+    "lcsc",
+]
+
+
+class LibraryConfig(BaseModel):
+    """Per-library config, always has concrete values -- resolved at init time."""
+
+    version: int = 1
+    symbols_dir: str = "symbols"
+    footprints_dir: str = "footprints"
+    models_dir: str = "3dmodels"
+    blocks_dir: str = "blocks"
+    suppliers: list[str] = list(DEFAULT_SUPPLIERS)
+
+
+class GlobalConfig(BaseModel):
+    """User-level defaults. All fields optional with built-in defaults."""
+
+    symbols_dir: str = "symbols"
+    footprints_dir: str = "footprints"
+    models_dir: str = "3dmodels"
+    blocks_dir: str = "blocks"
+    suppliers: list[str] = list(DEFAULT_SUPPLIERS)
+
+
+class ProjectRef(BaseModel):
+    """Project-level reference pointing to a library root."""
+
+    version: int = 1
+    library_path: str

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -1,0 +1,95 @@
+"""CLI integration tests for init and link commands."""
+
+import pytest
+from typer.testing import CliRunner
+
+from kist.cli.app import app
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(tmp_path / "config"))
+
+
+# --- kist init ---
+
+
+def test_init_success(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
+    assert "Initialised" in result.output
+    assert (tmp_path / ".kist" / "config.toml").exists()
+
+
+def test_init_with_path(tmp_path):
+    target = tmp_path / "mylib"
+    result = runner.invoke(app, ["init", "--path", str(target)])
+    assert result.exit_code == 0
+    assert (target / ".kist" / "config.toml").exists()
+
+
+def test_init_with_dir_overrides(tmp_path):
+    result = runner.invoke(
+        app,
+        ["init", "--path", str(tmp_path), "--symbols-dir", "sym", "--blocks-dir", "b"],
+    )
+    assert result.exit_code == 0
+    assert (tmp_path / "sym").is_dir()
+    assert (tmp_path / "b").is_dir()
+
+
+def test_init_already_initialised(tmp_path):
+    runner.invoke(app, ["init", "--path", str(tmp_path)])
+    result = runner.invoke(app, ["init", "--path", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "Already initialised" in result.output
+
+
+# --- kist link ---
+
+
+def test_link_success(tmp_path, monkeypatch):
+    lib = tmp_path / "lib"
+    runner.invoke(app, ["init", "--path", str(lib)])
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["link", str(lib)])
+    assert result.exit_code == 0
+    assert "Linked" in result.output
+    assert (project / "kist.toml").exists()
+
+
+def test_link_with_path(tmp_path):
+    lib = tmp_path / "lib"
+    runner.invoke(app, ["init", "--path", str(lib)])
+    project = tmp_path / "project"
+    project.mkdir()
+
+    result = runner.invoke(app, ["link", str(lib), "--path", str(project)])
+    assert result.exit_code == 0
+    assert (project / "kist.toml").exists()
+
+
+def test_link_invalid_library(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["link", str(tmp_path / "nope")])
+    assert result.exit_code == 1
+    assert "Not a kist library" in result.output
+
+
+def test_link_already_linked(tmp_path, monkeypatch):
+    lib = tmp_path / "lib"
+    runner.invoke(app, ["init", "--path", str(lib)])
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    runner.invoke(app, ["link", str(lib)])
+    result = runner.invoke(app, ["link", str(lib)])
+    assert result.exit_code == 1
+    assert "Already linked" in result.output

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,146 @@
+"""Tests for configuration I/O and resolution."""
+
+import pytest
+
+from kist.core.config import (
+    load_global_config,
+    load_library_config,
+    load_project_ref,
+    resolve_init_config,
+    save_library_config,
+    save_project_ref,
+)
+from kist.errors import ConfigError
+from kist.models import DEFAULT_SUPPLIERS, LibraryConfig, ProjectRef
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(monkeypatch, tmp_path):
+    """Point global config at an empty temp directory for every test."""
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(tmp_path / "config"))
+
+
+# --- load_global_config ---
+
+
+def test_load_global_config_missing_file_returns_defaults():
+    cfg = load_global_config()
+    assert cfg.symbols_dir == "symbols"
+    assert cfg.suppliers == DEFAULT_SUPPLIERS
+
+
+def test_load_global_config_partial_toml(tmp_path, monkeypatch):
+    config_dir = tmp_path / "global"
+    config_dir.mkdir()
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(config_dir))
+    (config_dir / "config.toml").write_text('symbols_dir = "sym"\n')
+    cfg = load_global_config()
+    assert cfg.symbols_dir == "sym"
+    assert cfg.footprints_dir == "footprints"  # default preserved
+
+
+def test_load_global_config_invalid_toml(tmp_path, monkeypatch):
+    config_dir = tmp_path / "global"
+    config_dir.mkdir()
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(config_dir))
+    (config_dir / "config.toml").write_text("not valid toml [[[")
+    with pytest.raises(ConfigError):
+        load_global_config()
+
+
+# --- resolve_init_config ---
+
+
+def test_resolve_defaults_only():
+    cfg = resolve_init_config()
+    assert cfg.version == 1
+    assert cfg.symbols_dir == "symbols"
+    assert cfg.suppliers == DEFAULT_SUPPLIERS
+
+
+def test_resolve_global_merge(tmp_path, monkeypatch):
+    config_dir = tmp_path / "global"
+    config_dir.mkdir()
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(config_dir))
+    (config_dir / "config.toml").write_text(
+        'footprints_dir = "fp"\nsuppliers = ["digikey"]\n'
+    )
+    cfg = resolve_init_config()
+    assert cfg.footprints_dir == "fp"
+    assert cfg.suppliers == ["digikey"]
+    assert cfg.symbols_dir == "symbols"  # built-in default
+
+
+def test_resolve_cli_overrides():
+    cfg = resolve_init_config(symbols_dir="my-sym", blocks_dir="my-blk")
+    assert cfg.symbols_dir == "my-sym"
+    assert cfg.blocks_dir == "my-blk"
+    assert cfg.footprints_dir == "footprints"
+
+
+def test_resolve_none_filtering():
+    """None values from absent CLI flags are ignored."""
+    cfg = resolve_init_config(symbols_dir=None, footprints_dir="fp")
+    assert cfg.symbols_dir == "symbols"
+    assert cfg.footprints_dir == "fp"
+
+
+# --- save/load library config ---
+
+
+def test_library_config_roundtrip(tmp_path):
+    cfg = LibraryConfig(symbols_dir="sym", suppliers=["lcsc"])
+    save_library_config(tmp_path, cfg)
+    loaded = load_library_config(tmp_path)
+    assert loaded == cfg
+
+
+def test_library_config_creates_kist_dir(tmp_path):
+    save_library_config(tmp_path, LibraryConfig())
+    assert (tmp_path / ".kist").is_dir()
+    assert (tmp_path / ".kist" / "config.toml").exists()
+
+
+def test_load_library_config_missing_raises(tmp_path):
+    with pytest.raises(ConfigError, match="not found"):
+        load_library_config(tmp_path)
+
+
+def test_load_library_config_invalid_raises(tmp_path):
+    kist_dir = tmp_path / ".kist"
+    kist_dir.mkdir()
+    (kist_dir / "config.toml").write_text("bad toml [[[")
+    with pytest.raises(ConfigError):
+        load_library_config(tmp_path)
+
+
+# --- save/load project ref ---
+
+
+def test_project_ref_roundtrip(tmp_path):
+    ref = ProjectRef(library_path="../lib")
+    path = tmp_path / "kist.toml"
+    save_project_ref(path, ref)
+    loaded = load_project_ref(path)
+    assert loaded == ref
+
+
+def test_project_ref_toml_content(tmp_path):
+    ref = ProjectRef(library_path="./lib")
+    path = tmp_path / "kist.toml"
+    save_project_ref(path, ref)
+    content = path.read_text()
+    assert "version = 1" in content
+    assert 'library_path = "./lib"' in content
+
+
+def test_load_project_ref_missing_raises(tmp_path):
+    with pytest.raises(ConfigError, match="not found"):
+        load_project_ref(tmp_path / "kist.toml")
+
+
+def test_load_project_ref_invalid_raises(tmp_path):
+    path = tmp_path / "kist.toml"
+    path.write_text("bad [[[")
+    with pytest.raises(ConfigError):
+        load_project_ref(path)

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -1,0 +1,170 @@
+"""Tests for library operations: init, link, and discovery."""
+
+import pytest
+
+from kist.core.library import find_library, init_library, link_library
+from kist.errors import LibraryExistsError, LibraryNotFoundError
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(tmp_path / "config"))
+
+
+# --- init_library ---
+
+
+def test_init_creates_structure(tmp_path):
+    root = init_library(tmp_path / "lib")
+    assert (root / ".kist" / "config.toml").exists()
+    assert (root / "parts.json").exists()
+    assert (root / "symbols").is_dir()
+    assert (root / "footprints").is_dir()
+    assert (root / "3dmodels").is_dir()
+    assert (root / "blocks").is_dir()
+
+
+def test_init_respects_overrides(tmp_path):
+    root = init_library(tmp_path / "lib", symbols_dir="sym", footprints_dir="fp")
+    assert (root / "sym").is_dir()
+    assert (root / "fp").is_dir()
+    assert not (root / "symbols").exists()
+    assert not (root / "footprints").exists()
+
+
+def test_init_rejects_already_initialised(tmp_path):
+    init_library(tmp_path / "lib")
+    with pytest.raises(LibraryExistsError, match="Already initialised"):
+        init_library(tmp_path / "lib")
+
+
+def test_init_preserves_existing_dirs(tmp_path):
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    (lib / "symbols").mkdir()
+    (lib / "symbols" / "existing.kicad_sym").touch()
+    init_library(lib)
+    assert (lib / "symbols" / "existing.kicad_sym").exists()
+
+
+def test_init_preserves_existing_parts_json(tmp_path):
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    (lib / "parts.json").write_text('{"version": 1, "parts": {"a": "b"}}')
+    init_library(lib)
+    assert '"a"' in (lib / "parts.json").read_text()
+
+
+# --- link_library ---
+
+
+def test_link_creates_ref_and_symlink(tmp_path):
+    lib = tmp_path / "lib"
+    init_library(lib)
+    project = tmp_path / "project"
+    project.mkdir()
+
+    ref_path = link_library(project, lib)
+    assert ref_path.exists()
+    content = ref_path.read_text()
+    assert "library_path" in content
+    assert (project / "lib").is_symlink()
+
+
+def test_link_skips_existing_lib_dir(tmp_path):
+    lib = tmp_path / "lib"
+    init_library(lib)
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "lib").mkdir()  # e.g. git submodule
+
+    link_library(project, lib)
+    assert not (project / "lib").is_symlink()
+    assert (project / "lib").is_dir()
+
+
+def test_link_rejects_invalid_library(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    not_a_lib = tmp_path / "not-a-lib"
+    not_a_lib.mkdir()
+
+    with pytest.raises(LibraryNotFoundError, match="Not a kist library"):
+        link_library(project, not_a_lib)
+
+
+def test_link_rejects_already_linked(tmp_path):
+    lib = tmp_path / "lib"
+    init_library(lib)
+    project = tmp_path / "project"
+    project.mkdir()
+
+    link_library(project, lib)
+    with pytest.raises(LibraryExistsError, match="Already linked"):
+        link_library(project, lib)
+
+
+# --- find_library ---
+
+
+def test_find_from_library_root(tmp_path):
+    lib = tmp_path / "lib"
+    init_library(lib)
+    assert find_library(lib) == lib.resolve()
+
+
+def test_find_from_subdirectory(tmp_path):
+    lib = tmp_path / "lib"
+    init_library(lib)
+    subdir = lib / "symbols" / "deep"
+    subdir.mkdir(parents=True)
+    assert find_library(subdir) == lib.resolve()
+
+
+def test_find_via_project_ref(tmp_path):
+    lib = tmp_path / "lib"
+    init_library(lib)
+    project = tmp_path / "project"
+    project.mkdir()
+    link_library(project, lib)
+    assert find_library(project) == lib.resolve()
+
+
+def test_find_via_nested_subdir_to_project_ref(tmp_path):
+    lib = tmp_path / "lib"
+    init_library(lib)
+    project = tmp_path / "project"
+    project.mkdir()
+    link_library(project, lib)
+    subdir = project / "boards" / "rev-a"
+    subdir.mkdir(parents=True)
+    assert find_library(subdir) == lib.resolve()
+
+
+def test_find_not_found(tmp_path):
+    with pytest.raises(LibraryNotFoundError, match="Not a kist library"):
+        find_library(tmp_path)
+
+
+def test_find_invalid_reference(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "kist.toml").write_text('version = 1\nlibrary_path = "../nonexistent"\n')
+    with pytest.raises(LibraryNotFoundError, match="not a kist library"):
+        find_library(project)
+
+
+def test_find_prefers_kist_marker_over_ref(tmp_path):
+    """When both .kist/ and kist.toml exist, .kist/ wins."""
+    lib = tmp_path / "lib"
+    init_library(lib)
+    # Also drop a kist.toml pointing elsewhere
+    (lib / "kist.toml").write_text('version = 1\nlibrary_path = "../other"\n')
+    assert find_library(lib) == lib.resolve()
+
+
+def test_find_uses_cwd_default(tmp_path, monkeypatch):
+    lib = tmp_path / "lib"
+    init_library(lib)
+    monkeypatch.chdir(lib)
+    assert find_library() == lib.resolve()

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -1,0 +1,81 @@
+"""Tests for configuration models."""
+
+from kist.models import DEFAULT_SUPPLIERS, GlobalConfig, LibraryConfig, ProjectRef
+
+# --- DEFAULT_SUPPLIERS ---
+
+
+def test_default_suppliers_contents():
+    expected = ["digikey", "mouser", "lcsc"]
+    assert DEFAULT_SUPPLIERS == expected
+
+
+# --- LibraryConfig ---
+
+
+def test_library_config_defaults():
+    cfg = LibraryConfig()
+    assert cfg.version == 1
+    assert cfg.symbols_dir == "symbols"
+    assert cfg.footprints_dir == "footprints"
+    assert cfg.models_dir == "3dmodels"
+    assert cfg.blocks_dir == "blocks"
+    assert cfg.suppliers == DEFAULT_SUPPLIERS
+
+
+def test_library_config_custom_values():
+    cfg = LibraryConfig(
+        symbols_dir="sym",
+        footprints_dir="fp",
+        models_dir="models",
+        blocks_dir="blk",
+        suppliers=["digikey"],
+    )
+    assert cfg.symbols_dir == "sym"
+    assert cfg.footprints_dir == "fp"
+    assert cfg.models_dir == "models"
+    assert cfg.blocks_dir == "blk"
+    assert cfg.suppliers == ["digikey"]
+
+
+def test_library_config_roundtrip():
+    cfg = LibraryConfig(symbols_dir="custom-sym", suppliers=["lcsc", "mouser"])
+    data = cfg.model_dump()
+    restored = LibraryConfig.model_validate(data)
+    assert restored == cfg
+
+
+# --- GlobalConfig ---
+
+
+def test_global_config_defaults():
+    cfg = GlobalConfig()
+    assert cfg.symbols_dir == "symbols"
+    assert cfg.footprints_dir == "footprints"
+    assert cfg.models_dir == "3dmodels"
+    assert cfg.blocks_dir == "blocks"
+    assert cfg.suppliers == DEFAULT_SUPPLIERS
+
+
+def test_global_config_partial_override():
+    cfg = GlobalConfig(symbols_dir="my-symbols")
+    assert cfg.symbols_dir == "my-symbols"
+    # Other fields keep defaults
+    assert cfg.footprints_dir == "footprints"
+    assert cfg.suppliers == DEFAULT_SUPPLIERS
+
+
+# --- ProjectRef ---
+
+
+def test_project_ref_required_library_path():
+    ref = ProjectRef(library_path="./lib")
+    assert ref.version == 1
+    assert ref.library_path == "./lib"
+
+
+def test_project_ref_roundtrip():
+    ref = ProjectRef(library_path="../shared-lib")
+    data = ref.model_dump()
+    restored = ProjectRef.model_validate(data)
+    assert restored == ref

--- a/uv.lock
+++ b/uv.lock
@@ -204,6 +204,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "rich" },
     { name = "structlog" },
+    { name = "tomlkit" },
     { name = "typer" },
 ]
 
@@ -225,6 +226,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "rich", specifier = ">=14.3.2" },
     { name = "structlog", specifier = ">=25.5.0" },
+    { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "typer", specifier = ">=0.21.1" },
 ]
 provides-extras = ["dev"]
@@ -467,6 +469,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

ADR-003 defines a three-level config hierarchy (global, library, project ref) so that every kist command can find its library and know where symbols, footprints, and models live. This PR implements the data models, I/O layer, and init/link commands.

## Changes

- Add `tomlkit` dependency for round-trip TOML read/write
- `LibraryConfig`, `GlobalConfig`, `ProjectRef` pydantic models in `models/config.py`
- Config I/O in `core/config.py`: load/save for each level, defaults→global→CLI merge via `resolve_init_config()`
- `KIST_CONFIG_DIR` env var override for testability
- `LibraryNotFoundError`, `LibraryExistsError`, `ConfigError` added to error hierarchy
- `kist init` and `kist link` commands (pending -- next commit)

## Test plan

- 23 new tests covering model defaults, custom values, roundtrips, missing/corrupt file handling, merge logic, and None filtering
- Full suite passes (54 tests), ruff and ty clean

## Notes

- `pydantic-settings` is still in deps but unused -- cleanup deferred