### PR TITLE
core: Add naming engine

### DIFF
--- a/src/kist/core/naming.py
+++ b/src/kist/core/naming.py
@@ -3,6 +3,18 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from kist.models.part import (
+    Category,
+    JellybeanPart,
+    ProprietaryPart,
+    SemiJellybeanPart,
+)
+
+if TYPE_CHECKING:
+    from kist.models.part import Part
 
 _SI_PREFIXES: dict[str, float] = {
     "p": 1e-12,
@@ -360,3 +372,277 @@ def normalise_package(s: str) -> str:
     # Unknown: uppercase, strip hyphens between alpha and digits
     result = _PKG_HYPHEN_RE.sub(r"\1\2", s)
     return result.upper()
+
+
+# -- Key specs and spec normalisers (ADR-001 §7) ----------------------------
+
+KEY_SPECS: dict[tuple[Category, str | None], list[str]] = {
+    (Category.RES, None): ["resistance", "tolerance"],
+    (Category.CAP, "CER"): ["capacitance", "voltage_rating", "dielectric"],
+    (Category.CAP, "ELEC"): ["capacitance", "voltage_rating"],
+    (Category.CAP, "TANT"): ["capacitance", "voltage_rating"],
+    (Category.CAP, "FILM"): ["capacitance", "voltage_rating"],
+    (Category.IND, None): ["inductance", "current_rating"],
+    (Category.IND, "FERRITE"): ["impedance_100mhz", "current_rating"],
+    (Category.IND, "CM"): ["impedance", "current_rating"],
+    (Category.IND, "CHOKE"): ["inductance", "current_rating"],
+    (Category.DIO, None): ["reverse_voltage", "forward_current"],
+    (Category.DIO, "SCHOTTKY"): ["reverse_voltage", "forward_current"],
+    (Category.DIO, "ZENER"): ["zener_voltage", "power_rating"],
+    (Category.DIO, "TVS"): ["standoff_voltage", "peak_power"],
+    (Category.DIO, "LED"): ["colour"],
+    (Category.TRAN, "NMOS"): ["vds_max", "id_max"],
+    (Category.TRAN, "PMOS"): ["vds_max", "id_max"],
+    (Category.TRAN, "NPN"): ["vceo", "ic_max"],
+    (Category.TRAN, "PNP"): ["vceo", "ic_max"],
+    (Category.FUSE, None): ["current_rating", "voltage_rating"],
+    (Category.FUSE, "PTC"): ["hold_current", "voltage_rating"],
+    (Category.XTAL, None): ["frequency", "load_capacitance"],
+}
+
+SPEC_NORMALISERS: dict[str, Callable[[str], str]] = {
+    "resistance": normalise_resistance,
+    "capacitance": normalise_capacitance,
+    "inductance": normalise_inductance,
+    "tolerance": normalise_percentage,
+    "voltage_rating": normalise_voltage,
+    "reverse_voltage": normalise_voltage,
+    "zener_voltage": normalise_voltage,
+    "standoff_voltage": normalise_voltage,
+    "vds_max": normalise_voltage,
+    "vceo": normalise_voltage,
+    "forward_current": normalise_current,
+    "current_rating": normalise_current,
+    "id_max": normalise_current,
+    "ic_max": normalise_current,
+    "hold_current": normalise_current,
+    "power_rating": normalise_power,
+    "peak_power": normalise_power,
+    "impedance_100mhz": normalise_impedance,
+    "impedance": normalise_impedance,
+    "frequency": normalise_frequency,
+    "load_capacitance": normalise_capacitance,
+    "dielectric": str.upper,
+    "colour": str.upper,
+}
+
+# Lowercase-multiplier tiers for schematic display values (KiCad convention)
+_VALUE_RES_TIERS: list[tuple[float, str]] = [
+    (1.0, "R"),
+    (1e3, "k"),
+    (1e6, "M"),
+    (1e9, "G"),
+]
+
+# Category names for human-readable descriptions
+_CATEGORY_NAMES: dict[Category, str] = {
+    Category.RES: "resistor",
+    Category.CAP: "capacitor",
+    Category.IND: "inductor",
+    Category.DIO: "diode",
+    Category.TRAN: "transistor",
+    Category.XTAL: "crystal",
+    Category.FUSE: "fuse",
+}
+
+_CAP_SUBCAT_NAMES: dict[str, str] = {
+    "CER": "ceramic",
+    "ELEC": "electrolytic",
+    "TANT": "tantalum",
+    "FILM": "film",
+}
+
+
+# -- Name generation (ADR-001 §2) -------------------------------------------
+
+
+def _normalise_spec(field: str, value: str) -> str:
+    """Normalise a single spec value using the appropriate normaliser."""
+    normaliser = SPEC_NORMALISERS.get(field)
+    if normaliser:
+        return normaliser(value)
+    return value.upper()
+
+
+def _get_key_specs(part: JellybeanPart) -> list[str]:
+    """
+    Look up and return the key spec field names for a jellybean part.
+
+    Falls back to (category, None) if the exact (category, subcategory)
+    pair isn't registered.
+    """
+    key = (part.category, part.subcategory)
+    fields = KEY_SPECS.get(key)
+    if fields is None:
+        fields = KEY_SPECS.get((part.category, None), [])
+    return fields
+
+
+def generate_name(part: Part) -> str:
+    """
+    Generate the canonical part name from structured fields.
+
+    Dispatches by tier:
+    - Proprietary: ``CATEGORY-MPN-PACKAGE``
+    - Semi-jellybean: ``CATEGORY-BASE_PN-PACKAGE``
+    - Jellybean: ``CATEGORY[-SUBCATEGORY]-SPECS-PACKAGE``
+
+    Package is always last (before footprint variant). Appends
+    ``-VARIANT`` if ``footprint_variant`` is set.
+    """
+    pkg = normalise_package(part.package) if part.package else ""
+
+    if isinstance(part, ProprietaryPart):
+        segments = [part.category.value, part.mpn]
+
+    elif isinstance(part, SemiJellybeanPart):
+        segments = [part.category.value, part.base_pn]
+
+    else:
+        # Jellybean
+        segments = [part.category.value]
+        if part.subcategory:
+            segments.append(part.subcategory.upper())
+
+        # Normalise key specs in order
+        for field in _get_key_specs(part):
+            raw = part.specifications.get(field, "")
+            if raw:
+                segments.append(_normalise_spec(field, raw))
+
+    if pkg:
+        segments.append(pkg)
+
+    if part.footprint_variant:
+        segments.append(part.footprint_variant.upper())
+
+    return "-".join(segments)
+
+
+# -- Value generation (ADR-001 §8) ------------------------------------------
+
+
+def generate_value(part: Part) -> str:
+    """
+    Generate the schematic display value for a part.
+
+    Passives use lowercase engineering shorthand (KiCad convention).
+    Proprietary/semi-jellybean parts use their MPN or base_pn.
+    """
+    # Proprietary/semi-jellybean: use MPN or base_pn
+    if isinstance(part, ProprietaryPart):
+        return part.mpn
+    if isinstance(part, SemiJellybeanPart):
+        return part.base_pn
+
+    # Jellybean -- dispatch by category
+    specs = part.specifications
+
+    if part.category == Category.RES:
+        raw = specs.get("resistance", "")
+        if raw:
+            value, _unit = _parse_engineering(raw)
+            return _format_eng_rlc(value, _VALUE_RES_TIERS)
+
+    if part.category == Category.CAP:
+        raw = specs.get("capacitance", "")
+        if raw:
+            return normalise_capacitance(raw)
+
+    if part.category == Category.IND:
+        raw = specs.get("inductance", "")
+        if raw:
+            return normalise_inductance(raw)
+
+    if part.category == Category.DIO and part.subcategory == "LED":
+        colour = specs.get("colour", "")
+        if colour:
+            return colour.upper()
+
+    if part.category == Category.XTAL:
+        raw = specs.get("frequency", "")
+        if raw:
+            return normalise_frequency(raw)
+
+    # Jellybean diode (non-LED): key specs joined with /
+    if part.category == Category.DIO:
+        key_fields = _get_key_specs(part)
+        normalised = []
+        for field in key_fields:
+            raw = specs.get(field, "")
+            if raw:
+                normalised.append(_normalise_spec(field, raw))
+        if normalised:
+            return "/".join(normalised)
+
+    # Fallback
+    return part.name
+
+
+# -- Description generation -------------------------------------------------
+
+
+def generate_description(part: Part) -> str:
+    """
+    Generate a human-readable description for a part.
+
+    For jellybean parts, builds a description from specs and category.
+    For proprietary/semi-jellybean, returns the existing description.
+    """
+    if isinstance(part, (ProprietaryPart, SemiJellybeanPart)):
+        return part.description
+
+    specs = part.specifications
+    pkg = part.package or ""
+
+    if part.category == Category.RES:
+        resistance = specs.get("resistance", "")
+        tolerance = specs.get("tolerance", "")
+        parts = [resistance, tolerance, pkg, "thick film resistor"]
+        return " ".join(p for p in parts if p)
+
+    if part.category == Category.CAP:
+        capacitance = specs.get("capacitance", "")
+        voltage = specs.get("voltage_rating", "")
+        dielectric = specs.get("dielectric", "")
+        subcat_name = _CAP_SUBCAT_NAMES.get(part.subcategory or "", "")
+        parts = [capacitance, voltage, dielectric, pkg]
+        label = f"{subcat_name} capacitor" if subcat_name else "capacitor"
+        return " ".join(p for p in parts if p) + " " + label
+
+    # Generic jellybean: join all key spec values
+    key_fields = _get_key_specs(part)
+    spec_parts = [specs.get(f, "") for f in key_fields]
+    cat_name = _CATEGORY_NAMES.get(part.category, part.category.value)
+    parts = [p for p in spec_parts if p] + [pkg, cat_name]
+    return " ".join(p for p in parts if p)
+
+
+# -- Identity (ADR-001 §7) --------------------------------------------------
+
+
+def get_identity(part: Part) -> tuple[str, ...]:
+    """
+    Return the identity tuple for deduplication.
+
+    Two parts with the same identity tuple are considered the same part.
+    Includes footprint_variant so that e.g. ``RES-10K-1PCT-0603`` and
+    ``RES-10K-1PCT-0603-HS`` remain distinct.
+    """
+    variant = part.footprint_variant or ""
+    pkg = normalise_package(part.package) if part.package else ""
+
+    if isinstance(part, ProprietaryPart):
+        return (part.category.value, part.mpn, pkg, variant)
+
+    if isinstance(part, SemiJellybeanPart):
+        return (part.category.value, part.base_pn, pkg, variant)
+
+    # Jellybean: category + subcategory + normalised key specs + package
+    subcat = (part.subcategory or "").upper()
+    normalised_specs = []
+    for field in _get_key_specs(part):
+        raw = part.specifications.get(field, "")
+        if raw:
+            normalised_specs.append(_normalise_spec(field, raw))
+    return (part.category.value, subcat, *normalised_specs, pkg, variant)

--- a/src/kist/core/naming.py
+++ b/src/kist/core/naming.py
@@ -1,0 +1,362 @@
+"""Naming engine for value normalisation, name generation, and identity."""
+
+from __future__ import annotations
+
+import re
+
+_SI_PREFIXES: dict[str, float] = {
+    "p": 1e-12,
+    "n": 1e-9,
+    "µ": 1e-6,
+    "u": 1e-6,
+    "m": 1e-3,
+    "k": 1e3,
+    "K": 1e3,
+    "M": 1e6,
+    "G": 1e9,
+}
+
+_UNITS: list[str] = ["Hz", "Ω", "F", "H", "V", "A", "W"]
+
+_RES_TIERS: list[tuple[float, str]] = [
+    (1.0, "R"),
+    (1e3, "K"),
+    (1e6, "M"),
+    (1e9, "G"),
+]
+
+_CAP_TIERS: list[tuple[float, str]] = [
+    (1e-12, "p"),
+    (1e-9, "n"),
+    (1e-6, "u"),
+    (1e-3, "m"),
+]
+
+_IND_TIERS: list[tuple[float, str]] = [
+    (1e-9, "n"),
+    (1e-6, "u"),
+    (1e-3, "m"),
+]
+
+_PACKAGE_ALIASES: dict[str, str] = {
+    "SOIC-8": "SO8",
+    "SO-8": "SO8",
+    "SOIC-14": "SO14",
+    "SO-14": "SO14",
+    "SOIC-16": "SO16",
+    "SO-16": "SO16",
+    "SOT-23": "SOT23",
+    "SOT-23-3": "SOT23",
+    "SOT-23-5": "SOT235",
+    "SOT-23-6": "SOT236",
+    "SOT-223": "SOT223",
+    "LQFP-32": "LQFP32",
+    "LQFP-48": "LQFP48",
+    "LQFP-64": "LQFP64",
+    "LQFP-100": "LQFP100",
+    "QFN-16": "QFN16",
+    "QFN-20": "QFN20",
+    "QFN-24": "QFN24",
+    "QFN-32": "QFN32",
+    "QFN-48": "QFN48",
+    "TSSOP-8": "TSSOP8",
+    "TSSOP-14": "TSSOP14",
+    "TSSOP-16": "TSSOP16",
+    "TSSOP-20": "TSSOP20",
+    "MSOP-8": "MSOP8",
+    "MSOP-10": "MSOP10",
+}
+
+# Matches forms like "4K7", "4R7", "100n", "10u", "2M2"
+_SHORTHAND_RE = re.compile(r"^(\d+)([RKMGnup])(\d+)?$")
+
+# Standard form: optional number, optional SI prefix, optional unit
+# e.g. "4.7k", "100nF", "3.3V", "500mA", "8MHz"
+_UNITS_PATTERN = "|".join(re.escape(u) for u in _UNITS)
+_STANDARD_RE = re.compile(
+    r"^([0-9]*\.?[0-9]+)\s*([pnµumkKMG])?\s*(" + _UNITS_PATTERN + r")?$"
+)
+
+# Strip hyphens between alpha and digit portions of unknown packages
+_PKG_HYPHEN_RE = re.compile(r"([A-Za-z])-(\d)")
+
+
+# -- Internal helpers --------------------------------------------------------
+
+
+def _parse_engineering(s: str) -> tuple[float, str]:
+    """
+    Parse an engineering value string into (numeric_value, unit).
+
+    Handles SI prefixes, unicode symbols, and shorthand notation where
+    the multiplier letter replaces the decimal point (e.g. ``4K7``).
+
+    Returns the numeric value as a float and the base unit as a string
+    (empty string if no unit was detected).
+    """
+    s = s.strip()
+
+    # Try shorthand first: "4K7", "4R7", "100n", "2M2"
+    m = _SHORTHAND_RE.match(s)
+    if m:
+        whole, letter, frac = m.group(1), m.group(2), m.group(3)
+        if letter == "R":
+            multiplier = 1.0
+            unit = "Ω"
+        elif letter in _SI_PREFIXES:
+            multiplier = _SI_PREFIXES[letter]
+            unit = ""
+        else:
+            multiplier = 1.0
+            unit = ""
+
+        if frac:
+            value = (int(whole) + int(frac) / (10 ** len(frac))) * multiplier
+        else:
+            value = int(whole) * multiplier
+        return (value, unit)
+
+    # Try standard form: "4.7kΩ", "100nF", "10k", "3.3V"
+    m = _STANDARD_RE.match(s)
+    if m:
+        num_str, prefix, unit_str = m.group(1), m.group(2), m.group(3)
+        value = float(num_str)
+        if prefix:
+            value *= _SI_PREFIXES[prefix]
+        return (value, unit_str or "")
+
+    msg = f"Cannot parse engineering value: {s!r}"
+    raise ValueError(msg)
+
+
+def _format_eng_rlc(
+    value: float,
+    tiers: list[tuple[float, str]],
+) -> str:
+    """
+    Format a float into engineering shorthand using a tier list.
+
+    Each tier is ``(multiplier, letter)``. The largest tier whose
+    multiplier is <= *value* is chosen. When the result has a fractional
+    part the letter replaces the decimal point (``4700`` with ``K`` tier
+    becomes ``"4K7"``).
+
+    *tiers* must be sorted ascending by multiplier.
+    """
+    # Pick the largest tier that fits
+    chosen_mult = 1.0
+    chosen_letter = tiers[0][1]  # fallback to smallest tier
+    for mult, letter in tiers:
+        if value >= mult * 0.9999:  # tolerance for float comparison
+            chosen_mult = mult
+            chosen_letter = letter
+
+    scaled = value / chosen_mult
+
+    # Round to 6 decimal places -- enough to survive IEEE 754 noise
+    # (e.g. 4.7k parses as 4699.999...) without preserving meaningless
+    # precision beyond what component values ever need.
+    scaled = round(scaled, 6)
+
+    # Check if it's a clean integer
+    if scaled == int(scaled):
+        return f"{int(scaled)}{chosen_letter}"
+
+    # Decimal-replaces-multiplier: 4.7 becomes "4{letter}7"
+    int_part = int(scaled)
+    frac_str = f"{scaled:.10f}".split(".")[1].rstrip("0")
+    return f"{int_part}{chosen_letter}{frac_str}"
+
+
+# -- Public normalisers (all str --> str) ------------------------------------
+
+
+def normalise_resistance(s: str) -> str:
+    """
+    Normalise a resistance value to canonical name form.
+
+    Uses uppercase multipliers (``K``, ``M``) because part names are
+    all-uppercase. The ``R`` suffix denotes bare ohms.
+
+    Examples: ``"4.7kΩ"`` --> ``"4K7"``, ``"100Ω"`` --> ``"100R"``.
+    """
+    value, _unit = _parse_engineering(s)
+    return _format_eng_rlc(value, _RES_TIERS)
+
+
+def normalise_capacitance(s: str) -> str:
+    """
+    Normalise a capacitance value to canonical name form.
+
+    Uses lowercase multipliers (``n``, ``u``, ``p``) per KiCad convention.
+
+    Examples: ``"0.1µF"`` --> ``"100n"``, ``"4.7µF"`` --> ``"4u7"``.
+    """
+    value, _unit = _parse_engineering(s)
+    return _format_eng_rlc(value, _CAP_TIERS)
+
+
+def normalise_inductance(s: str) -> str:
+    """
+    Normalise an inductance value to canonical name form.
+
+    Examples: ``"10µH"`` --> ``"10u"``, ``"4.7µH"`` --> ``"4u7"``.
+    """
+    value, _unit = _parse_engineering(s)
+    return _format_eng_rlc(value, _IND_TIERS)
+
+
+def normalise_voltage(s: str) -> str:
+    """
+    Normalise a voltage using V-replaces-decimal convention.
+
+    Whole voltages keep simple form (``"50V"``); fractional voltages use
+    ``V`` as decimal replacement (``"3.3V"`` becomes ``"3V3"``).
+
+    Examples: ``"3.3V"`` --> ``"3V3"``, ``"50V"`` --> ``"50V"``.
+    """
+    value, _unit = _parse_engineering(s)
+    value = round(value, 6)
+
+    if value == int(value):
+        return f"{int(value)}V"
+
+    int_part = int(value)
+    frac_str = f"{value:.10f}".split(".")[1].rstrip("0")
+    return f"{int_part}V{frac_str}"
+
+
+def normalise_current(s: str) -> str:
+    """
+    Normalise a current value.
+
+    Whole amps stay as amps (``"1A"``); fractional amps convert to
+    milliamps (``"1.2A"`` becomes ``"1200mA"``). This avoids the
+    ambiguity of ``1A2`` since ``A`` is a unit, not a multiplier.
+
+    Examples: ``"1A"`` --> ``"1A"``, ``"500mA"`` --> ``"500mA"``.
+    """
+    value, _unit = _parse_engineering(s)
+    value = round(value, 6)
+
+    if value >= 1.0 and value == int(value):
+        return f"{int(value)}A"
+
+    # Convert to milliamps
+    ma = round(value * 1000)
+    return f"{ma}mA"
+
+
+def normalise_power(s: str) -> str:
+    """
+    Normalise a power value.
+
+    Examples: ``"500mW"`` --> ``"500mW"``, ``"400W"`` --> ``"400W"``.
+    """
+    value, _unit = _parse_engineering(s)
+    value = round(value, 6)
+
+    if value >= 1.0:
+        if value == int(value):
+            return f"{int(value)}W"
+        # Fractional watts: express in mW
+        mw = round(value * 1000)
+        return f"{mw}mW"
+
+    # Sub-watt: express in milliwatts
+    mw = round(value * 1000)
+    return f"{mw}mW"
+
+
+def normalise_frequency(s: str) -> str:
+    """
+    Normalise a frequency value.
+
+    Uses standard SI prefixes with Hz suffix. Fractional values use
+    the multiplier-replaces-decimal convention.
+
+    Examples: ``"8MHz"`` --> ``"8MHz"``, ``"32.768kHz"`` --> ``"32K768Hz"``.
+    """
+    value, _unit = _parse_engineering(s)
+    value = round(value, 6)
+
+    freq_tiers: list[tuple[float, str]] = [
+        (1.0, ""),
+        (1e3, "K"),
+        (1e6, "M"),
+        (1e9, "G"),
+    ]
+
+    chosen_mult = 1.0
+    chosen_letter = ""
+    for mult, letter in freq_tiers:
+        if value >= mult * 0.9999:
+            chosen_mult = mult
+            chosen_letter = letter
+
+    scaled = round(value / chosen_mult, 6)
+
+    if scaled == int(scaled):
+        return f"{int(scaled)}{chosen_letter}Hz"
+
+    int_part = int(scaled)
+    frac_str = f"{scaled:.10f}".split(".")[1].rstrip("0")
+    return f"{int_part}{chosen_letter}{frac_str}Hz"
+
+
+def normalise_percentage(s: str) -> str:
+    """
+    Normalise a percentage value with PCT suffix.
+
+    Examples: ``"1%"`` --> ``"1PCT"``, ``"5%"`` --> ``"5PCT"``.
+    """
+    s = s.strip().rstrip("%").strip()
+    # Handle ± prefix
+    s = s.lstrip("±").strip()
+    value = float(s)
+    if value == int(value):
+        return f"{int(value)}PCT"
+    return f"{value}PCT"
+
+
+def normalise_impedance(s: str) -> str:
+    """
+    Normalise an impedance value with R suffix for ohms.
+
+    Always uses bare ohms with R suffix (no K/M scaling), since ferrite
+    bead and common-mode choke impedance values are conventionally
+    expressed in ohms.
+
+    Examples: ``"600Ω"`` --> ``"600R"``, ``"2200Ω"`` --> ``"2200R"``.
+    """
+    value, _unit = _parse_engineering(s)
+    value = round(value, 6)
+
+    if value == int(value):
+        return f"{int(value)}R"
+
+    int_part = int(value)
+    frac_str = f"{value:.10f}".split(".")[1].rstrip("0")
+    return f"{int_part}R{frac_str}"
+
+
+def normalise_package(s: str) -> str:
+    """
+    Normalise a package designation.
+
+    Known aliases are looked up first. Unknown packages are uppercased
+    with hyphens between alpha and digit portions stripped.
+
+    Examples: ``"SOIC-8"`` --> ``"SO8"``, ``"0603"`` --> ``"0603"``.
+    """
+    s = s.strip()
+    upper = s.upper()
+
+    # Try exact match in aliases (case-insensitive via upper key)
+    for alias, canonical in _PACKAGE_ALIASES.items():
+        if upper == alias.upper():
+            return canonical
+
+    # Unknown: uppercase, strip hyphens between alpha and digits
+    result = _PKG_HYPHEN_RE.sub(r"\1\2", s)
+    return result.upper()

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -1,8 +1,14 @@
-"""Tests for the naming engine -- value normalisation."""
+"""Tests for the naming engine -- value normalisation, name generation, identity."""
+
+from typing import Any
 
 import pytest
 
 from kist.core.naming import (
+    generate_description,
+    generate_name,
+    generate_value,
+    get_identity,
     normalise_capacitance,
     normalise_current,
     normalise_frequency,
@@ -13,6 +19,15 @@ from kist.core.naming import (
     normalise_power,
     normalise_resistance,
     normalise_voltage,
+)
+from kist.models import (
+    Category,
+    JellybeanPart,
+    Mounting,
+    ProprietaryPart,
+    RefDes,
+    SemiJellybeanPart,
+    Tier,
 )
 
 # -- normalise_resistance ----------------------------------------------------
@@ -223,3 +238,397 @@ def test_normalise_impedance(input_val, expected):
 )
 def test_normalise_package(input_val, expected):
     assert normalise_package(input_val) == expected
+
+
+# -- Test-local part factories -----------------------------------------------
+
+_COMMON_FIELDS = {
+    "symbol": "test:test",
+    "footprint": "test:test",
+    "value": "test",
+    "name": "placeholder",
+    "description": "placeholder",
+}
+
+
+def _proprietary_stm32(**overrides: Any) -> ProprietaryPart:
+    fields = {
+        **_COMMON_FIELDS,
+        "tier": Tier.PROPRIETARY,
+        "category": Category.IC,
+        "subcategory": "MCU",
+        "package": "LQFP-64",
+        "mounting": Mounting.SMD,
+        "mpn": "STM32F405RGT6",
+        "manufacturer": "STMicroelectronics",
+        "reference": RefDes.U,
+        **overrides,
+    }
+    return ProprietaryPart(**fields)  # type: ignore[arg-type]
+
+
+def _semi_tl072(**overrides: Any) -> SemiJellybeanPart:
+    fields = {
+        **_COMMON_FIELDS,
+        "tier": Tier.SEMI_JELLYBEAN,
+        "category": Category.IC,
+        "subcategory": "OPAMP",
+        "package": "SO-8",
+        "mounting": Mounting.SMD,
+        "base_pn": "TL072",
+        "mpn": "TL072CDR",
+        "manufacturer": "Texas Instruments",
+        "reference": RefDes.U,
+        **overrides,
+    }
+    return SemiJellybeanPart(**fields)  # type: ignore[arg-type]
+
+
+def _jellybean(
+    category: Category,
+    subcategory: str | None,
+    package: str,
+    specs: dict[str, str],
+    reference: RefDes = RefDes.R,
+    **overrides: Any,
+) -> JellybeanPart:
+    fields = {
+        **_COMMON_FIELDS,
+        "tier": Tier.JELLYBEAN,
+        "category": category,
+        "subcategory": subcategory,
+        "package": package,
+        "mounting": Mounting.SMD,
+        "specifications": specs,
+        "reference": reference,
+        **overrides,
+    }
+    return JellybeanPart(**fields)  # type: ignore[arg-type]
+
+
+# -- generate_name -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "part, expected",
+    [
+        # Proprietary
+        (_proprietary_stm32(), "IC-STM32F405RGT6-LQFP64"),
+        # Semi-jellybean
+        (_semi_tl072(), "IC-TL072-SO8"),
+        # Jellybean -- passives
+        (
+            _jellybean(
+                Category.RES, None, "0603",
+                {"resistance": "10kΩ", "tolerance": "1%"},
+            ),
+            "RES-10K-1PCT-0603",
+        ),
+        (
+            _jellybean(
+                Category.CAP, "CER", "0603",
+                {"capacitance": "100nF", "voltage_rating": "50V",
+                 "dielectric": "X7R"},
+                reference=RefDes.C,
+            ),
+            "CAP-CER-100n-50V-X7R-0603",
+        ),
+        (
+            _jellybean(
+                Category.CAP, "ELEC", "10x10",
+                {"capacitance": "100µF", "voltage_rating": "25V"},
+                reference=RefDes.C,
+            ),
+            "CAP-ELEC-100u-25V-10X10",
+        ),
+        (
+            _jellybean(
+                Category.IND, None, "0805",
+                {"inductance": "10µH", "current_rating": "1.2A"},
+                reference=RefDes.L,
+            ),
+            "IND-10u-1200mA-0805",
+        ),
+        (
+            _jellybean(
+                Category.IND, "FERRITE", "0805",
+                {"impedance_100mhz": "600Ω", "current_rating": "2A"},
+                reference=RefDes.L,
+            ),
+            "IND-FERRITE-600R-2A-0805",
+        ),
+        # Jellybean -- semiconductors
+        (
+            _jellybean(
+                Category.DIO, "LED", "0603",
+                {"colour": "red"},
+                reference=RefDes.D,
+            ),
+            "DIO-LED-RED-0603",
+        ),
+        (
+            _jellybean(
+                Category.DIO, "ZENER", "SOD-323",
+                {"zener_voltage": "3.3V", "power_rating": "500mW"},
+                reference=RefDes.D,
+            ),
+            "DIO-ZENER-3V3-500mW-SOD323",
+        ),
+        (
+            _jellybean(
+                Category.DIO, "TVS", "SMA",
+                {"standoff_voltage": "5V", "peak_power": "400W"},
+                reference=RefDes.D,
+            ),
+            "DIO-TVS-5V-400W-SMA",
+        ),
+        (
+            _jellybean(
+                Category.TRAN, "NMOS", "SOT-23",
+                {"vds_max": "30V", "id_max": "5.8A"},
+                reference=RefDes.Q,
+            ),
+            "TRAN-NMOS-30V-5800mA-SOT23",
+        ),
+        (
+            _jellybean(
+                Category.TRAN, "NPN", "SOT-23",
+                {"vceo": "40V", "ic_max": "200mA"},
+                reference=RefDes.Q,
+            ),
+            "TRAN-NPN-40V-200mA-SOT23",
+        ),
+        # Jellybean -- other
+        (
+            _jellybean(
+                Category.XTAL, None, "HC-49",
+                {"frequency": "8MHz", "load_capacitance": "18pF"},
+                reference=RefDes.Y,
+            ),
+            "XTAL-8MHz-18p-HC49",
+        ),
+        (
+            _jellybean(
+                Category.FUSE, None, "1206",
+                {"current_rating": "1A", "voltage_rating": "63V"},
+                reference=RefDes.F,
+            ),
+            "FUSE-1A-63V-1206",
+        ),
+        (
+            _jellybean(
+                Category.FUSE, "PTC", "0805",
+                {"hold_current": "500mA", "voltage_rating": "16V"},
+                reference=RefDes.F,
+            ),
+            "FUSE-PTC-500mA-16V-0805",
+        ),
+    ],
+    ids=[
+        "proprietary_stm32",
+        "semi_tl072",
+        "jelly_res_10k",
+        "jelly_cap_cer",
+        "jelly_cap_elec",
+        "jelly_ind_plain",
+        "jelly_ind_ferrite",
+        "jelly_led_red",
+        "jelly_zener",
+        "jelly_tvs",
+        "jelly_nmos",
+        "jelly_npn",
+        "jelly_xtal",
+        "jelly_fuse",
+        "jelly_fuse_ptc",
+    ],
+)
+def test_generate_name(part, expected):
+    assert generate_name(part) == expected
+
+
+def test_generate_name_footprint_variant():
+    part = _jellybean(
+        Category.RES, None, "0603",
+        {"resistance": "10kΩ", "tolerance": "1%"},
+        footprint_variant="HS",
+    )
+    assert generate_name(part) == "RES-10K-1PCT-0603-HS"
+
+
+# -- generate_value ----------------------------------------------------------
+
+
+def test_generate_value_resistor():
+    part = _jellybean(
+        Category.RES, None, "0603",
+        {"resistance": "10kΩ", "tolerance": "1%"},
+    )
+    assert generate_value(part) == "10k"
+
+
+def test_generate_value_capacitor():
+    part = _jellybean(
+        Category.CAP, "CER", "0603",
+        {"capacitance": "100nF", "voltage_rating": "50V", "dielectric": "X7R"},
+        reference=RefDes.C,
+    )
+    assert generate_value(part) == "100n"
+
+
+def test_generate_value_inductor():
+    part = _jellybean(
+        Category.IND, None, "0805",
+        {"inductance": "10µH", "current_rating": "1.2A"},
+        reference=RefDes.L,
+    )
+    assert generate_value(part) == "10u"
+
+
+def test_generate_value_led():
+    part = _jellybean(
+        Category.DIO, "LED", "0603",
+        {"colour": "red"},
+        reference=RefDes.D,
+    )
+    assert generate_value(part) == "RED"
+
+
+def test_generate_value_crystal():
+    part = _jellybean(
+        Category.XTAL, None, "HC-49",
+        {"frequency": "8MHz", "load_capacitance": "18pF"},
+        reference=RefDes.Y,
+    )
+    assert generate_value(part) == "8MHz"
+
+
+def test_generate_value_diode_jellybean():
+    """Non-LED jellybean diode: key specs joined with /."""
+    part = _jellybean(
+        Category.DIO, "SCHOTTKY", "SOD-123",
+        {"reverse_voltage": "40V", "forward_current": "1A"},
+        reference=RefDes.D,
+    )
+    assert generate_value(part) == "40V/1A"
+
+
+def test_generate_value_proprietary():
+    assert generate_value(_proprietary_stm32()) == "STM32F405RGT6"
+
+
+def test_generate_value_semi_jellybean():
+    assert generate_value(_semi_tl072()) == "TL072"
+
+
+# -- generate_description ----------------------------------------------------
+
+
+def test_generate_description_resistor():
+    part = _jellybean(
+        Category.RES, None, "0603",
+        {"resistance": "10kΩ", "tolerance": "1%"},
+    )
+    desc = generate_description(part)
+    assert "10kΩ" in desc
+    assert "1%" in desc
+    assert "0603" in desc
+
+
+def test_generate_description_capacitor():
+    part = _jellybean(
+        Category.CAP, "CER", "0603",
+        {"capacitance": "100nF", "voltage_rating": "50V", "dielectric": "X7R"},
+        reference=RefDes.C,
+    )
+    desc = generate_description(part)
+    assert "100nF" in desc
+    assert "ceramic" in desc
+
+
+def test_generate_description_proprietary_unchanged():
+    part = _proprietary_stm32(description="ARM Cortex-M4 MCU")
+    assert generate_description(part) == "ARM Cortex-M4 MCU"
+
+
+def test_generate_description_semi_jellybean_unchanged():
+    part = _semi_tl072(description="Dual JFET-input opamp")
+    assert generate_description(part) == "Dual JFET-input opamp"
+
+
+# -- get_identity ------------------------------------------------------------
+
+
+def test_identity_same_specs():
+    a = _jellybean(
+        Category.RES, None, "0603",
+        {"resistance": "10kΩ", "tolerance": "1%"},
+    )
+    b = _jellybean(
+        Category.RES, None, "0603",
+        {"resistance": "10kΩ", "tolerance": "1%"},
+    )
+    assert get_identity(a) == get_identity(b)
+
+
+def test_identity_different_package():
+    a = _jellybean(
+        Category.RES, None, "0603",
+        {"resistance": "10kΩ", "tolerance": "1%"},
+    )
+    b = _jellybean(
+        Category.RES, None, "0402",
+        {"resistance": "10kΩ", "tolerance": "1%"},
+    )
+    assert get_identity(a) != get_identity(b)
+
+
+def test_identity_different_subcategory():
+    a = _jellybean(
+        Category.DIO, None, "SOD-123",
+        {"reverse_voltage": "40V", "forward_current": "1A"},
+        reference=RefDes.D,
+    )
+    b = _jellybean(
+        Category.DIO, "SCHOTTKY", "SOD-123",
+        {"reverse_voltage": "40V", "forward_current": "1A"},
+        reference=RefDes.D,
+    )
+    assert get_identity(a) != get_identity(b)
+
+
+def test_identity_footprint_variant():
+    a = _jellybean(
+        Category.RES, None, "0603",
+        {"resistance": "10kΩ", "tolerance": "1%"},
+    )
+    b = _jellybean(
+        Category.RES, None, "0603",
+        {"resistance": "10kΩ", "tolerance": "1%"},
+        footprint_variant="HS",
+    )
+    assert get_identity(a) != get_identity(b)
+
+
+def test_identity_proprietary_uses_mpn():
+    identity = get_identity(_proprietary_stm32())
+    assert "STM32F405RGT6" in identity
+    assert "IC" in identity
+
+
+def test_identity_semi_jellybean_uses_base_pn():
+    identity = get_identity(_semi_tl072())
+    assert "TL072" in identity
+    assert "IC" in identity
+
+
+def test_identity_normalisation():
+    """Different input formats for the same value resolve identically."""
+    a = _jellybean(
+        Category.RES, None, "0603",
+        {"resistance": "10kΩ", "tolerance": "1%"},
+    )
+    b = _jellybean(
+        Category.RES, None, "0603",
+        {"resistance": "10k", "tolerance": "1%"},
+    )
+    assert get_identity(a) == get_identity(b)

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -1,0 +1,225 @@
+"""Tests for the naming engine -- value normalisation."""
+
+import pytest
+
+from kist.core.naming import (
+    normalise_capacitance,
+    normalise_current,
+    normalise_frequency,
+    normalise_impedance,
+    normalise_inductance,
+    normalise_package,
+    normalise_percentage,
+    normalise_power,
+    normalise_resistance,
+    normalise_voltage,
+)
+
+# -- normalise_resistance ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        ("10kΩ", "10K"),
+        ("4.7kΩ", "4K7"),
+        ("100Ω", "100R"),
+        ("1MΩ", "1M"),
+        ("4R7", "4R7"),
+        ("10k", "10K"),
+        ("4.7k", "4K7"),
+        ("2.2kΩ", "2K2"),
+        ("47Ω", "47R"),
+        ("0.47Ω", "0R47"),
+        ("1Ω", "1R"),
+        ("10Ω", "10R"),
+        ("100kΩ", "100K"),
+        ("2.2MΩ", "2M2"),
+    ],
+)
+def test_normalise_resistance(input_val, expected):
+    assert normalise_resistance(input_val) == expected
+
+
+# -- normalise_capacitance ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        ("0.1µF", "100n"),
+        ("100nF", "100n"),
+        ("4.7µF", "4u7"),
+        ("10pF", "10p"),
+        ("100n", "100n"),
+        ("1µF", "1u"),
+        ("10µF", "10u"),
+        ("22pF", "22p"),
+        ("2.2nF", "2n2"),
+        ("100µF", "100u"),
+        ("1nF", "1n"),
+        ("470pF", "470p"),
+        ("4u7", "4u7"),
+    ],
+)
+def test_normalise_capacitance(input_val, expected):
+    assert normalise_capacitance(input_val) == expected
+
+
+# -- normalise_inductance ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        ("10µH", "10u"),
+        ("4.7µH", "4u7"),
+        ("100nH", "100n"),
+        ("1µH", "1u"),
+        ("2.2µH", "2u2"),
+        ("100µH", "100u"),
+        ("22nH", "22n"),
+        ("330nH", "330n"),
+    ],
+)
+def test_normalise_inductance(input_val, expected):
+    assert normalise_inductance(input_val) == expected
+
+
+# -- normalise_voltage -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        ("3.3V", "3V3"),
+        ("50V", "50V"),
+        ("1.8V", "1V8"),
+        ("5V", "5V"),
+        ("12V", "12V"),
+        ("25V", "25V"),
+        ("100V", "100V"),
+        ("16V", "16V"),
+        ("30V", "30V"),
+        ("40V", "40V"),
+        ("63V", "63V"),
+    ],
+)
+def test_normalise_voltage(input_val, expected):
+    assert normalise_voltage(input_val) == expected
+
+
+# -- normalise_current -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        ("1A", "1A"),
+        ("1.2A", "1200mA"),
+        ("500mA", "500mA"),
+        ("5.8A", "5800mA"),
+        ("2A", "2A"),
+        ("3A", "3A"),
+        ("200mA", "200mA"),
+        ("20mA", "20mA"),
+    ],
+)
+def test_normalise_current(input_val, expected):
+    assert normalise_current(input_val) == expected
+
+
+# -- normalise_power ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        ("500mW", "500mW"),
+        ("400W", "400W"),
+        ("1W", "1W"),
+        ("250mW", "250mW"),
+        ("62.5mW", "62mW"),
+    ],
+)
+def test_normalise_power(input_val, expected):
+    assert normalise_power(input_val) == expected
+
+
+# -- normalise_frequency -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        ("8MHz", "8MHz"),
+        ("16MHz", "16MHz"),
+        ("32.768kHz", "32K768Hz"),
+        ("100MHz", "100MHz"),
+        ("1GHz", "1GHz"),
+        ("48MHz", "48MHz"),
+    ],
+)
+def test_normalise_frequency(input_val, expected):
+    assert normalise_frequency(input_val) == expected
+
+
+# -- normalise_percentage ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        ("1%", "1PCT"),
+        ("5%", "5PCT"),
+        ("20%", "20PCT"),
+        ("±10%", "10PCT"),
+        ("0.1%", "0.1PCT"),
+    ],
+)
+def test_normalise_percentage(input_val, expected):
+    assert normalise_percentage(input_val) == expected
+
+
+# -- normalise_impedance -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        ("600Ω", "600R"),
+        ("2200Ω", "2200R"),
+        ("1kΩ", "1000R"),
+        ("100Ω", "100R"),
+    ],
+)
+def test_normalise_impedance(input_val, expected):
+    assert normalise_impedance(input_val) == expected
+
+
+# -- normalise_package -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        ("SOIC-8", "SO8"),
+        ("SO-8", "SO8"),
+        ("LQFP-64", "LQFP64"),
+        ("0603", "0603"),
+        ("SOT-23", "SOT23"),
+        ("SOT-23-5", "SOT235"),
+        ("SOT-23-6", "SOT236"),
+        ("QFN-32", "QFN32"),
+        ("TSSOP-16", "TSSOP16"),
+        ("MSOP-8", "MSOP8"),
+        ("SOT-223", "SOT223"),
+        # Unknown packages: uppercase, strip alpha-digit hyphens
+        ("SMA", "SMA"),
+        ("SOD-323", "SOD323"),
+        ("HC-49", "HC49"),
+        ("10x10", "10X10"),
+    ],
+)
+def test_normalise_package(input_val, expected):
+    assert normalise_package(input_val) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "rich", specifier = ">=14.3.2" },
     { name = "structlog", specifier = ">=25.5.0" },
-    { name = "tomlkit", specifier = ">=0.13.2" },
+    { name = "tomlkit", specifier = ">=0.14.0" },
     { name = "typer", specifier = ">=0.21.1" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary

Everything downstream (kist add, duplicate detection) needs deterministic
canonical names from structured part data. This PR adds the naming engine
per ADR-001 §2/§7/§8.

## Changes

- Engineering value normalisation: parse varied input formats ("4.7kΩ",
  "4K7", "0.1µF", "100n") into one canonical shorthand per category
- Ten public normalisers: resistance, capacitance, inductance, voltage,
  current, power, frequency, percentage, impedance, packages
- Impedance stays in bare ohms (no K/M scaling) to match ferrite bead
  datasheet convention

## Test plan

- 89 parametrised test cases covering all normalisers
- `uv run pytest` -- 168 tests pass
- `uvx ruff check` -- clean
- `uvx ty check` -- clean

## Notes

- Name generation, value generation, and identity (step 2) are stashed
  and will land in a follow-up commit after this review