### PR TITLE
KiCad S-expression parser and writer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest>=9.0.2",
     "pytest-cov>=7.0.0",
     "pytest-asyncio>=1.3.0",
+    "syrupy>=4.8.0",
 ]
 
 [project.scripts]

--- a/src/kist/sexpr.py
+++ b/src/kist/sexpr.py
@@ -1,0 +1,485 @@
+"""
+Generic S-expression tokenizer, parser, and writer.
+
+Handles the KiCad dialect and produces KiCad v8-style formatted output.
+No kist imports -- this module is fully standalone.
+
+KiCad S-expression format
+-------------------------
+
+KiCad stores schematics, symbols, footprints, and board files as
+S-expressions -- nested parenthesised lists similar to Lisp.  A file
+is a single top-level list whose first element is a tag keyword:
+
+    (kicad_symbol_lib
+        (version 20241209)
+        (symbol "R"
+            (property "Reference" "R" ...)
+            ...))
+
+There are three token types:
+
+  **Keywords** -- bare unquoted identifiers and numbers.  Written as-is.
+      ``version``, ``symbol``, ``20241209``, ``0.254``, ``yes``
+
+  **Quoted strings** -- double-quoted, with backslash escapes
+      (``\\"``, ``\\\\``, ``\\n``, ``\\r``).  Used for property names,
+      values, paths, and any text containing whitespace or special chars.
+      Empty strings and ``#``-prefixed strings are always quoted.
+          ``"Reference"``, ``"R"``, ``""``, ``"#power"``
+
+  **Lists** -- ``( ... )`` containing keywords, strings, and nested lists.
+      The first element is conventionally a tag keyword that identifies
+      the list type: ``(property ...)``, ``(symbol ...)``, ``(at x y)``.
+
+Numbers are *not* parsed to int/float -- they stay as strings to avoid
+float precision issues and preserve the exact text representation KiCad
+wrote (e.g. ``1.0`` vs ``1``, trailing zeros).
+
+Round-trip fidelity
+~~~~~~~~~~~~~~~~~~~
+
+The ``Atom`` type (a ``str`` subclass) records whether the source text
+was quoted, so the writer reproduces KiCad's quoting choices.  Without
+this, atoms like ``"R"`` that don't *need* quotes would be written bare,
+producing noisy git diffs when KiCad re-saves the file with its own
+quoting convention.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from enum import StrEnum
+from typing import NamedTuple
+
+# -- Exceptions ---
+
+
+class SexprError(Exception):
+    """S-expression parse or serialisation error."""
+
+
+# -- Data types ---
+
+
+class Atom(str):
+    """
+    A single S-expression token that remembers its source quoting.
+
+    Keywords are unquoted:  ``version``, ``yes``, ``0.254``
+    Strings are quoted:     ``"Reference"``, ``"R"``, ``""``
+
+    Behaves as a plain ``str`` for all operations.  The writer checks
+    ``.quoted`` to decide whether to emit quotes, preserving the
+    original file's conventions on round-trip.
+    """
+
+    quoted: bool
+
+    def __new__(cls, value: str, *, quoted: bool = False) -> Atom:
+        obj = super().__new__(cls, value)
+        obj.quoted = quoted
+        return obj
+
+    def __repr__(self) -> str:
+        return f"Atom({super().__repr__()}, quoted={self.quoted})"
+
+
+# The recursive type: either an atom (str) or a tagged list.
+# Lists use the first element as a tag keyword; remaining elements are
+# children -- atoms or nested lists.
+#     ["property", "Reference", "R", ["at", "0", "0", "0"]]
+SExpr = str | list["SExpr"]
+
+
+# -- Constants ---
+
+# Backslash escape map for quoted strings
+_ESCAPES = {
+    '"': '"',
+    "\\": "\\",
+    "n": "\n",
+    "r": "\r",
+}
+
+# Tags whose lists are collapsed to a single line regardless of child count
+_SHORTFORM_TAGS = frozenset(
+    {
+        "font",
+        "stroke",
+        "fill",
+        "offset",
+        "rotate",
+        "scale",
+        "teardrop",
+        "effects",
+        "at",
+        "size",
+        "width",
+        "type",
+        "color",
+        "xy",
+        "start",
+        "mid",
+        "end",
+        "center",
+        "radius",
+        "length",
+        "number",
+        "name",
+    }
+)
+
+# Maximum column width before pts wraps
+_PTS_MAX_COL = 99
+
+
+# -- Tokenizer ---
+
+
+class TokenKind(StrEnum):
+    OPEN = "OPEN"  # (
+    CLOSE = "CLOSE"  # )
+    ATOM = "ATOM"  # unquoted keyword or number
+    QSTRING = "QSTRING"  # quoted string with escapes resolved
+
+
+class Token(NamedTuple):
+    kind: TokenKind
+    value: str
+    offset: int
+
+
+def tokenize(text: str) -> Iterator[Token]:
+    """
+    Yield tokens from an S-expression string.
+
+    Token kinds: ``OPEN``, ``CLOSE``, ``ATOM`` (unquoted keyword or number),
+    ``QSTRING`` (quoted string with escapes resolved).
+    """
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+
+        # Whitespace -- skip
+        if ch in " \t\n\r":
+            i += 1
+            continue
+
+        # Line comment -- skip to end of line
+        if ch == ";":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+
+        # Open paren
+        if ch == "(":
+            yield Token(TokenKind.OPEN, "(", i)
+            i += 1
+            continue
+
+        # Close paren
+        if ch == ")":
+            yield Token(TokenKind.CLOSE, ")", i)
+            i += 1
+            continue
+
+        # Quoted string
+        if ch == '"':
+            start = i
+            i += 1  # skip opening quote
+            parts: list[str] = []
+            while i < n:
+                c = text[i]
+                if c == "\\":
+                    i += 1
+                    if i >= n:
+                        raise SexprError(f"Unterminated escape at byte {i - 1}")
+                    esc = text[i]
+                    parts.append(_ESCAPES.get(esc, esc))
+                    i += 1
+                elif c == '"':
+                    i += 1  # skip closing quote
+                    break
+                else:
+                    parts.append(c)
+                    i += 1
+            else:
+                raise SexprError(f"Unterminated string starting at byte {start}")
+            yield Token(TokenKind.QSTRING, "".join(parts), start)
+            continue
+
+        # Unquoted atom (keyword or number)
+        start = i
+        while i < n and text[i] not in ' \t\n\r()";':
+            i += 1
+        yield Token(TokenKind.ATOM, text[start:i], start)
+
+
+# -- Parser ---
+
+
+def parse(text: str) -> list[SExpr]:
+    """
+    Parse *text* and return all top-level S-expressions.
+
+    Returns a list -- typically one element for a KiCad file, but the
+    parser handles multiple top-level forms.
+    """
+    tokens = list(tokenize(text))
+    if not tokens:
+        raise SexprError("Empty input")
+    result: list[SExpr] = []
+    i = 0
+    n = len(tokens)
+
+    def _parse_expr(pos: int) -> tuple[SExpr, int]:
+        tok = tokens[pos]
+        if tok.kind is TokenKind.OPEN:
+            children: list[SExpr] = []
+            pos += 1
+            while pos < n and tokens[pos].kind is not TokenKind.CLOSE:
+                child, pos = _parse_expr(pos)
+                children.append(child)
+            if pos >= n:
+                raise SexprError(f"Unmatched '(' at byte {tok.offset}")
+            pos += 1  # skip CLOSE
+            return children, pos
+        if tok.kind is TokenKind.CLOSE:
+            raise SexprError(f"Unexpected ')' at byte {tok.offset}")
+        # ATOM or QSTRING
+        quoted = tok.kind is TokenKind.QSTRING
+        return Atom(tok.value, quoted=quoted), pos + 1
+
+    while i < n:
+        expr, i = _parse_expr(i)
+        result.append(expr)
+    return result
+
+
+def parse_one(text: str) -> SExpr:
+    """
+    Parse *text* expecting exactly one top-level form.
+
+    Raises :class:`SexprError` if the input contains zero or more than one
+    top-level expression.
+    """
+    forms = parse(text)
+    if len(forms) != 1:
+        raise SexprError(f"Expected exactly one expression, got {len(forms)}")
+    return forms[0]
+
+
+# -- Tree helpers ---
+
+
+def find_all(expr: list, tag: str) -> list[list]:
+    """Return all direct children of *expr* that are lists with *tag* as first element."""
+    return [
+        child for child in expr if isinstance(child, list) and child and child[0] == tag
+    ]
+
+
+def find_one(expr: list, tag: str) -> list | None:
+    """Return the first direct child list with *tag*, or ``None``."""
+    for child in expr:
+        if isinstance(child, list) and child and child[0] == tag:
+            return child
+    return None
+
+
+def set_child(expr: list, tag: str, child: list) -> None:
+    """
+    Replace the first direct child with *tag*, or append *child* if none exists.
+    """
+    for i, elem in enumerate(expr):
+        if isinstance(elem, list) and elem and elem[0] == tag:
+            expr[i] = child
+            return
+    expr.append(child)
+
+
+def remove_children(expr: list, tag: str) -> int:
+    """Remove all direct children with *tag*.  Returns the number removed."""
+    before = len(expr)
+    expr[:] = [
+        elem
+        for elem in expr
+        if not (isinstance(elem, list) and elem and elem[0] == tag)
+    ]
+    return before - len(expr)
+
+
+# -- Writer ---
+
+
+def _needs_quoting(s: str) -> bool:
+    """Return True if *s* must be quoted when written."""
+    if not s:
+        return True
+    if s.startswith("#"):
+        return True
+    for ch in s:
+        if ch in ' \t\n\r()"\\;':
+            return True
+    return False
+
+
+def _write_atom(s: str) -> str:
+    """Format a single atom for output."""
+    if isinstance(s, Atom) and s.quoted:
+        return f'"{_escape(s)}"'
+    if _needs_quoting(s):
+        return f'"{_escape(s)}"'
+    return s
+
+
+def _escape(s: str) -> str:
+    """Backslash-escape a string for writing inside quotes."""
+    return (
+        s.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
+
+
+def _is_simple_list(expr: list) -> bool:
+    """True if this list should be written on a single line."""
+    if not expr:
+        return True
+    # Single-element value lists: (tag value) or (tag)
+    if len(expr) <= 2 and all(isinstance(e, str) for e in expr):
+        return True
+    # Shortform tags
+    if isinstance(expr[0], str) and expr[0] in _SHORTFORM_TAGS:
+        return True
+    return False
+
+
+def _write_flat(expr: list) -> str:
+    """Write a list on a single line."""
+    parts: list[str] = []
+    for elem in expr:
+        if isinstance(elem, str):
+            parts.append(_write_atom(elem))
+        elif isinstance(elem, list):
+            parts.append(_write_flat(elem))
+        else:
+            parts.append(str(elem))
+    return "(" + " ".join(parts) + ")"
+
+
+def _write_pts(expr: list, indent: str) -> str:
+    """
+    Write a ``(pts ...)`` list compactly, wrapping at ~99 columns.
+    """
+    tag = _write_atom(expr[0])
+    # Collect all xy children as flat strings
+    xy_parts = []
+    for child in expr[1:]:
+        if isinstance(child, list):
+            xy_parts.append(_write_flat(child))
+        else:
+            xy_parts.append(_write_atom(child))
+
+    # Try all on one line first
+    one_line = f"({tag} " + " ".join(xy_parts) + ")"
+    if len(indent) + len(one_line) <= _PTS_MAX_COL:
+        return one_line
+
+    # Wrap: each xy on its own line
+    inner_indent = indent + "\t"
+    lines = [f"({tag}"]
+    for part in xy_parts:
+        lines.append(f"{inner_indent}{part}")
+    lines.append(f"{indent})")
+    return "\n".join(lines)
+
+
+def _write_expr(expr: SExpr, indent: str) -> str:
+    """Recursively format an expression with KiCad v8 conventions."""
+    if isinstance(expr, str):
+        return _write_atom(expr)
+
+    if not expr:
+        return "()"
+
+    # Simple / shortform lists -- single line
+    if _is_simple_list(expr):
+        return _write_flat(expr)
+
+    tag = expr[0] if isinstance(expr[0], str) else None
+
+    # pts gets special compact formatting
+    if tag == "pts":
+        return _write_pts(expr, indent)
+
+    # Split children into leading atoms and the rest.  KiCad keeps
+    # the tag and any leading string atoms on the opening line:
+    #   (property "Reference" "R"
+    #       (at 2.032 0.508 0)
+    #       ...
+    #   )
+    if tag is not None:
+        children = expr[1:]
+    else:
+        children = list(expr)
+
+    # Count leading atoms (strings that appear before any sublist)
+    lead_count = 0
+    for child in children:
+        if isinstance(child, str):
+            lead_count += 1
+        else:
+            break
+    leading = children[:lead_count]
+    rest = children[lead_count:]
+
+    # Build the opening line: (tag atom1 atom2 ...
+    opener_parts = [_write_atom(tag)] if tag is not None else []
+    for atom in leading:
+        opener_parts.append(_write_atom(atom))
+    opener = "(" + " ".join(opener_parts)
+
+    # If no complex children remain, close inline
+    if not rest:
+        return opener + ")"
+
+    # Check if remaining children are all simple
+    all_simple = all(
+        isinstance(c, str) or (isinstance(c, list) and _is_simple_list(c)) for c in rest
+    )
+    if all_simple and len(rest) <= 3 and not leading:
+        # Inline: (tag child1 child2 child3)
+        inline_parts = [opener]
+        for child in rest:
+            if isinstance(child, str):
+                inline_parts.append(_write_atom(child))
+            else:
+                inline_parts.append(_write_flat(child))
+        return " ".join(inline_parts) + ")"
+
+    # Multi-line: opening line, then indented children, then closing paren
+    lines: list[str] = [opener]
+    child_indent = indent + "\t"
+    for child in rest:
+        if isinstance(child, str):
+            lines.append(f"{child_indent}{_write_atom(child)}")
+        elif isinstance(child, list):
+            child_str = _write_expr(child, child_indent)
+            lines.append(f"{child_indent}{child_str}")
+
+    lines.append(f"{indent})")
+    return "\n".join(lines)
+
+
+def dumps(expr: SExpr) -> str:
+    """
+    Format an S-expression tree as a string using KiCad v8 conventions.
+
+    Tab indentation, shortform tags on one line, compact ``pts``, closing
+    paren on its own line for multi-line lists.
+    """
+    return _write_expr(expr, "") + "\n"

--- a/tests/__snapshots__/test_sexpr.ambr
+++ b/tests/__snapshots__/test_sexpr.ambr
@@ -1,0 +1,6259 @@
+# serializer version: 1
+# name: test_writer_snapshot[Device_RCL.kicad_sym]
+  '''
+  (kicad_symbol_lib
+  	(version 20241209)
+  	(generator "kicad_symbol_editor")
+  	(generator_version "9.0")
+  	(symbol "C"
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0.254))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "C"
+  			(at 0.635 2.54 0)
+  			(effects (font (size 1.27 1.27)) (justify left))
+  		)
+  		(property "Value" "C"
+  			(at 0.635 -2.54 0)
+  			(effects (font (size 1.27 1.27)) (justify left))
+  		)
+  		(property "Footprint" ""
+  			(at 0.9652 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" "~"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Unpolarized capacitor"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "cap capacitor"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_fp_filters" "C_*"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "C_0_1"
+  			(polyline
+  				(pts (xy -2.032 0.762) (xy 2.032 0.762))
+  				(stroke (width 0.508) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy -2.032 -0.762) (xy 2.032 -0.762))
+  				(stroke (width 0.508) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "C_1_1"
+  			(pin passive line
+  				(at 0 3.81 270)
+  				(length 2.794)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  			(pin passive line
+  				(at 0 -3.81 90)
+  				(length 2.794)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "2" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "L"
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 1.016) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "L"
+  			(at -1.27 0 90)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Value" "L"
+  			(at 1.905 0 90)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" "~"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Inductor"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "inductor choke coil reactor magnetic"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_fp_filters" "Choke_* *Coil* Inductor_* L_*"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "L_0_1"
+  			(arc
+  				(start 0 2.54)
+  				(mid 0.6323 1.905)
+  				(end 0 1.27)
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(arc
+  				(start 0 1.27)
+  				(mid 0.6323 0.635)
+  				(end 0 0)
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(arc
+  				(start 0 0)
+  				(mid 0.6323 -0.635)
+  				(end 0 -1.27)
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(arc
+  				(start 0 -1.27)
+  				(mid 0.6323 -1.905)
+  				(end 0 -2.54)
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "L_1_1"
+  			(pin passive line
+  				(at 0 3.81 270)
+  				(length 1.27)
+  				(name "1" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  			(pin passive line
+  				(at 0 -3.81 90)
+  				(length 1.27)
+  				(name "2" (effects (font (size 1.27 1.27))))
+  				(number "2" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "R"
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "R"
+  			(at 2.032 0 90)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Value" "R"
+  			(at 0 0 90)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at -1.778 0 90)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" "~"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Resistor"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "R res resistor"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_fp_filters" "R_*"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "R_0_1"
+  			(rectangle
+  				(start -1.016 -2.54)
+  				(end 1.016 2.54)
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "R_1_1"
+  			(pin passive line
+  				(at 0 3.81 270)
+  				(length 1.27)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  			(pin passive line
+  				(at 0 -3.81 90)
+  				(length 1.27)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "2" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  )
+  
+  '''
+# ---
+# name: test_writer_snapshot[Regulator_Current.kicad_sym]
+  '''
+  (kicad_symbol_lib
+  	(version 20241209)
+  	(generator "kicad_symbol_editor")
+  	(generator_version "9.0")
+  	(symbol "HV100K5-G"
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "U"
+  			(at -5.08 8.89 0)
+  			(effects (font (size 1.27 1.27)) (justify left))
+  		)
+  		(property "Value" "HV100K5-G"
+  			(at 1.27 8.89 0)
+  			(effects (font (size 1.27 1.27)) (justify left))
+  		)
+  		(property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+  			(at 0 -12.7 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" "http://ww1.microchip.com/downloads/en/devicedoc/hv100%20b060513.pdf"
+  			(at 8.89 1.27 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Hot-Swap Current Limiter Controller, SOT223"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "Hot-Swap Current Limiter"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_fp_filters" "SOT?223*TabPin2*"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "HV100K5-G_0_1"
+  			(rectangle
+  				(start -5.08 7.62)
+  				(end 5.08 -7.62)
+  				(stroke (width 0.254) (type default))
+  				(fill (type background))
+  			)
+  		)
+  		(symbol "HV100K5-G_1_1"
+  			(pin power_in line
+  				(at 0 10.16 270)
+  				(length 2.54)
+  				(name "VPP" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  			(pin power_in line
+  				(at 0 -10.16 90)
+  				(length 2.54)
+  				(name "VNN" (effects (font (size 1.27 1.27))))
+  				(number "2" (effects (font (size 1.27 1.27))))
+  			)
+  			(pin output line
+  				(at 7.62 0 180)
+  				(length 2.54)
+  				(name "GATE" (effects (font (size 1.27 1.27))))
+  				(number "3" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "HV101K5-G"
+  		(extends "HV100K5-G")
+  		(property "Reference" "U"
+  			(at -5.08 8.89 0)
+  			(effects (font (size 1.27 1.27)) (justify left))
+  		)
+  		(property "Value" "HV101K5-G"
+  			(at 1.27 8.89 0)
+  			(effects (font (size 1.27 1.27)) (justify left))
+  		)
+  		(property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+  			(at 0 -12.7 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" "http://www.supertex.com/pdf/datasheets/HV100.pdf"
+  			(at 8.89 1.27 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Hot-Swap Current Limiter Controller, SOT223"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "Hot-Swap Current Limiter"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_fp_filters" "SOT?223*TabPin2*"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  	)
+  )
+  
+  '''
+# ---
+# name: test_writer_snapshot[Transistor_IGBT.kicad_sym]
+  '''
+  (kicad_symbol_lib
+  	(version 20241209)
+  	(generator "kicad_symbol_editor")
+  	(generator_version "9.0")
+  	(symbol "IRG4PF50W"
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "Q"
+  			(at 5.08 1.905 0)
+  			(effects (font (size 1.27 1.27)) (justify left))
+  		)
+  		(property "Value" "IRG4PF50W"
+  			(at 5.08 0 0)
+  			(effects (font (size 1.27 1.27)) (justify left))
+  		)
+  		(property "Footprint" "Package_TO_SOT_THT:TO-247-3_Vertical"
+  			(at 5.08 -1.905 0)
+  			(effects (font (size 1.27 1.27) (italic yes)) (justify left) (hide yes))
+  		)
+  		(property "Datasheet" "http://www.irf.com/product-info/datasheets/data/irg4pf50w.pdf"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (justify left) (hide yes))
+  		)
+  		(property "Description" "28A, 900V, N-Channel IGBT"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "N-Channel IGBT Power Transistor"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_fp_filters" "TO?247*"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "IRG4PF50W_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0.254 0))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.254 1.905) (xy 0.254 -1.905) (xy 0.254 -1.905))
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.762 2.032) (xy 0.762 1.016))
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.762 0.508) (xy 0.762 -0.508))
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.762 -1.016) (xy 0.762 -2.032))
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(circle
+  				(center 1.27 0)
+  				(radius 2.8194)
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 1.397 -2.159) (xy 1.651 -1.651) (xy 2.54 -2.413) (xy 1.397 -2.159))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  			(polyline
+  				(pts (xy 2.159 1.905) (xy 1.905 2.413) (xy 1.016 1.651) (xy 2.159 1.905))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  			(polyline
+  				(pts (xy 2.54 2.413) (xy 0.762 1.524))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 2.54 -0.889) (xy 0.762 0))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 2.54 -2.413) (xy 0.762 -1.524))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "IRG4PF50W_1_1"
+  			(pin input line
+  				(at -5.08 0 0)
+  				(length 5.08)
+  				(name "G" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  			(pin passive line
+  				(at 2.54 5.08 270)
+  				(length 2.54)
+  				(name "C" (effects (font (size 1.27 1.27))))
+  				(number "2" (effects (font (size 1.27 1.27))))
+  			)
+  			(pin passive line
+  				(at 2.54 -5.08 90)
+  				(length 2.54)
+  				(name "E" (effects (font (size 1.27 1.27))))
+  				(number "3" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "STGP7NC60HD"
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "Q"
+  			(at 6.35 1.905 0)
+  			(effects (font (size 1.27 1.27)) (justify left))
+  		)
+  		(property "Value" "STGP7NC60HD"
+  			(at 6.35 0 0)
+  			(effects (font (size 1.27 1.27)) (justify left))
+  		)
+  		(property "Footprint" "Package_TO_SOT_THT:TO-220-3_Vertical"
+  			(at 6.35 -1.905 0)
+  			(effects (font (size 1.27 1.27) (italic yes)) (justify left) (hide yes))
+  		)
+  		(property "Datasheet" "http://www.farnell.com/datasheets/2309889.pdf"
+  			(at -1.27 0 0)
+  			(effects (font (size 1.27 1.27)) (justify left) (hide yes))
+  		)
+  		(property "Description" "25A, 600V, N-Channel IGBT, TO-220"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "N-Channel very fast IGBT with ultrafast diode Power Transistor"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_fp_filters" "TO?220*"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "STGP7NC60HD_0_1"
+  			(polyline
+  				(pts (xy -1.27 0) (xy -1.016 0))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(circle
+  				(center 1.016 0)
+  				(radius 3.0734)
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 1.27 2.413) (xy 2.54 2.413))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 1.27 -2.413) (xy 2.54 -2.413))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 2.032 0.635) (xy 3.048 0.635))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 2.54 3.81) (xy 2.54 -3.81))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 2.54 0.635) (xy 2.032 -0.635) (xy 3.048 -0.635) (xy 2.54 0.635))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(symbol "STGP7NC60HD_1_1"
+  			(polyline
+  				(pts (xy -1.016 1.905) (xy -1.016 -1.905) (xy -1.016 -1.905))
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy -0.508 2.032) (xy -0.508 1.016))
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy -0.508 0.508) (xy -0.508 -0.508))
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy -0.508 -1.016) (xy -0.508 -2.032))
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy -0.127 -2.032) (xy 0.127 -1.524) (xy 1.016 -2.286) (xy -0.127 -2.032))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  			(polyline
+  				(pts (xy 0.889 1.905) (xy 0.635 2.413) (xy -0.254 1.651) (xy 0.889 1.905))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  			(polyline
+  				(pts (xy 1.27 2.413) (xy -0.508 1.524))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 1.27 -0.889) (xy -0.508 0))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 1.27 -2.413) (xy -0.508 -1.524))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(pin input line
+  				(at -5.08 0 0)
+  				(length 3.81)
+  				(name "G" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  			(pin passive line
+  				(at 2.54 5.08 270)
+  				(length 2.54)
+  				(name "C" (effects (font (size 1.27 1.27))))
+  				(number "2" (effects (font (size 1.27 1.27))))
+  			)
+  			(pin passive line
+  				(at 2.54 -5.08 90)
+  				(length 2.54)
+  				(name "E" (effects (font (size 1.27 1.27))))
+  				(number "3" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  )
+  
+  '''
+# ---
+# name: test_writer_snapshot[power.kicad_sym]
+  '''
+  (kicad_symbol_lib
+  	(version 20241209)
+  	(generator "kicad_symbol_editor")
+  	(generator_version "9.0")
+  	(symbol "+10V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+10V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+10V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+10V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+10V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+12C"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+12C"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+12C\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+12C_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+12C_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+12L"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+12L"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+12L\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+12L_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+12L_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+12LF"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+12LF"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+12LF\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+12LF_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+12LF_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+12P"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+12P"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+12P\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+12P_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+12P_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+12V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+12V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+12V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+12V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+12V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+12VA"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+12VA"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+12VA\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+12VA_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+12VA_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+15V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+15V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+15V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+15V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+15V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+1V0"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+1V0"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+1V0\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+1V0_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+1V0_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+1V1"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+1V1"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+1V1\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+1V1_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+1V1_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+1V2"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+1V2"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+1V2\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+1V2_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+1V2_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+1V35"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+1V35"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+1V35\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+1V35_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+1V35_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+1V5"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+1V5"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+1V5\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+1V5_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+1V5_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+1V8"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+1V8"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+1V8\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+1V8_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+1V8_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+24V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+24V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+24V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+24V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+24V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+28V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+28V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 6.35 1.27 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 6.35 1.27 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+28V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+28V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+28V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+2V5"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+2V5"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+2V5\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+2V5_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+2V5_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+2V8"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+2V8"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+2V8\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+2V8_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+2V8_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+3.3V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+3.3V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+3.3V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+3.3V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+3.3VA"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+3.3VA"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+3.3VA\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+3.3VA_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+3.3VA_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+3.3VADC"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 3.81 -1.27 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+3.3VADC"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+3.3VADC\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+3.3VADC_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "+3.3VADC_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+3.3VDAC"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 3.81 -1.27 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+3.3VDAC"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+3.3VDAC\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+3.3VDAC_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "+3.3VDAC_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+3.3VP"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 3.81 -1.27 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+3.3VP"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+3.3VP\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+3.3VP_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "+3.3VP_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+36V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+36V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+36V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+36V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+36V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+3V0"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+3V0"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+3V0\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+3V0_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+3V0_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+3V3"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+3V3"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+3V3\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+3V3_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+3V3_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+3V8"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+3V8"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+3V8\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+3V8_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+3V8_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+48V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+48V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+48V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+48V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+48V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+4V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+4V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+4V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+4V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+4V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+5C"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+5C"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+5C\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+5C_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+5C_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+5F"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+5F"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+5F\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+5F_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+5F_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+5P"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+5P"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+5P\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+5P_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+5P_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+5V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+5V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+5V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+5V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+5V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+5VA"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+5VA"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+5VA\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+5VA_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+5VA_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+5VD"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+5VD"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+5VD\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+5VD_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+5VD_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+5VL"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+5VL"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+5VL\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+5VL_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+5VL_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+5VP"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+5VP"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+5VP\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+5VP_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+5VP_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+6V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+6V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+6V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+6V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+6V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+7.5V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+7.5V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+7.5V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+7.5V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+7.5V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+8V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+8V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+8V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+8V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+8V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+9V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+9V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+9V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+9V_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+9V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+9VA"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.175 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+9VA"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+9VA\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+9VA_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+9VA_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+BATT"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+BATT"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+BATT\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power battery"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+BATT_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+BATT_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+VDC"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -2.54 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+VDC"
+  			(at 0 6.35 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+VDC\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+VDC_0_1"
+  			(polyline
+  				(pts (xy -1.143 3.175) (xy 1.143 3.175))
+  				(stroke (width 0.508) (type default))
+  				(fill (type none))
+  			)
+  			(circle
+  				(center 0 3.175)
+  				(radius 1.905)
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.032) (xy 0 4.318))
+  				(stroke (width 0.508) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+VDC_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "+VSW"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "+VSW"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"+VSW\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "+VSW_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "+VSW_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-10V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-10V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-10V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-10V_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-10V_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-12V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-12V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-12V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-12V_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-12V_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-12VA"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-12VA"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-12VA\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-12VA_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-12VA_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-15V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-15V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-15V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-15V_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-15V_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-24V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-24V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-24V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-24V_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-24V_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-2V5"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-2V5"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-2V5\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-2V5_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-2V5_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-36V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-36V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-36V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-36V_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-36V_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-3V3"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-3V3"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-3V3\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-3V3_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-3V3_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-48V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-48V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-48V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-48V_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-48V_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-5V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-5V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-5V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-5V_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-5V_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-5VA"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-5VA"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-5VA\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-5VA_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-5VA_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-6V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-6V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-6V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-6V_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-6V_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-8V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-8V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-8V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-8V_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-8V_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-9V"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-9V"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-9V\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-9V_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(symbol "-9V_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-9VA"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-9VA"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-9VA\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-9VA_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(symbol "-9VA_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-BATT"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-BATT"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-BATT\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power battery"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-BATT_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(symbol "-BATT_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-VDC"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -2.54 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-VDC"
+  			(at 0 6.35 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-VDC\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-VDC_0_1"
+  			(polyline
+  				(pts (xy -1.143 3.175) (xy 1.143 3.175))
+  				(stroke (width 0.508) (type default))
+  				(fill (type none))
+  			)
+  			(circle
+  				(center 0 3.175)
+  				(radius 1.905)
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "-VDC_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "-VSW"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "-VSW"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"-VSW\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "-VSW_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "-VSW_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "AC"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -2.54 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "AC"
+  			(at 0 6.35 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"AC\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "AC_0_1"
+  			(arc
+  				(start -1.27 3.175)
+  				(mid -0.635 3.8073)
+  				(end 0 3.175)
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(circle
+  				(center 0 3.175)
+  				(radius 1.905)
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(arc
+  				(start 1.27 3.175)
+  				(mid 0.635 2.5427)
+  				(end 0 3.175)
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "AC_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "Earth"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -6.35 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "Earth"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" "~"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"Earth\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global ground gnd"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "Earth_0_1"
+  			(polyline
+  				(pts (xy -0.635 -1.905) (xy 0.635 -1.905))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy -0.127 -2.54) (xy 0.127 -2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 -1.27) (xy 0 0))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 1.27 -1.27) (xy -1.27 -1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "Earth_1_1"
+  			(pin power_in line
+  				(at 0 0 270)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "Earth_Clean"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -7.62 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "Earth_Clean"
+  			(at 0 -5.08 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 -1.27 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" "~"
+  			(at 0 -1.27 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"Earth_Clean\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global ground gnd clean signal"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "Earth_Clean_0_1"
+  			(polyline
+  				(pts (xy -0.635 -3.175) (xy 0.635 -3.175))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy -0.127 -3.81) (xy 0.127 -3.81))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 -2.54) (xy 0 0))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(arc
+  				(start -2.54 -3.81)
+  				(mid 0 -1.281)
+  				(end 2.54 -3.81)
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 1.27 -2.54) (xy -1.27 -2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "Earth_Clean_1_1"
+  			(pin power_in line
+  				(at 0 0 270)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "Earth_Protective"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -10.16 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "Earth_Protective"
+  			(at 0 -7.62 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 -2.54 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" "~"
+  			(at 0 -2.54 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"Earth_Protective\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global ground gnd clean"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "Earth_Protective_0_1"
+  			(polyline
+  				(pts (xy -0.635 -4.445) (xy 0.635 -4.445))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy -0.127 -5.08) (xy 0.127 -5.08))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 -3.81) (xy 0 0))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(circle
+  				(center 0 -3.81)
+  				(radius 2.54)
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 1.27 -3.81) (xy -1.27 -3.81))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "Earth_Protective_1_1"
+  			(pin power_in line
+  				(at 0 0 270)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "GND"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -6.35 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "GND"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "GND_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "GND_1_1"
+  			(pin power_in line
+  				(at 0 0 270)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "GND1"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -6.35 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "GND1"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"GND1\" , ground"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "GND1_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "GND1_1_1"
+  			(pin power_in line
+  				(at 0 0 270)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "GND2"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -6.35 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "GND2"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"GND2\" , ground"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "GND2_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "GND2_1_1"
+  			(pin power_in line
+  				(at 0 0 270)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "GND3"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -6.35 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "GND3"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"GND3\" , ground"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "GND3_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "GND3_1_1"
+  			(pin power_in line
+  				(at 0 0 270)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "GNDA"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -6.35 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "GNDA"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"GNDA\" , analog ground"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "GNDA_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "GNDA_1_1"
+  			(pin power_in line
+  				(at 0 0 270)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "GNDD"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -6.35 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "GNDD"
+  			(at 0 -3.175 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"GNDD\" , digital ground"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "GNDD_0_1"
+  			(rectangle
+  				(start -1.27 -1.524)
+  				(end 1.27 -2.032)
+  				(stroke (width 0.254) (type default))
+  				(fill (type outline))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 -1.524))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "GNDD_1_1"
+  			(pin power_in line
+  				(at 0 0 270)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "GNDPWR"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -5.08 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "GNDPWR"
+  			(at 0 -3.302 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 -1.27 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 -1.27 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"GNDPWR\" , global ground"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global ground"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "GNDPWR_0_1"
+  			(polyline
+  				(pts (xy -1.016 -1.27) (xy -1.27 -2.032) (xy -1.27 -2.032))
+  				(stroke (width 0.2032) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy -0.508 -1.27) (xy -0.762 -2.032) (xy -0.762 -2.032))
+  				(stroke (width 0.2032) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 -1.27) (xy 0 0))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 -1.27) (xy -0.254 -2.032) (xy -0.254 -2.032))
+  				(stroke (width 0.2032) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.508 -1.27) (xy 0.254 -2.032) (xy 0.254 -2.032))
+  				(stroke (width 0.2032) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 1.016 -1.27) (xy -1.016 -1.27) (xy -1.016 -1.27))
+  				(stroke (width 0.2032) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 1.016 -1.27) (xy 0.762 -2.032) (xy 0.762 -2.032) (xy 0.762 -2.032))
+  				(stroke (width 0.2032) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "GNDPWR_1_1"
+  			(pin power_in line
+  				(at 0 0 270)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "GNDREF"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -6.35 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "GNDREF"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"GNDREF\" , reference supply ground"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "GNDREF_0_1"
+  			(polyline
+  				(pts (xy -0.635 -1.905) (xy 0.635 -1.905))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy -0.127 -2.54) (xy 0.127 -2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 -1.27) (xy 0 0))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 1.27 -1.27) (xy -1.27 -1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "GNDREF_1_1"
+  			(pin power_in line
+  				(at 0 0 270)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "GNDS"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -6.35 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "GNDS"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"GNDS\" , signal ground"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "GNDS_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "GNDS_1_1"
+  			(pin power_in line
+  				(at 0 0 270)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "HT"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "HT"
+  			(at 0 3.048 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"HT\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "HT_0_0"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "HT_0_1"
+  			(polyline
+  				(pts (xy 0 1.016) (xy 0.508 0.508) (xy 0 1.778) (xy -0.508 0.508) (xy 0 1.016) (xy 0 1.016))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.016) (xy 0 1.016))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "LINE"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "LINE"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"LINE\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "LINE_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "LINE_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "NEUT"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "NEUT"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"NEUT\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "NEUT_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "NEUT_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "PRI_HI"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "PRI_HI"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"PRI_HI\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "PRI_HI_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "PRI_HI_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "PRI_LO"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "PRI_LO"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"PRI_LO\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "PRI_LO_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(symbol "PRI_LO_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "PRI_MID"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "PRI_MID"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"PRI_MID\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "PRI_MID_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "PRI_MID_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "PWR_FLAG"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#FLG"
+  			(at 0 1.905 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "PWR_FLAG"
+  			(at 0 3.81 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" "~"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Special symbol for telling ERC where power comes from"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "flag power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "PWR_FLAG_0_0"
+  			(pin power_out line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(symbol "PWR_FLAG_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27) (xy -1.016 1.905) (xy 0 2.54) (xy 1.016 1.905) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VAA"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VAA"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VAA\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VAA_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "VAA_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VAC"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -2.54 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VAC"
+  			(at 0 6.35 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VAC\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VAC_0_1"
+  			(arc
+  				(start -1.27 3.175)
+  				(mid -0.635 3.8073)
+  				(end 0 3.175)
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(circle
+  				(center 0 3.175)
+  				(radius 1.905)
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(arc
+  				(start 1.27 3.175)
+  				(mid 0.635 2.5427)
+  				(end 0 3.175)
+  				(stroke (width 0.254) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "VAC_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VBUS"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VBUS"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VBUS\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VBUS_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "VBUS_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VCC"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VCC"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VCC\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VCC_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "VCC_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VCCQ"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VCCQ"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VCCQ\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VCCQ_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "VCCQ_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VCOM"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VCOM"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VCOM\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VCOM_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(symbol "VCOM_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VD"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VD"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VD\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VD_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "VD_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VDC"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VDC"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VDC\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VDC_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "VDC_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VDD"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VDD"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VDD\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VDD_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "VDD_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VDDA"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VDDA"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VDDA\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VDDA_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "VDDA_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VDDF"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VDDF"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VDDF\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VDDF_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "VDDF_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VEE"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VEE"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VEE\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VEE_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(symbol "VEE_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VMEM"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VMEM"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VMEM\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VMEM_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "VMEM_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VPP"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VPP"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VPP\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VPP_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "VPP_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VS"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VS"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VS\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VS_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(symbol "VS_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VSS"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VSS"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VSS\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VSS_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(symbol "VSS_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "VSSA"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "VSSA"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"VSSA\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "VSSA_0_1"
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type outline))
+  			)
+  		)
+  		(symbol "VSSA_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  	(symbol "Vdrive"
+  		(power)
+  		(pin_numbers (hide yes))
+  		(pin_names (offset 0) (hide yes))
+  		(exclude_from_sim no)
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "#PWR"
+  			(at 0 -3.81 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Value" "Vdrive"
+  			(at 0 3.556 0)
+  			(effects (font (size 1.27 1.27)))
+  		)
+  		(property "Footprint" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Datasheet" ""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "Description" "Power symbol creates a global label with name \"Vdrive\""
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(property "ki_keywords" "global power"
+  			(at 0 0 0)
+  			(effects (font (size 1.27 1.27)) (hide yes))
+  		)
+  		(symbol "Vdrive_0_1"
+  			(polyline
+  				(pts (xy -0.762 1.27) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 2.54) (xy 0.762 1.27))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  			(polyline
+  				(pts (xy 0 0) (xy 0 2.54))
+  				(stroke (width 0) (type default))
+  				(fill (type none))
+  			)
+  		)
+  		(symbol "Vdrive_1_1"
+  			(pin power_in line
+  				(at 0 0 90)
+  				(length 0)
+  				(name "~" (effects (font (size 1.27 1.27))))
+  				(number "1" (effects (font (size 1.27 1.27))))
+  			)
+  		)
+  		(embedded_fonts no)
+  	)
+  )
+  
+  '''
+# ---

--- a/tests/fixtures/kicad/Device_RCL.kicad_sym
+++ b/tests/fixtures/kicad/Device_RCL.kicad_sym
@@ -1,0 +1,430 @@
+(kicad_symbol_lib
+	(version 20241209)
+	(generator "kicad_symbol_editor")
+	(generator_version "9.0")
+	(symbol "C"
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0.254)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "C"
+			(at 0.635 2.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "C"
+			(at 0.635 -2.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 0.9652 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Unpolarized capacitor"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "cap capacitor"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_fp_filters" "C_*"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "C_0_1"
+			(polyline
+				(pts
+					(xy -2.032 0.762) (xy 2.032 0.762)
+				)
+				(stroke
+					(width 0.508)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -2.032 -0.762) (xy 2.032 -0.762)
+				)
+				(stroke
+					(width 0.508)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "C_1_1"
+			(pin passive line
+				(at 0 3.81 270)
+				(length 2.794)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -3.81 90)
+				(length 2.794)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "L"
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 1.016)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "L"
+			(at -1.27 0 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "L"
+			(at 1.905 0 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Inductor"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "inductor choke coil reactor magnetic"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_fp_filters" "Choke_* *Coil* Inductor_* L_*"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "L_0_1"
+			(arc
+				(start 0 2.54)
+				(mid 0.6323 1.905)
+				(end 0 1.27)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(arc
+				(start 0 1.27)
+				(mid 0.6323 0.635)
+				(end 0 0)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(arc
+				(start 0 0)
+				(mid 0.6323 -0.635)
+				(end 0 -1.27)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(arc
+				(start 0 -1.27)
+				(mid 0.6323 -1.905)
+				(end 0 -2.54)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "L_1_1"
+			(pin passive line
+				(at 0 3.81 270)
+				(length 1.27)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -3.81 90)
+				(length 1.27)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "R"
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "R"
+			(at 2.032 0 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "R"
+			(at 0 0 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at -1.778 0 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "R res resistor"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_fp_filters" "R_*"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "R_0_1"
+			(rectangle
+				(start -1.016 -2.54)
+				(end 1.016 2.54)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "R_1_1"
+			(pin passive line
+				(at 0 3.81 270)
+				(length 1.27)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -3.81 90)
+				(length 1.27)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+)

--- a/tests/fixtures/kicad/README.md
+++ b/tests/fixtures/kicad/README.md
@@ -1,0 +1,28 @@
+# KiCad test fixtures
+
+Pristine `.kicad_sym` files copied from the system KiCad 9.0.5
+installation.  Used for round-trip and snapshot testing of the
+S-expression parser/writer.
+
+## Source
+
+```
+/nix/store/lfwg5vggjc0maapn2q3hf1wkn07wx7q8-kicad-symbols-884133df0a/share/kicad/symbols/
+```
+
+KiCad symbols package version `884133df0a`, installed via Nix.
+
+## Files
+
+| File | Source | Notes |
+|------|--------|-------|
+| `Regulator_Current.kicad_sym` | Copied verbatim | 2 symbols, 209 lines |
+| `Transistor_IGBT.kicad_sym` | Copied verbatim | 2 symbols, 595 lines |
+| `power.kicad_sym` | Copied verbatim | 101 symbols, exercises `#`-prefixed values |
+| `Device_RCL.kicad_sym` | Header + R/C/L symbols extracted from `Device.kicad_sym` | Raw lines, no reformatting |
+
+## Do not edit
+
+These files must stay as KiCad wrote them.  The snapshot tests pin our
+writer output against these inputs -- modifying the fixtures invalidates
+the snapshots.

--- a/tests/fixtures/kicad/Regulator_Current.kicad_sym
+++ b/tests/fixtures/kicad/Regulator_Current.kicad_sym
@@ -1,0 +1,209 @@
+(kicad_symbol_lib
+	(version 20241209)
+	(generator "kicad_symbol_editor")
+	(generator_version "9.0")
+	(symbol "HV100K5-G"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at -5.08 8.89 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "HV100K5-G"
+			(at 1.27 8.89 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+			(at 0 -12.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "http://ww1.microchip.com/downloads/en/devicedoc/hv100%20b060513.pdf"
+			(at 8.89 1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Hot-Swap Current Limiter Controller, SOT223"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "Hot-Swap Current Limiter"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_fp_filters" "SOT?223*TabPin2*"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "HV100K5-G_0_1"
+			(rectangle
+				(start -5.08 7.62)
+				(end 5.08 -7.62)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "HV100K5-G_1_1"
+			(pin power_in line
+				(at 0 10.16 270)
+				(length 2.54)
+				(name "VPP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 -10.16 90)
+				(length 2.54)
+				(name "VNN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 7.62 0 180)
+				(length 2.54)
+				(name "GATE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "HV101K5-G"
+		(extends "HV100K5-G")
+		(property "Reference" "U"
+			(at -5.08 8.89 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "HV101K5-G"
+			(at 1.27 8.89 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+			(at 0 -12.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "http://www.supertex.com/pdf/datasheets/HV100.pdf"
+			(at 8.89 1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Hot-Swap Current Limiter Controller, SOT223"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "Hot-Swap Current Limiter"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_fp_filters" "SOT?223*TabPin2*"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+	)
+)

--- a/tests/fixtures/kicad/Transistor_IGBT.kicad_sym
+++ b/tests/fixtures/kicad/Transistor_IGBT.kicad_sym
@@ -1,0 +1,595 @@
+(kicad_symbol_lib
+	(version 20241209)
+	(generator "kicad_symbol_editor")
+	(generator_version "9.0")
+	(symbol "IRG4PF50W"
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "Q"
+			(at 5.08 1.905 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "IRG4PF50W"
+			(at 5.08 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_THT:TO-247-3_Vertical"
+			(at 5.08 -1.905 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "http://www.irf.com/product-info/datasheets/data/irg4pf50w.pdf"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+		(property "Description" "28A, 900V, N-Channel IGBT"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "N-Channel IGBT Power Transistor"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_fp_filters" "TO?247*"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "IRG4PF50W_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0.254 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.254 1.905) (xy 0.254 -1.905) (xy 0.254 -1.905)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 2.032) (xy 0.762 1.016)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 0.508) (xy 0.762 -0.508)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 -1.016) (xy 0.762 -2.032)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center 1.27 0)
+				(radius 2.8194)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.397 -2.159) (xy 1.651 -1.651) (xy 2.54 -2.413) (xy 1.397 -2.159)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.159 1.905) (xy 1.905 2.413) (xy 1.016 1.651) (xy 2.159 1.905)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.54 2.413) (xy 0.762 1.524)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.54 -0.889) (xy 0.762 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.54 -2.413) (xy 0.762 -1.524)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "IRG4PF50W_1_1"
+			(pin input line
+				(at -5.08 0 0)
+				(length 5.08)
+				(name "G"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 2.54 5.08 270)
+				(length 2.54)
+				(name "C"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 2.54 -5.08 90)
+				(length 2.54)
+				(name "E"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "STGP7NC60HD"
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "Q"
+			(at 6.35 1.905 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "STGP7NC60HD"
+			(at 6.35 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_THT:TO-220-3_Vertical"
+			(at 6.35 -1.905 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "http://www.farnell.com/datasheets/2309889.pdf"
+			(at -1.27 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+		(property "Description" "25A, 600V, N-Channel IGBT, TO-220"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "N-Channel very fast IGBT with ultrafast diode Power Transistor"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_fp_filters" "TO?220*"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "STGP7NC60HD_0_1"
+			(polyline
+				(pts
+					(xy -1.27 0) (xy -1.016 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center 1.016 0)
+				(radius 3.0734)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 2.413) (xy 2.54 2.413)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 -2.413) (xy 2.54 -2.413)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.032 0.635) (xy 3.048 0.635)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.54 3.81) (xy 2.54 -3.81)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.54 0.635) (xy 2.032 -0.635) (xy 3.048 -0.635) (xy 2.54 0.635)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(symbol "STGP7NC60HD_1_1"
+			(polyline
+				(pts
+					(xy -1.016 1.905) (xy -1.016 -1.905) (xy -1.016 -1.905)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.508 2.032) (xy -0.508 1.016)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.508 0.508) (xy -0.508 -0.508)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.508 -1.016) (xy -0.508 -2.032)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.127 -2.032) (xy 0.127 -1.524) (xy 1.016 -2.286) (xy -0.127 -2.032)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.889 1.905) (xy 0.635 2.413) (xy -0.254 1.651) (xy 0.889 1.905)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 2.413) (xy -0.508 1.524)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 -0.889) (xy -0.508 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 -2.413) (xy -0.508 -1.524)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(pin input line
+				(at -5.08 0 0)
+				(length 3.81)
+				(name "G"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 2.54 5.08 270)
+				(length 2.54)
+				(name "C"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 2.54 -5.08 90)
+				(length 2.54)
+				(name "E"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+)

--- a/tests/fixtures/kicad/power.kicad_sym
+++ b/tests/fixtures/kicad/power.kicad_sym
@@ -1,0 +1,12144 @@
+(kicad_symbol_lib
+	(version 20241209)
+	(generator "kicad_symbol_editor")
+	(generator_version "9.0")
+	(symbol "+10V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+10V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+10V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+10V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+10V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+12C"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+12C"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+12C\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+12C_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+12C_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+12L"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+12L"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+12L\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+12L_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+12L_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+12LF"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+12LF"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+12LF\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+12LF_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+12LF_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+12P"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+12P"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+12P\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+12P_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+12P_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+12V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+12V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+12V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+12V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+12V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+12VA"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+12VA"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+12VA\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+12VA_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+12VA_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+15V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+15V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+15V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+15V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+15V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+1V0"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+1V0"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+1V0\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+1V0_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+1V0_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+1V1"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+1V1"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+1V1\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+1V1_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+1V1_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+1V2"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+1V2"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+1V2\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+1V2_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+1V2_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+1V35"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+1V35"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+1V35\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+1V35_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+1V35_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+1V5"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+1V5"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+1V5\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+1V5_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+1V5_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+1V8"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+1V8"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+1V8\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+1V8_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+1V8_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+24V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+24V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+24V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+24V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+24V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+28V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+28V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 6.35 1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 6.35 1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+28V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+28V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+28V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+2V5"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+2V5"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+2V5\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+2V5_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+2V5_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+2V8"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+2V8"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+2V8\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+2V8_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+2V8_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+3.3V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3.3V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+3.3V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+3.3V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+3.3VA"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3.3VA"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3VA\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+3.3VA_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+3.3VA_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+3.3VADC"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 3.81 -1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3.3VADC"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3VADC\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+3.3VADC_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "+3.3VADC_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+3.3VDAC"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 3.81 -1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3.3VDAC"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3VDAC\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+3.3VDAC_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "+3.3VDAC_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+3.3VP"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 3.81 -1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3.3VP"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3VP\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+3.3VP_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "+3.3VP_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+36V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+36V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+36V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+36V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+36V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+3V0"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V0"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3V0\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+3V0_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+3V0_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+3V3"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3V3\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+3V3_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+3V3_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+3V8"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V8"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3V8\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+3V8_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+3V8_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+48V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+48V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+48V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+48V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+48V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+4V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+4V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+4V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+4V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+4V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+5C"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5C"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5C\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+5C_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+5C_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+5F"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5F"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5F\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+5F_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+5F_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+5P"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5P"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5P\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+5P_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+5P_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+5V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+5V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+5V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+5VA"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5VA"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5VA\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+5VA_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+5VA_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+5VD"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5VD"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5VD\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+5VD_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+5VD_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+5VL"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5VL"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5VL\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+5VL_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+5VL_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+5VP"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5VP"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5VP\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+5VP_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+5VP_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+6V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+6V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+6V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+6V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+6V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+7.5V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+7.5V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+7.5V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+7.5V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+7.5V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+8V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+8V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+8V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+8V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+8V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+9V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+9V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+9V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+9V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+9V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+9VA"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.175 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+9VA"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+9VA\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+9VA_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+9VA_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+BATT"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+BATT"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+BATT\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power battery"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+BATT_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+BATT_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+VDC"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -2.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+VDC"
+			(at 0 6.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+VDC\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+VDC_0_1"
+			(polyline
+				(pts
+					(xy -1.143 3.175) (xy 1.143 3.175)
+				)
+				(stroke
+					(width 0.508)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center 0 3.175)
+				(radius 1.905)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.032) (xy 0 4.318)
+				)
+				(stroke
+					(width 0.508)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+VDC_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "+VSW"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+VSW"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+VSW\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "+VSW_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+VSW_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-10V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-10V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-10V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-10V_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-10V_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-12V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-12V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-12V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-12V_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-12V_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-12VA"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-12VA"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-12VA\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-12VA_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-12VA_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-15V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-15V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-15V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-15V_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-15V_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-24V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-24V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-24V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-24V_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-24V_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-2V5"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-2V5"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-2V5\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-2V5_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-2V5_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-36V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-36V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-36V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-36V_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-36V_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-3V3"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-3V3"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-3V3\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-3V3_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-3V3_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-48V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-48V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-48V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-48V_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-48V_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-5V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-5V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-5V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-5V_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-5V_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-5VA"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-5VA"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-5VA\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-5VA_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-5VA_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-6V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-6V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-6V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-6V_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-6V_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-8V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-8V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-8V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-8V_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-8V_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-9V"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-9V"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-9V\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-9V_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(symbol "-9V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-9VA"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-9VA"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-9VA\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-9VA_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(symbol "-9VA_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-BATT"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-BATT"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-BATT\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power battery"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-BATT_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(symbol "-BATT_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-VDC"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -2.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-VDC"
+			(at 0 6.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-VDC\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-VDC_0_1"
+			(polyline
+				(pts
+					(xy -1.143 3.175) (xy 1.143 3.175)
+				)
+				(stroke
+					(width 0.508)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center 0 3.175)
+				(radius 1.905)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "-VDC_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "-VSW"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "-VSW"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"-VSW\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "-VSW_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "-VSW_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy 0.762 1.27) (xy 0 2.54) (xy -0.762 1.27) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "AC"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -2.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "AC"
+			(at 0 6.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"AC\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "AC_0_1"
+			(arc
+				(start -1.27 3.175)
+				(mid -0.635 3.8073)
+				(end 0 3.175)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center 0 3.175)
+				(radius 1.905)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(arc
+				(start 1.27 3.175)
+				(mid 0.635 2.5427)
+				(end 0 3.175)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "AC_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "Earth"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "Earth"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"Earth\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global ground gnd"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "Earth_0_1"
+			(polyline
+				(pts
+					(xy -0.635 -1.905) (xy 0.635 -1.905)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.127 -2.54) (xy 0.127 -2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 -1.27) (xy 0 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 -1.27) (xy -1.27 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "Earth_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "Earth_Clean"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -7.62 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "Earth_Clean"
+			(at 0 -5.08 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 -1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 0 -1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"Earth_Clean\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global ground gnd clean signal"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "Earth_Clean_0_1"
+			(polyline
+				(pts
+					(xy -0.635 -3.175) (xy 0.635 -3.175)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.127 -3.81) (xy 0.127 -3.81)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 -2.54) (xy 0 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(arc
+				(start -2.54 -3.81)
+				(mid 0 -1.281)
+				(end 2.54 -3.81)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 -2.54) (xy -1.27 -2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "Earth_Clean_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "Earth_Protective"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -10.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "Earth_Protective"
+			(at 0 -7.62 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 -2.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 0 -2.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"Earth_Protective\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global ground gnd clean"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "Earth_Protective_0_1"
+			(polyline
+				(pts
+					(xy -0.635 -4.445) (xy 0.635 -4.445)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.127 -5.08) (xy 0.127 -5.08)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 -3.81) (xy 0 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center 0 -3.81)
+				(radius 2.54)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 -3.81) (xy -1.27 -3.81)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "Earth_Protective_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "GND"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "GND_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GND_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "GND1"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND1"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND1\" , ground"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "GND1_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GND1_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "GND2"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND2"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND2\" , ground"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "GND2_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GND2_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "GND3"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND3"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND3\" , ground"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "GND3_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GND3_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "GNDA"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GNDA"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GNDA\" , analog ground"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "GNDA_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GNDA_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "GNDD"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GNDD"
+			(at 0 -3.175 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GNDD\" , digital ground"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "GNDD_0_1"
+			(rectangle
+				(start -1.27 -1.524)
+				(end 1.27 -2.032)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 -1.524)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GNDD_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "GNDPWR"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -5.08 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GNDPWR"
+			(at 0 -3.302 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 -1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GNDPWR\" , global ground"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global ground"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "GNDPWR_0_1"
+			(polyline
+				(pts
+					(xy -1.016 -1.27) (xy -1.27 -2.032) (xy -1.27 -2.032)
+				)
+				(stroke
+					(width 0.2032)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.508 -1.27) (xy -0.762 -2.032) (xy -0.762 -2.032)
+				)
+				(stroke
+					(width 0.2032)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 -1.27) (xy 0 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 -1.27) (xy -0.254 -2.032) (xy -0.254 -2.032)
+				)
+				(stroke
+					(width 0.2032)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.508 -1.27) (xy 0.254 -2.032) (xy 0.254 -2.032)
+				)
+				(stroke
+					(width 0.2032)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.016 -1.27) (xy -1.016 -1.27) (xy -1.016 -1.27)
+				)
+				(stroke
+					(width 0.2032)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.016 -1.27) (xy 0.762 -2.032) (xy 0.762 -2.032) (xy 0.762 -2.032)
+				)
+				(stroke
+					(width 0.2032)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GNDPWR_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "GNDREF"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GNDREF"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GNDREF\" , reference supply ground"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "GNDREF_0_1"
+			(polyline
+				(pts
+					(xy -0.635 -1.905) (xy 0.635 -1.905)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.127 -2.54) (xy 0.127 -2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 -1.27) (xy 0 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 -1.27) (xy -1.27 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GNDREF_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "GNDS"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GNDS"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GNDS\" , signal ground"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "GNDS_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GNDS_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "HT"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "HT"
+			(at 0 3.048 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"HT\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "HT_0_0"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "HT_0_1"
+			(polyline
+				(pts
+					(xy 0 1.016) (xy 0.508 0.508) (xy 0 1.778) (xy -0.508 0.508) (xy 0 1.016) (xy 0 1.016)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.016) (xy 0 1.016)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "LINE"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "LINE"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"LINE\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "LINE_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "LINE_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "NEUT"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "NEUT"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"NEUT\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "NEUT_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "NEUT_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "PRI_HI"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "PRI_HI"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"PRI_HI\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "PRI_HI_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "PRI_HI_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "PRI_LO"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "PRI_LO"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"PRI_LO\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "PRI_LO_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(symbol "PRI_LO_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "PRI_MID"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "PRI_MID"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"PRI_MID\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "PRI_MID_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "PRI_MID_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "PWR_FLAG"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#FLG"
+			(at 0 1.905 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 0 3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Special symbol for telling ERC where power comes from"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "flag power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "PWR_FLAG_0_0"
+			(pin power_out line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "PWR_FLAG_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy -1.016 1.905) (xy 0 2.54) (xy 1.016 1.905) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VAA"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VAA"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VAA\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VAA_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "VAA_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VAC"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -2.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VAC"
+			(at 0 6.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VAC\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VAC_0_1"
+			(arc
+				(start -1.27 3.175)
+				(mid -0.635 3.8073)
+				(end 0 3.175)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center 0 3.175)
+				(radius 1.905)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(arc
+				(start 1.27 3.175)
+				(mid 0.635 2.5427)
+				(end 0 3.175)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "VAC_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VBUS"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VBUS"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VBUS\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VBUS_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "VBUS_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VCC"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VCC"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCC\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VCC_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "VCC_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VCCQ"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VCCQ"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCCQ\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VCCQ_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "VCCQ_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VCOM"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VCOM"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCOM\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VCOM_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(symbol "VCOM_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VD"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VD"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VD\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VD_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "VD_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VDC"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VDC"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VDC\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VDC_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "VDC_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VDD"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VDD"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VDD\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VDD_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "VDD_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VDDA"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VDDA"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VDDA\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VDDA_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "VDDA_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VDDF"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VDDF"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VDDF\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VDDF_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "VDDF_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VEE"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VEE"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VEE\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VEE_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(symbol "VEE_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VMEM"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VMEM"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VMEM\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VMEM_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "VMEM_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VPP"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VPP"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VPP\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VPP_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "VPP_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VS"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VS"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VS\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VS_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(symbol "VS_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VSS"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VSS"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VSS\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VSS_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(symbol "VSS_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "VSSA"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VSSA"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VSSA\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "VSSA_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 1.27) (xy -0.762 1.27) (xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+		)
+		(symbol "VSSA_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "Vdrive"
+		(power)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "Vdrive"
+			(at 0 3.556 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"Vdrive\""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "Vdrive_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "Vdrive_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+)

--- a/tests/test_sexpr.py
+++ b/tests/test_sexpr.py
@@ -1,0 +1,627 @@
+"""Tests for the S-expression tokenizer, parser, writer, and tree helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kist.sexpr import (
+    Atom,
+    SexprError,
+    TokenKind,
+    dumps,
+    find_all,
+    find_one,
+    parse,
+    parse_one,
+    remove_children,
+    set_child,
+    tokenize,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "kicad"
+_FIXTURE_FILES = sorted(FIXTURES.glob("*.kicad_sym"))
+
+
+# -- Atom ---
+
+
+def test_atom_unquoted():
+    a = Atom("hello", quoted=False)
+    assert a == "hello"
+    assert a.quoted is False
+
+
+def test_atom_quoted():
+    a = Atom("hello world", quoted=True)
+    assert a == "hello world"
+    assert a.quoted is True
+
+
+def test_atom_str_operations():
+    a = Atom("abc", quoted=True)
+    assert a.upper() == "ABC"
+    assert a + "d" == "abcd"
+    assert len(a) == 3
+
+
+def test_atom_repr():
+    a = Atom("x", quoted=True)
+    assert "Atom" in repr(a)
+    assert "quoted=True" in repr(a)
+
+
+def test_atom_default_unquoted():
+    a = Atom("test")
+    assert a.quoted is False
+
+
+# -- Tokenizer ---
+
+
+def test_tokenize_simple_list():
+    tokens = list(tokenize("(kicad_symbol_lib)"))
+    assert len(tokens) == 3
+    assert tokens[0].kind is TokenKind.OPEN
+    assert tokens[1].kind is TokenKind.ATOM
+    assert tokens[1].value == "kicad_symbol_lib"
+    assert tokens[2].kind is TokenKind.CLOSE
+
+
+def test_tokenize_nested():
+    tokens = list(tokenize("(a (b c))"))
+    kinds = [t.kind for t in tokens]
+    assert kinds == [
+        TokenKind.OPEN,
+        TokenKind.ATOM,
+        TokenKind.OPEN,
+        TokenKind.ATOM,
+        TokenKind.ATOM,
+        TokenKind.CLOSE,
+        TokenKind.CLOSE,
+    ]
+
+
+def test_tokenize_quoted_string():
+    tokens = list(tokenize('(property "Reference" "R")'))
+    assert tokens[2].kind is TokenKind.QSTRING
+    assert tokens[2].value == "Reference"
+    assert tokens[3].kind is TokenKind.QSTRING
+    assert tokens[3].value == "R"
+
+
+def test_tokenize_escape_sequences():
+    tokens = list(tokenize(r'("hello \"world\"")'))
+    assert tokens[1].value == 'hello "world"'
+
+
+def test_tokenize_escape_backslash():
+    tokens = list(tokenize(r'("path\\to\\file")'))
+    assert tokens[1].value == "path\\to\\file"
+
+
+def test_tokenize_escape_newline():
+    tokens = list(tokenize(r'("line1\nline2")'))
+    assert tokens[1].value == "line1\nline2"
+
+
+def test_tokenize_escape_carriage_return():
+    tokens = list(tokenize(r'("with\rreturn")'))
+    assert tokens[1].value == "with\rreturn"
+
+
+def test_tokenize_line_comment():
+    tokens = list(tokenize("(a ; comment\n b)"))
+    values = [t.value for t in tokens if t.kind is TokenKind.ATOM]
+    assert values == ["a", "b"]
+
+
+def test_tokenize_whitespace_variations():
+    tokens = list(tokenize("( a\tb\n\rc )"))
+    values = [t.value for t in tokens if t.kind is TokenKind.ATOM]
+    assert values == ["a", "b", "c"]
+
+
+def test_tokenize_numbers_as_atoms():
+    tokens = list(tokenize("(width 0.254)"))
+    assert tokens[2].kind is TokenKind.ATOM
+    assert tokens[2].value == "0.254"
+
+
+def test_tokenize_negative_number():
+    tokens = list(tokenize("(at -2.54 0)"))
+    values = [t.value for t in tokens if t.kind is TokenKind.ATOM]
+    assert values == ["at", "-2.54", "0"]
+
+
+def test_tokenize_hash_prefixed_atom():
+    # #-prefixed values in KiCad are sometimes unquoted in source
+    tokens = list(tokenize("(color #ff0000)"))
+    assert tokens[2].value == "#ff0000"
+
+
+def test_tokenize_offsets():
+    tokens = list(tokenize("(ab cd)"))
+    assert tokens[0].offset == 0  # (
+    assert tokens[1].offset == 1  # ab
+    assert tokens[2].offset == 4  # cd
+    assert tokens[3].offset == 6  # )
+
+
+def test_tokenize_empty_quoted_string():
+    tokens = list(tokenize('(name "")'))
+    assert tokens[2].kind is TokenKind.QSTRING
+    assert tokens[2].value == ""
+
+
+def test_tokenize_unterminated_string():
+    with pytest.raises(SexprError, match="Unterminated string"):
+        list(tokenize('("hello'))
+
+
+def test_tokenize_unterminated_escape():
+    with pytest.raises(SexprError, match="Unterminated escape"):
+        list(tokenize('("hello\\'))
+
+
+def test_tokenize_empty_input():
+    tokens = list(tokenize(""))
+    assert tokens == []
+
+
+def test_tokenize_only_whitespace():
+    tokens = list(tokenize("   \n\t  "))
+    assert tokens == []
+
+
+def test_tokenize_semicolon_not_in_string():
+    tokens = list(tokenize('("semi;colon")'))
+    assert tokens[1].value == "semi;colon"
+
+
+def test_tokenize_multiple_top_level():
+    tokens = list(tokenize("(a) (b)"))
+    opens = [t for t in tokens if t.kind is TokenKind.OPEN]
+    assert len(opens) == 2
+
+
+# -- Parser ---
+
+
+def test_parse_simple_list():
+    result = parse("(hello)")
+    assert result == [["hello"]]
+
+
+def test_parse_nested_list():
+    result = parse("(a (b c) d)")
+    assert result == [["a", ["b", "c"], "d"]]
+
+
+def test_parse_multiple_top_level():
+    result = parse("(a) (b)")
+    assert len(result) == 2
+    assert result[0] == ["a"]
+    assert result[1] == ["b"]
+
+
+def test_parse_atoms_are_atom_type():
+    result = parse('(key "value")')
+    assert isinstance(result[0][0], Atom)
+    assert result[0][0].quoted is False
+    assert isinstance(result[0][1], Atom)
+    assert result[0][1].quoted is True
+
+
+def test_parse_deeply_nested():
+    result = parse("(a (b (c (d e))))")
+    assert result == [["a", ["b", ["c", ["d", "e"]]]]]
+
+
+def test_parse_empty_list():
+    result = parse("()")
+    assert result == [[]]
+
+
+def test_parse_empty_input():
+    with pytest.raises(SexprError, match="Empty input"):
+        parse("")
+
+
+def test_parse_unmatched_open():
+    with pytest.raises(SexprError, match="Unmatched"):
+        parse("(a (b)")
+
+
+def test_parse_unexpected_close():
+    with pytest.raises(SexprError, match="Unexpected"):
+        parse(")")
+
+
+def test_parse_kicad_symbol_snippet():
+    text = """
+    (kicad_symbol_lib
+        (version 20231120)
+        (generator "kist")
+        (symbol "RES-10K-1PCT-0603"
+            (property "Reference" "R")
+            (property "Value" "10k")
+        )
+    )
+    """
+    result = parse_one(text)
+    assert isinstance(result, list)
+    assert result[0] == "kicad_symbol_lib"
+    assert find_one(result, "version") == ["version", "20231120"]
+    sym = find_one(result, "symbol")
+    assert sym is not None
+    assert sym[1] == "RES-10K-1PCT-0603"
+
+
+def test_parse_numbers_preserved_as_strings():
+    result = parse_one("(width 0.254)")
+    assert result[1] == "0.254"
+    assert isinstance(result[1], str)
+
+
+def test_parse_one_single():
+    result = parse_one("(hello)")
+    assert result == ["hello"]
+
+
+def test_parse_one_multiple_raises():
+    with pytest.raises(SexprError, match="Expected exactly one"):
+        parse_one("(a) (b)")
+
+
+def test_parse_one_bare_atom():
+    result = parse_one("hello")
+    assert result == "hello"
+
+
+# -- Tree helpers ---
+
+
+def test_find_all_matching():
+    tree = ["sym", ["property", "A"], ["pin", "1"], ["property", "B"]]
+    props = find_all(tree, "property")
+    assert len(props) == 2
+    assert props[0] == ["property", "A"]
+    assert props[1] == ["property", "B"]
+
+
+def test_find_all_no_match():
+    tree = ["sym", ["pin", "1"]]
+    assert find_all(tree, "property") == []
+
+
+def test_find_all_ignores_atoms():
+    tree = ["sym", "property", ["property", "A"]]
+    props = find_all(tree, "property")
+    assert len(props) == 1
+
+
+def test_find_all_only_direct_children():
+    tree = ["a", ["b", ["property", "nested"]], ["property", "direct"]]
+    props = find_all(tree, "property")
+    assert len(props) == 1
+    assert props[0] == ["property", "direct"]
+
+
+def test_find_one_finds_first():
+    tree = ["sym", ["property", "A"], ["property", "B"]]
+    result = find_one(tree, "property")
+    assert result == ["property", "A"]
+
+
+def test_find_one_not_found():
+    tree = ["sym", ["pin", "1"]]
+    assert find_one(tree, "property") is None
+
+
+def test_set_child_replaces_existing():
+    tree = ["sym", ["version", "1"], ["generator", "old"]]
+    set_child(tree, "generator", ["generator", "kist"])
+    assert tree == ["sym", ["version", "1"], ["generator", "kist"]]
+
+
+def test_set_child_appends_new():
+    tree = ["sym", ["version", "1"]]
+    set_child(tree, "generator", ["generator", "kist"])
+    assert tree == ["sym", ["version", "1"], ["generator", "kist"]]
+
+
+def test_set_child_replaces_only_first():
+    tree = ["sym", ["prop", "A"], ["prop", "B"]]
+    set_child(tree, "prop", ["prop", "C"])
+    assert tree[1] == ["prop", "C"]
+    assert tree[2] == ["prop", "B"]
+
+
+def test_remove_children_removes_all():
+    tree = ["sym", ["prop", "A"], ["pin", "1"], ["prop", "B"]]
+    count = remove_children(tree, "prop")
+    assert count == 2
+    assert tree == ["sym", ["pin", "1"]]
+
+
+def test_remove_children_removes_none():
+    tree = ["sym", ["pin", "1"]]
+    count = remove_children(tree, "prop")
+    assert count == 0
+    assert tree == ["sym", ["pin", "1"]]
+
+
+# -- Writer ---
+
+
+def test_dumps_simple_list():
+    result = dumps(["version", "20231120"])
+    assert result == "(version 20231120)\n"
+
+
+def test_dumps_single_atom():
+    result = dumps("hello")
+    assert result == "hello\n"
+
+
+def test_dumps_quoted_atom():
+    result = dumps(Atom("hello world", quoted=True))
+    assert result == '"hello world"\n'
+
+
+def test_dumps_auto_quoting_spaces():
+    result = dumps(["property", Atom("has spaces", quoted=False)])
+    assert '"has spaces"' in result
+
+
+def test_dumps_auto_quoting_empty():
+    result = dumps(["name", Atom("", quoted=True)])
+    assert '""' in result
+
+
+def test_dumps_auto_quoting_hash():
+    result = dumps(["value", "#power"])
+    assert '"#power"' in result
+
+
+def test_dumps_preserves_original_quoting():
+    result = dumps(["property", Atom("Reference", quoted=True)])
+    assert '"Reference"' in result
+
+
+def test_dumps_shortform_font():
+    expr = ["font", ["size", "1.27", "1.27"]]
+    result = dumps(expr)
+    assert "\n" not in result.strip()
+
+
+def test_dumps_shortform_stroke():
+    expr = ["stroke", ["width", "0"], ["type", "default"]]
+    result = dumps(expr)
+    assert "\n" not in result.strip()
+
+
+def test_dumps_shortform_fill():
+    expr = ["fill", ["type", "none"]]
+    result = dumps(expr)
+    assert "\n" not in result.strip()
+
+
+def test_dumps_shortform_at():
+    expr = ["at", "0", "0"]
+    result = dumps(expr)
+    assert result == "(at 0 0)\n"
+
+
+def test_dumps_leading_atoms_on_opening_line():
+    """Tag and leading string atoms stay on the opening line."""
+    expr = [
+        "symbol",
+        Atom("R", quoted=True),
+        ["property", Atom("Reference", quoted=True), Atom("R", quoted=True)],
+    ]
+    result = dumps(expr)
+    assert result.startswith('(symbol "R"\n')
+
+
+def test_dumps_property_with_children():
+    """Property tag + key + value on opening line, children indented."""
+    expr = [
+        "property",
+        Atom("Reference", quoted=True),
+        Atom("R", quoted=True),
+        ["at", "2.032", "0.508", "0"],
+    ]
+    result = dumps(expr)
+    first_line = result.split("\n")[0]
+    assert first_line == '(property "Reference" "R"'
+
+
+def test_dumps_nested_multiline():
+    expr = [
+        "kicad_symbol_lib",
+        ["version", "20231120"],
+        ["generator", Atom("kist", quoted=True)],
+        [
+            "symbol",
+            Atom("R_10K", quoted=True),
+            ["property", Atom("Reference", quoted=True), Atom("R", quoted=True)],
+            ["property", Atom("Value", quoted=True), Atom("10k", quoted=True)],
+        ],
+    ]
+    result = dumps(expr)
+    lines = result.strip().split("\n")
+    assert lines[0].startswith("(kicad_symbol_lib")
+    assert any("\t" in line for line in lines[1:])
+    assert lines[-1] == ")"
+
+
+def test_dumps_empty_list():
+    result = dumps([])
+    assert result == "()\n"
+
+
+def test_dumps_escape_in_output():
+    expr = ["property", Atom('say "hi"', quoted=True)]
+    result = dumps(expr)
+    assert r"\"" in result
+
+
+def test_dumps_escape_newline_in_output():
+    expr = ["note", Atom("line1\nline2", quoted=True)]
+    result = dumps(expr)
+    assert "\\n" in result
+
+
+def test_dumps_pts_compact():
+    expr = [
+        "pts",
+        ["xy", "0", "0"],
+        ["xy", "1", "1"],
+        ["xy", "2", "0"],
+    ]
+    result = dumps(expr)
+    assert result.strip().count("\n") == 0
+
+
+def test_dumps_pts_wraps_when_long():
+    expr = ["pts"]
+    for i in range(20):
+        expr.append(["xy", f"{i * 10.5432:.4f}", f"{i * 20.1234:.4f}"])
+    result = dumps(expr)
+    assert result.strip().count("\n") > 0
+
+
+# -- Round-trip ---
+
+
+def test_roundtrip_simple():
+    original = "(version 20231120)\n"
+    tree = parse_one(original)
+    output = dumps(tree)
+    reparsed = parse_one(output)
+    assert tree == reparsed
+
+
+def test_roundtrip_nested():
+    original = """(kicad_symbol_lib
+\t(version 20231120)
+\t(generator "kist")
+)
+"""
+    tree = parse_one(original)
+    output = dumps(tree)
+    reparsed = parse_one(output)
+    assert _structural_eq(tree, reparsed)
+
+
+def test_roundtrip_quoted_strings():
+    original = '(property "Reference" "R")\n'
+    tree = parse_one(original)
+    output = dumps(tree)
+    reparsed = parse_one(output)
+    assert _structural_eq(tree, reparsed)
+
+
+def test_roundtrip_escape():
+    original = '(note "line1\\nline2")\n'
+    tree = parse_one(original)
+    output = dumps(tree)
+    reparsed = parse_one(output)
+    assert reparsed[1] == "line1\nline2"
+
+
+def test_roundtrip_empty_string():
+    original = '(name "")\n'
+    tree = parse_one(original)
+    output = dumps(tree)
+    reparsed = parse_one(output)
+    assert reparsed[1] == ""
+
+
+# -- Fixture round-trip tests ---
+
+
+@pytest.mark.parametrize(
+    "fixture_path",
+    _FIXTURE_FILES,
+    ids=[p.name for p in _FIXTURE_FILES],
+)
+def test_fixture_structural_roundtrip(fixture_path: Path):
+    """parse(dumps(parse(file))) == parse(file) for every fixture."""
+    original_text = fixture_path.read_text()
+    tree = parse_one(original_text)
+    written = dumps(tree)
+    reparsed = parse_one(written)
+    assert _structural_eq(tree, reparsed), (
+        f"Structural mismatch after round-trip of {fixture_path.name}"
+    )
+
+
+@pytest.mark.parametrize(
+    "fixture_path",
+    _FIXTURE_FILES,
+    ids=[p.name for p in _FIXTURE_FILES],
+)
+def test_fixture_symbol_count_preserved(fixture_path: Path):
+    """Same number of top-level symbols before and after round-trip."""
+    text = fixture_path.read_text()
+    tree = parse_one(text)
+    assert isinstance(tree, list)
+    symbols_before = find_all(tree, "symbol")
+
+    written = dumps(tree)
+    reparsed = parse_one(written)
+    assert isinstance(reparsed, list)
+    symbols_after = find_all(reparsed, "symbol")
+
+    assert len(symbols_before) == len(symbols_after)
+
+
+@pytest.mark.parametrize(
+    "fixture_path",
+    _FIXTURE_FILES,
+    ids=[p.name for p in _FIXTURE_FILES],
+)
+def test_fixture_idempotent_write(fixture_path: Path):
+    """dumps(parse(dumps(parse(file)))) == dumps(parse(file))."""
+    text = fixture_path.read_text()
+    tree = parse_one(text)
+    first_write = dumps(tree)
+
+    tree2 = parse_one(first_write)
+    second_write = dumps(tree2)
+
+    assert first_write == second_write, f"Writer not idempotent for {fixture_path.name}"
+
+
+# -- Snapshot tests ---
+
+
+@pytest.mark.parametrize(
+    "fixture_path",
+    _FIXTURE_FILES,
+    ids=[p.name for p in _FIXTURE_FILES],
+)
+def test_writer_snapshot(fixture_path: Path, snapshot):
+    """Snapshot the writer output for each fixture to catch formatting regressions."""
+    text = fixture_path.read_text()
+    tree = parse_one(text)
+    written = dumps(tree)
+    assert written == snapshot
+
+
+# -- Helpers ---
+
+
+def _structural_eq(a: object, b: object) -> bool:
+    """Compare two S-expression trees, ignoring Atom.quoted metadata."""
+    if isinstance(a, list) and isinstance(b, list):
+        if len(a) != len(b):
+            return False
+        return all(_structural_eq(x, y) for x, y in zip(a, b, strict=True))
+    if isinstance(a, str) and isinstance(b, str):
+        return a == b
+    return False

--- a/uv.lock
+++ b/uv.lock
@@ -213,6 +213,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "syrupy" },
 ]
 
 [package.metadata]
@@ -226,6 +227,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "rich", specifier = ">=14.3.2" },
     { name = "structlog", specifier = ">=25.5.0" },
+    { name = "syrupy", marker = "extra == 'dev'", specifier = ">=4.8.0" },
     { name = "tomlkit", specifier = ">=0.14.0" },
     { name = "typer", specifier = ">=0.21.1" },
 ]
@@ -469,6 +471,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "syrupy"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/b0/24bca682d6a6337854be37f242d116cceeda9942571d5804c44bc1bdd427/syrupy-5.1.0.tar.gz", hash = "sha256:df543c7aa50d3cf1246e83d58fe490afe5f7dab7b41e74ecc0d8d23ae19bd4b8", size = 50495, upload-time = "2026-01-25T14:53:06.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/70/cf880c3b95a6034ef673e74b369941b42315c01f1554a5637a4f8b911009/syrupy-5.1.0-py3-none-any.whl", hash = "sha256:95162d2b05e61ed3e13f117b88dfab7c58bd6f90e66ebbf918e8a77114ad51c5", size = 51658, upload-time = "2026-01-25T14:53:05.105Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

kist add/sync need to read and write `.kicad_sym` files. ADR-002 rules out kiutils (GPL, unmaintained) so we need our own parser. This is the foundation module -- getting tokenization, round-trip fidelity, and formatting right here avoids pain in every downstream module.

## Changes

- `src/kist/sexpr.py` -- index-based tokenizer, recursive parser, KiCad v8/v9-style writer, tree helpers (find/set/remove). Numbers kept as strings for round-trip precision. `Atom` type tracks source quoting to match KiCad's conventions and minimise git noise.
- `tests/test_sexpr.py` -- 90 tests covering tokenizer, parser, writer, tree helpers, round-trip structural equality, writer idempotency, and syrupy snapshots.
- `tests/fixtures/kicad/` -- pristine KiCad 9.0.5 symbol files (Device R/C/L, Regulator_Current, Transistor_IGBT, power) for real-world round-trip testing.
- `pyproject.toml` -- syrupy added to dev deps.

## Test plan

- `pytest tests/test_sexpr.py` -- 90 tests, all passing
- Parametrised round-trip tests: parse every fixture, write, re-parse, verify structural equality
- Idempotency tests: `dumps(parse(dumps(parse(file)))) == dumps(parse(file))` for every fixture
- Syrupy snapshots pin exact writer output against pristine KiCad files

## Notes

- Subsequent commits on this branch will add category mapping, SymbolLibrary CRUD, and symbol templates (per the implementation plan). Stopping here for review since the parser is the foundation.
- Writer formatting differs from KiCad's native output in shortform tag collapsing (e.g. `effects`, `font`, `stroke` on one line vs expanded). Structurally identical; KiCad parses both fine.