### PR TITLE
core: Add KiCad symbol library API

### DIFF
--- a/src/kist/kicad/__init__.py
+++ b/src/kist/kicad/__init__.py
@@ -1,1 +1,27 @@
 """KiCad file handling -- symbol libraries, templates, and category mapping."""
+
+from kist.kicad.mapping import CATEGORY_LIBRARY, library_filename, symbol_reference
+from kist.kicad.symbols import SymbolLibrary
+from kist.kicad.templates import (
+    build_properties,
+    capacitor_symbol,
+    inductor_symbol,
+    resistor_symbol,
+    resistor_symbol_iec,
+    stub_symbol,
+    symbol_for_part,
+)
+
+__all__ = [
+    "CATEGORY_LIBRARY",
+    "SymbolLibrary",
+    "build_properties",
+    "capacitor_symbol",
+    "inductor_symbol",
+    "library_filename",
+    "resistor_symbol",
+    "resistor_symbol_iec",
+    "stub_symbol",
+    "symbol_for_part",
+    "symbol_reference",
+]

--- a/src/kist/kicad/__init__.py
+++ b/src/kist/kicad/__init__.py
@@ -1,0 +1,1 @@
+"""KiCad file handling -- symbol libraries, templates, and category mapping."""

--- a/src/kist/kicad/mapping.py
+++ b/src/kist/kicad/mapping.py
@@ -1,0 +1,44 @@
+"""
+Category-to-library mapping per ADR-002 §4.
+
+Maps each part category to a numbered KiCad library name, matching the
+convention ``NNk-Name`` where NN is a two-digit sort prefix and ``k``
+marks kist-managed libraries.
+"""
+
+from __future__ import annotations
+
+from kist.models import Category
+
+# -- Category-to-library mapping ---
+
+CATEGORY_LIBRARY: dict[Category, str] = {
+    Category.RES: "00k-Resistors",
+    Category.CAP: "01k-Capacitors",
+    Category.IND: "02k-Inductors",
+    Category.DIO: "03k-Diodes",
+    Category.TRAN: "04k-Transistors",
+    Category.IC: "05k-ICs",
+    Category.CONN: "06k-Connectors",
+    Category.SW: "07k-Switches",
+    Category.REL: "08k-Relays",
+    Category.XTAL: "09k-Crystals",
+    Category.FUSE: "10k-Fuses",
+    Category.TFRM: "11k-Transformers",
+    Category.TP: "12k-TestPoints",
+    Category.FID: "13k-Fiducials",
+    Category.MECH: "14k-Mechanical",
+    Category.MISC: "15k-Misc",
+}
+
+
+def library_filename(category: Category) -> str:
+    """Return the ``.kicad_sym`` filename for *category*."""
+    return f"{CATEGORY_LIBRARY[category]}.kicad_sym"
+
+
+def symbol_reference(category: Category, part_name: str) -> str:
+    """
+    Return a full KiCad symbol reference like ``00k-Resistors:RES-10K-1PCT-0603``.
+    """
+    return f"{CATEGORY_LIBRARY[category]}:{part_name}"

--- a/src/kist/kicad/symbols.py
+++ b/src/kist/kicad/symbols.py
@@ -1,0 +1,153 @@
+"""
+KiCad symbol library (.kicad_sym) read/write.
+
+Wraps the generic S-expression layer with a domain-specific API for
+listing, adding, replacing, and patching symbols inside a library file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kist.sexpr import Atom, SexprError, dumps, find_all, parse_one
+
+# -- Constants ---
+
+_LIB_TAG = "kicad_symbol_lib"
+# TODO: verify what the YYYYMMDD version value represents -- file format
+# revision date?  Matches KiCad 9.0 fixtures for now.
+_VERSION = "20241209"
+_GENERATOR = "kist"
+_GENERATOR_VERSION = "1.0"
+
+
+# -- SymbolLibrary ---
+
+
+class SymbolLibrary:
+    """
+    In-memory representation of a ``.kicad_sym`` symbol library.
+
+    Symbols are stored as raw S-expression subtrees so callers can
+    inspect or mutate them with the helpers in :mod:`kist.sexpr`.
+    """
+
+    def __init__(self, tree: list) -> None:
+        self._tree = tree
+
+    # -- Constructors ---
+
+    @classmethod
+    def load(cls, path: str | Path) -> SymbolLibrary:
+        """Parse a ``.kicad_sym`` file and return a library instance."""
+        text = Path(path).read_text(encoding="utf-8")
+        tree = parse_one(text)
+        if not isinstance(tree, list) or not tree or tree[0] != _LIB_TAG:
+            raise SexprError(f"Expected top-level ({_LIB_TAG} ...), got {tree[0]!r}")
+        return cls(tree)
+
+    @classmethod
+    def empty(cls) -> SymbolLibrary:
+        """Return a fresh library with only version and generator metadata."""
+        tree: list = [
+            Atom(_LIB_TAG),
+            [Atom("version"), Atom(_VERSION)],
+            [Atom("generator"), Atom(_GENERATOR, quoted=True)],
+            [Atom("generator_version"), Atom(_GENERATOR_VERSION, quoted=True)],
+        ]
+        return cls(tree)
+
+    # -- Persistence ---
+
+    def save(self, path: str | Path) -> None:
+        """Write the library to *path* with Unix line endings."""
+        Path(path).write_text(dumps(self._tree), encoding="utf-8", newline="\n")
+
+    # -- Symbol access ---
+
+    def symbols(self) -> list[str]:
+        """Return the names of all top-level symbols in definition order."""
+        return [str(sym[1]) for sym in find_all(self._tree, "symbol") if len(sym) > 1]
+
+    def get_symbol(self, name: str) -> list | None:
+        """Return the S-expression subtree for *name*, or ``None``."""
+        for sym in find_all(self._tree, "symbol"):
+            if len(sym) > 1 and sym[1] == name:
+                return sym
+        return None
+
+    def set_symbol(self, name: str, sexpr: list) -> None:
+        """Add or replace the symbol called *name*."""
+        for i, child in enumerate(self._tree):
+            if (
+                isinstance(child, list)
+                and child
+                and child[0] == "symbol"
+                and len(child) > 1
+                and child[1] == name
+            ):
+                self._tree[i] = sexpr
+                return
+        self._tree.append(sexpr)
+
+    def remove_symbol(self, name: str) -> bool:
+        """Remove the symbol called *name*.  Returns whether it existed."""
+        for i, child in enumerate(self._tree):
+            if (
+                isinstance(child, list)
+                and child
+                and child[0] == "symbol"
+                and len(child) > 1
+                and child[1] == name
+            ):
+                del self._tree[i]
+                return True
+        return False
+
+    # -- Property patching ---
+
+    def update_properties(self, name: str, props: dict[str, str]) -> None:
+        """
+        Patch property values on the symbol called *name*.
+
+        For each key in *props*, find the ``(property "Key" "Value" ...)``
+        child and replace the value atom (index 2).  If the property
+        doesn't exist, append a new minimal property node.
+
+        Raises ``KeyError`` if the symbol doesn't exist.
+        """
+        sym = self.get_symbol(name)
+        if sym is None:
+            raise KeyError(name)
+
+        for key, value in props.items():
+            prop = None
+            for child in sym:
+                if (
+                    isinstance(child, list)
+                    and child
+                    and child[0] == "property"
+                    and len(child) > 2
+                    and child[1] == key
+                ):
+                    prop = child
+                    break
+
+            if prop is not None:
+                # Patch value in-place, preserving (at ...), (effects ...) etc.
+                prop[2] = Atom(value, quoted=True)
+            else:
+                # Append a new minimal property
+                sym.append(
+                    [
+                        Atom("property"),
+                        Atom(key, quoted=True),
+                        Atom(value, quoted=True),
+                        [Atom("at"), Atom("0"), Atom("0"), Atom("0")],
+                        [
+                            Atom("effects"),
+                            [Atom("font"), [Atom("size"), Atom("1.27"), Atom("1.27")]],
+                            [Atom("hide"), Atom("yes")],
+                        ],
+                    ]
+                )

--- a/src/kist/kicad/templates.py
+++ b/src/kist/kicad/templates.py
@@ -1,0 +1,459 @@
+"""
+KiCad symbol templates for common part types.
+
+Generates complete ``(symbol ...)`` S-expression trees matching KiCad's
+own Device:R_US, Device:C, and Device:L symbols so generated libraries
+look identical to hand-placed parts. Graphics coordinates are copied
+from the KiCad 9.0 Device library.
+"""
+
+from __future__ import annotations
+
+from kist.models import Category, Part, PartBase, Tier
+from kist.sexpr import Atom, SExpr
+
+# -- Helpers ---
+
+
+def _q(val: str) -> Atom:
+    """Quoted atom."""
+    return Atom(val, quoted=True)
+
+
+def _k(val: str) -> Atom:
+    """Keyword (unquoted) atom."""
+    return Atom(val)
+
+
+def _hidden_property(key: str, value: str) -> list[SExpr]:
+    """A property hidden at (0,0,0) with standard font size."""
+    return [
+        _k("property"),
+        _q(key),
+        _q(value),
+        [_k("at"), _k("0"), _k("0"), _k("0")],
+        [
+            _k("effects"),
+            [_k("font"), [_k("size"), _k("1.27"), _k("1.27")]],
+            [_k("hide"), _k("yes")],
+        ],
+    ]
+
+
+def _pin(number: str, x: str, y: str, angle: str, length: str) -> list[SExpr]:
+    """A passive-line pin with hidden name ``~``."""
+    return [
+        _k("pin"),
+        _k("passive"),
+        _k("line"),
+        [_k("at"), _k(x), _k(y), _k(angle)],
+        [_k("length"), _k(length)],
+        [
+            _k("name"),
+            _q("~"),
+            [_k("effects"), [_k("font"), [_k("size"), _k("1.27"), _k("1.27")]]],
+        ],
+        [
+            _k("number"),
+            _q(number),
+            [_k("effects"), [_k("font"), [_k("size"), _k("1.27"), _k("1.27")]]],
+        ],
+    ]
+
+
+def _stroke(width: str = "0") -> list[SExpr]:
+    return [_k("stroke"), [_k("width"), _k(width)], [_k("type"), _k("default")]]
+
+
+def _fill_none() -> list[SExpr]:
+    return [_k("fill"), [_k("type"), _k("none")]]
+
+
+# -- Property builder ---
+
+
+def build_properties(part: PartBase) -> dict[str, str]:
+    """
+    Extract KiCad property values from a Part model.
+
+    Returns a dict suitable for passing to template functions or
+    ``SymbolLibrary.update_properties()``.
+    """
+    datasheet = str(part.datasheet) if part.datasheet else "~"
+    keywords = " ".join(part.keywords + part.tags)
+    return {
+        "Reference": part.reference.value,
+        "Value": part.value,
+        "Footprint": part.footprint,
+        "Datasheet": datasheet,
+        "Description": part.description,
+        "ki_keywords": keywords,
+    }
+
+
+# -- Resistor template (IEC rectangle body) ---
+
+
+def resistor_symbol_iec(name: str, props: dict[str, str]) -> list[SExpr]:
+    """
+    Complete ``(symbol ...)`` tree for a resistor.
+
+    IEC rectangle body matching KiCad Device:R, two passive pins.
+    """
+    return [
+        _k("symbol"),
+        _q(name),
+        [_k("pin_numbers"), [_k("hide"), _k("yes")]],
+        [_k("pin_names"), [_k("offset"), _k("0")]],
+        [_k("exclude_from_sim"), _k("no")],
+        [_k("in_bom"), _k("yes")],
+        [_k("on_board"), _k("yes")],
+        # Visible properties
+        [
+            _k("property"),
+            _q("Reference"),
+            _q(props.get("Reference", "R")),
+            [_k("at"), _k("2.032"), _k("0"), _k("90")],
+            [
+                _k("effects"),
+                [_k("font"), [_k("size"), _k("1.27"), _k("1.27")]],
+            ],
+        ],
+        [
+            _k("property"),
+            _q("Value"),
+            _q(props.get("Value", name)),
+            [_k("at"), _k("0"), _k("0"), _k("90")],
+            [
+                _k("effects"),
+                [_k("font"), [_k("size"), _k("1.27"), _k("1.27")]],
+            ],
+        ],
+        # Hidden properties
+        _hidden_property("Footprint", props.get("Footprint", "")),
+        _hidden_property("Datasheet", props.get("Datasheet", "~")),
+        _hidden_property("Description", props.get("Description", "")),
+        _hidden_property("ki_keywords", props.get("ki_keywords", "")),
+        # Graphics sub-symbol: rectangle body
+        [
+            _k("symbol"),
+            _q(f"{name}_0_1"),
+            [
+                _k("rectangle"),
+                [_k("start"), _k("-1.016"), _k("-2.54")],
+                [_k("end"), _k("1.016"), _k("2.54")],
+                _stroke("0.254"),
+                _fill_none(),
+            ],
+        ],
+        # Pins sub-symbol
+        [
+            _k("symbol"),
+            _q(f"{name}_1_1"),
+            _pin("1", "0", "3.81", "270", "1.27"),
+            _pin("2", "0", "-3.81", "90", "1.27"),
+        ],
+    ]
+
+
+# -- Resistor template (US zigzag body) ---
+
+
+def _zigzag_polyline(points: list[tuple[str, str]]) -> list[SExpr]:
+    """A polyline from a list of (x, y) coordinate pairs."""
+    pts: list[SExpr] = [_k("pts")]
+    for x, y in points:
+        pts.append([_k("xy"), _k(x), _k(y)])
+    return [_k("polyline"), pts, _stroke(), _fill_none()]
+
+
+def resistor_symbol(name: str, props: dict[str, str]) -> list[SExpr]:
+    """
+    Complete ``(symbol ...)`` tree for a resistor.
+
+    US zigzag body matching KiCad Device:R_US, two passive pins.
+    """
+    return [
+        _k("symbol"),
+        _q(name),
+        [_k("pin_numbers"), [_k("hide"), _k("yes")]],
+        [_k("pin_names"), [_k("offset"), _k("0")]],
+        [_k("exclude_from_sim"), _k("no")],
+        [_k("in_bom"), _k("yes")],
+        [_k("on_board"), _k("yes")],
+        # Visible properties
+        [
+            _k("property"),
+            _q("Reference"),
+            _q(props.get("Reference", "R")),
+            [_k("at"), _k("2.54"), _k("0"), _k("90")],
+            [
+                _k("effects"),
+                [_k("font"), [_k("size"), _k("1.27"), _k("1.27")]],
+            ],
+        ],
+        [
+            _k("property"),
+            _q("Value"),
+            _q(props.get("Value", name)),
+            [_k("at"), _k("-2.54"), _k("0"), _k("90")],
+            [
+                _k("effects"),
+                [_k("font"), [_k("size"), _k("1.27"), _k("1.27")]],
+            ],
+        ],
+        # Hidden properties
+        _hidden_property("Footprint", props.get("Footprint", "")),
+        _hidden_property("Datasheet", props.get("Datasheet", "~")),
+        _hidden_property("Description", props.get("Description", "")),
+        _hidden_property("ki_keywords", props.get("ki_keywords", "")),
+        # Graphics sub-symbol: US zigzag body (5 polylines from Device:R_US)
+        [
+            _k("symbol"),
+            _q(f"{name}_0_1"),
+            # Top lead stub
+            _zigzag_polyline([("0", "2.286"), ("0", "2.54")]),
+            # Upper zigzag
+            _zigzag_polyline(
+                [
+                    ("0", "2.286"),
+                    ("1.016", "1.905"),
+                    ("0", "1.524"),
+                    ("-1.016", "1.143"),
+                    ("0", "0.762"),
+                ]
+            ),
+            # Middle zigzag
+            _zigzag_polyline(
+                [
+                    ("0", "0.762"),
+                    ("1.016", "0.381"),
+                    ("0", "0"),
+                    ("-1.016", "-0.381"),
+                    ("0", "-0.762"),
+                ]
+            ),
+            # Lower zigzag
+            _zigzag_polyline(
+                [
+                    ("0", "-0.762"),
+                    ("1.016", "-1.143"),
+                    ("0", "-1.524"),
+                    ("-1.016", "-1.905"),
+                    ("0", "-2.286"),
+                ]
+            ),
+            # Bottom lead stub
+            _zigzag_polyline([("0", "-2.286"), ("0", "-2.54")]),
+        ],
+        # Pins sub-symbol
+        [
+            _k("symbol"),
+            _q(f"{name}_1_1"),
+            _pin("1", "0", "3.81", "270", "1.27"),
+            _pin("2", "0", "-3.81", "90", "1.27"),
+        ],
+    ]
+
+
+# -- Capacitor template (parallel plates) ---
+
+
+def capacitor_symbol(name: str, props: dict[str, str]) -> list[SExpr]:
+    """
+    Complete ``(symbol ...)`` tree for an unpolarized capacitor.
+
+    Parallel plate body matching KiCad Device:C, two passive pins.
+    """
+    return [
+        _k("symbol"),
+        _q(name),
+        [_k("pin_numbers"), [_k("hide"), _k("yes")]],
+        [_k("pin_names"), [_k("offset"), _k("0.254")]],
+        [_k("exclude_from_sim"), _k("no")],
+        [_k("in_bom"), _k("yes")],
+        [_k("on_board"), _k("yes")],
+        # Visible properties
+        [
+            _k("property"),
+            _q("Reference"),
+            _q(props.get("Reference", "C")),
+            [_k("at"), _k("0.635"), _k("2.54"), _k("0")],
+            [
+                _k("effects"),
+                [_k("font"), [_k("size"), _k("1.27"), _k("1.27")]],
+                [_k("justify"), _k("left")],
+            ],
+        ],
+        [
+            _k("property"),
+            _q("Value"),
+            _q(props.get("Value", name)),
+            [_k("at"), _k("0.635"), _k("-2.54"), _k("0")],
+            [
+                _k("effects"),
+                [_k("font"), [_k("size"), _k("1.27"), _k("1.27")]],
+                [_k("justify"), _k("left")],
+            ],
+        ],
+        # Hidden properties
+        _hidden_property("Footprint", props.get("Footprint", "")),
+        _hidden_property("Datasheet", props.get("Datasheet", "~")),
+        _hidden_property("Description", props.get("Description", "")),
+        _hidden_property("ki_keywords", props.get("ki_keywords", "")),
+        # Graphics sub-symbol: two parallel plates
+        [
+            _k("symbol"),
+            _q(f"{name}_0_1"),
+            [
+                _k("polyline"),
+                [
+                    _k("pts"),
+                    [_k("xy"), _k("-2.032"), _k("0.762")],
+                    [_k("xy"), _k("2.032"), _k("0.762")],
+                ],
+                _stroke("0.508"),
+                _fill_none(),
+            ],
+            [
+                _k("polyline"),
+                [
+                    _k("pts"),
+                    [_k("xy"), _k("-2.032"), _k("-0.762")],
+                    [_k("xy"), _k("2.032"), _k("-0.762")],
+                ],
+                _stroke("0.508"),
+                _fill_none(),
+            ],
+        ],
+        # Pins sub-symbol
+        [
+            _k("symbol"),
+            _q(f"{name}_1_1"),
+            _pin("1", "0", "3.81", "270", "2.794"),
+            _pin("2", "0", "-3.81", "90", "2.794"),
+        ],
+    ]
+
+
+# -- Inductor template (arc coil) ---
+
+
+def _arc(start_y: str, mid_y: str, end_y: str) -> list[SExpr]:
+    """Single arc segment for the inductor coil body."""
+    return [
+        _k("arc"),
+        [_k("start"), _k("0"), _k(start_y)],
+        [_k("mid"), _k("0.6323"), _k(mid_y)],
+        [_k("end"), _k("0"), _k(end_y)],
+        _stroke(),
+        _fill_none(),
+    ]
+
+
+def inductor_symbol(name: str, props: dict[str, str]) -> list[SExpr]:
+    """
+    Complete ``(symbol ...)`` tree for an inductor.
+
+    Four-arc coil body matching KiCad Device:L, two passive pins.
+    """
+    return [
+        _k("symbol"),
+        _q(name),
+        [_k("pin_numbers"), [_k("hide"), _k("yes")]],
+        [_k("pin_names"), [_k("offset"), _k("1.016")], [_k("hide"), _k("yes")]],
+        [_k("exclude_from_sim"), _k("no")],
+        [_k("in_bom"), _k("yes")],
+        [_k("on_board"), _k("yes")],
+        # Visible properties
+        [
+            _k("property"),
+            _q("Reference"),
+            _q(props.get("Reference", "L")),
+            [_k("at"), _k("-1.27"), _k("0"), _k("90")],
+            [
+                _k("effects"),
+                [_k("font"), [_k("size"), _k("1.27"), _k("1.27")]],
+            ],
+        ],
+        [
+            _k("property"),
+            _q("Value"),
+            _q(props.get("Value", name)),
+            [_k("at"), _k("1.905"), _k("0"), _k("90")],
+            [
+                _k("effects"),
+                [_k("font"), [_k("size"), _k("1.27"), _k("1.27")]],
+            ],
+        ],
+        # Hidden properties
+        _hidden_property("Footprint", props.get("Footprint", "")),
+        _hidden_property("Datasheet", props.get("Datasheet", "~")),
+        _hidden_property("Description", props.get("Description", "")),
+        _hidden_property("ki_keywords", props.get("ki_keywords", "")),
+        # Graphics sub-symbol: four arcs
+        [
+            _k("symbol"),
+            _q(f"{name}_0_1"),
+            _arc("2.54", "1.905", "1.27"),
+            _arc("1.27", "0.635", "0"),
+            _arc("0", "-0.635", "-1.27"),
+            _arc("-1.27", "-1.905", "-2.54"),
+        ],
+        # Pins sub-symbol
+        [
+            _k("symbol"),
+            _q(f"{name}_1_1"),
+            _pin("1", "0", "3.81", "270", "1.27"),
+            _pin("2", "0", "-3.81", "90", "1.27"),
+        ],
+    ]
+
+
+# -- Stub template (properties only, no graphics) ---
+
+
+def stub_symbol(name: str, props: dict[str, str]) -> list[SExpr]:
+    """
+    Minimal symbol with properties but no graphics or pins.
+
+    Used for part categories that don't have a standard schematic
+    symbol template (ICs, connectors, etc.).
+    """
+    return [
+        _k("symbol"),
+        _q(name),
+        [_k("exclude_from_sim"), _k("no")],
+        [_k("in_bom"), _k("yes")],
+        [_k("on_board"), _k("yes")],
+        _hidden_property("Reference", props.get("Reference", "U")),
+        _hidden_property("Value", props.get("Value", name)),
+        _hidden_property("Footprint", props.get("Footprint", "")),
+        _hidden_property("Datasheet", props.get("Datasheet", "~")),
+        _hidden_property("Description", props.get("Description", "")),
+        _hidden_property("ki_keywords", props.get("ki_keywords", "")),
+    ]
+
+
+# -- Dispatch ---
+
+# TODO: make resistor style (US/IEC) configurable via library config.
+# See resistor_symbol (US zigzag) and resistor_symbol_iec (IEC rectangle).
+_JELLYBEAN_TEMPLATES = {
+    Category.RES: resistor_symbol,
+    Category.CAP: capacitor_symbol,
+    Category.IND: inductor_symbol,
+}
+
+
+def symbol_for_part(part: Part) -> list[SExpr]:
+    """
+    Generate the appropriate symbol tree for *part*.
+
+    Jellybean resistors, capacitors, and inductors get full graphic
+    templates. Everything else gets a stub with properties only.
+    """
+    props = build_properties(part)
+    if part.tier == Tier.JELLYBEAN and part.category in _JELLYBEAN_TEMPLATES:
+        return _JELLYBEAN_TEMPLATES[part.category](part.name, props)
+    return stub_symbol(part.name, props)

--- a/tests/kicad/__snapshots__/test_symbols.ambr
+++ b/tests/kicad/__snapshots__/test_symbols.ambr
@@ -1,0 +1,21 @@
+# serializer version: 1
+# name: test_empty_with_symbol_snapshot
+  '''
+  (kicad_symbol_lib
+  	(version 20241209)
+  	(generator "kist")
+  	(generator_version "1.0")
+  	(symbol "TEST-PART"
+  		(in_bom yes)
+  		(on_board yes)
+  		(property "Reference" "R"
+  			(at 0 0 0)
+  		)
+  		(property "Value" "10k"
+  			(at 0 0 0)
+  		)
+  	)
+  )
+  
+  '''
+# ---

--- a/tests/kicad/__snapshots__/test_templates.ambr
+++ b/tests/kicad/__snapshots__/test_templates.ambr
@@ -1,0 +1,254 @@
+# serializer version: 1
+# name: test_capacitor_snapshot
+  '''
+  (symbol "CAP-100N"
+  	(pin_numbers (hide yes))
+  	(pin_names (offset 0.254))
+  	(exclude_from_sim no)
+  	(in_bom yes)
+  	(on_board yes)
+  	(property "Reference" "C"
+  		(at 0.635 2.54 0)
+  		(effects (font (size 1.27 1.27)) (justify left))
+  	)
+  	(property "Value" "100n"
+  		(at 0.635 -2.54 0)
+  		(effects (font (size 1.27 1.27)) (justify left))
+  	)
+  	(property "Footprint" "Resistor_SMD:R_0603_1608Metric"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "Datasheet" "~"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "Description" "10k resistor"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "ki_keywords" "resistor"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(symbol "CAP-100N_0_1"
+  		(polyline
+  			(pts (xy -2.032 0.762) (xy 2.032 0.762))
+  			(stroke (width 0.508) (type default))
+  			(fill (type none))
+  		)
+  		(polyline
+  			(pts (xy -2.032 -0.762) (xy 2.032 -0.762))
+  			(stroke (width 0.508) (type default))
+  			(fill (type none))
+  		)
+  	)
+  	(symbol "CAP-100N_1_1"
+  		(pin passive line
+  			(at 0 3.81 270)
+  			(length 2.794)
+  			(name "~" (effects (font (size 1.27 1.27))))
+  			(number "1" (effects (font (size 1.27 1.27))))
+  		)
+  		(pin passive line
+  			(at 0 -3.81 90)
+  			(length 2.794)
+  			(name "~" (effects (font (size 1.27 1.27))))
+  			(number "2" (effects (font (size 1.27 1.27))))
+  		)
+  	)
+  )
+  
+  '''
+# ---
+# name: test_inductor_snapshot
+  '''
+  (symbol "IND-10U"
+  	(pin_numbers (hide yes))
+  	(pin_names (offset 1.016) (hide yes))
+  	(exclude_from_sim no)
+  	(in_bom yes)
+  	(on_board yes)
+  	(property "Reference" "L"
+  		(at -1.27 0 90)
+  		(effects (font (size 1.27 1.27)))
+  	)
+  	(property "Value" "10u"
+  		(at 1.905 0 90)
+  		(effects (font (size 1.27 1.27)))
+  	)
+  	(property "Footprint" "Resistor_SMD:R_0603_1608Metric"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "Datasheet" "~"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "Description" "10k resistor"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "ki_keywords" "resistor"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(symbol "IND-10U_0_1"
+  		(arc
+  			(start 0 2.54)
+  			(mid 0.6323 1.905)
+  			(end 0 1.27)
+  			(stroke (width 0) (type default))
+  			(fill (type none))
+  		)
+  		(arc
+  			(start 0 1.27)
+  			(mid 0.6323 0.635)
+  			(end 0 0)
+  			(stroke (width 0) (type default))
+  			(fill (type none))
+  		)
+  		(arc
+  			(start 0 0)
+  			(mid 0.6323 -0.635)
+  			(end 0 -1.27)
+  			(stroke (width 0) (type default))
+  			(fill (type none))
+  		)
+  		(arc
+  			(start 0 -1.27)
+  			(mid 0.6323 -1.905)
+  			(end 0 -2.54)
+  			(stroke (width 0) (type default))
+  			(fill (type none))
+  		)
+  	)
+  	(symbol "IND-10U_1_1"
+  		(pin passive line
+  			(at 0 3.81 270)
+  			(length 1.27)
+  			(name "~" (effects (font (size 1.27 1.27))))
+  			(number "1" (effects (font (size 1.27 1.27))))
+  		)
+  		(pin passive line
+  			(at 0 -3.81 90)
+  			(length 1.27)
+  			(name "~" (effects (font (size 1.27 1.27))))
+  			(number "2" (effects (font (size 1.27 1.27))))
+  		)
+  	)
+  )
+  
+  '''
+# ---
+# name: test_resistor_snapshot
+  '''
+  (symbol "RES-10K"
+  	(pin_numbers (hide yes))
+  	(pin_names (offset 0))
+  	(exclude_from_sim no)
+  	(in_bom yes)
+  	(on_board yes)
+  	(property "Reference" "R"
+  		(at 2.54 0 90)
+  		(effects (font (size 1.27 1.27)))
+  	)
+  	(property "Value" "10k"
+  		(at -2.54 0 90)
+  		(effects (font (size 1.27 1.27)))
+  	)
+  	(property "Footprint" "Resistor_SMD:R_0603_1608Metric"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "Datasheet" "~"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "Description" "10k resistor"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "ki_keywords" "resistor"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(symbol "RES-10K_0_1"
+  		(polyline
+  			(pts (xy 0 2.286) (xy 0 2.54))
+  			(stroke (width 0) (type default))
+  			(fill (type none))
+  		)
+  		(polyline
+  			(pts (xy 0 2.286) (xy 1.016 1.905) (xy 0 1.524) (xy -1.016 1.143) (xy 0 0.762))
+  			(stroke (width 0) (type default))
+  			(fill (type none))
+  		)
+  		(polyline
+  			(pts (xy 0 0.762) (xy 1.016 0.381) (xy 0 0) (xy -1.016 -0.381) (xy 0 -0.762))
+  			(stroke (width 0) (type default))
+  			(fill (type none))
+  		)
+  		(polyline
+  			(pts (xy 0 -0.762) (xy 1.016 -1.143) (xy 0 -1.524) (xy -1.016 -1.905) (xy 0 -2.286))
+  			(stroke (width 0) (type default))
+  			(fill (type none))
+  		)
+  		(polyline
+  			(pts (xy 0 -2.286) (xy 0 -2.54))
+  			(stroke (width 0) (type default))
+  			(fill (type none))
+  		)
+  	)
+  	(symbol "RES-10K_1_1"
+  		(pin passive line
+  			(at 0 3.81 270)
+  			(length 1.27)
+  			(name "~" (effects (font (size 1.27 1.27))))
+  			(number "1" (effects (font (size 1.27 1.27))))
+  		)
+  		(pin passive line
+  			(at 0 -3.81 90)
+  			(length 1.27)
+  			(name "~" (effects (font (size 1.27 1.27))))
+  			(number "2" (effects (font (size 1.27 1.27))))
+  		)
+  	)
+  )
+  
+  '''
+# ---
+# name: test_stub_snapshot
+  '''
+  (symbol "IC-STM32"
+  	(exclude_from_sim no)
+  	(in_bom yes)
+  	(on_board yes)
+  	(property "Reference" "U"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "Value" "STM32"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "Footprint" "Resistor_SMD:R_0603_1608Metric"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "Datasheet" "~"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "Description" "10k resistor"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  	(property "ki_keywords" "resistor"
+  		(at 0 0 0)
+  		(effects (font (size 1.27 1.27)) (hide yes))
+  	)
+  )
+  
+  '''
+# ---

--- a/tests/kicad/test_integration.py
+++ b/tests/kicad/test_integration.py
@@ -1,0 +1,81 @@
+"""End-to-end integration test for the kist.kicad public API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kist.kicad import (
+    SymbolLibrary,
+    build_properties,
+    library_filename,
+    symbol_for_part,
+    symbol_reference,
+)
+from kist.models import JellybeanPart, ProprietaryPart, SemiJellybeanPart
+from kist.sexpr import find_all
+
+
+def test_full_workflow(
+    tmp_path: Path,
+    jellybean_part: JellybeanPart,
+    proprietary_part: ProprietaryPart,
+    semi_jellybean_part: SemiJellybeanPart,
+):
+    """Create library, add symbols from fixtures, save, reload, verify."""
+    lib = SymbolLibrary.empty()
+
+    parts = [jellybean_part, proprietary_part, semi_jellybean_part]
+    for part in parts:
+        sym = symbol_for_part(part)
+        lib.set_symbol(part.name, sym)
+
+    # All symbols present before save
+    assert lib.symbols() == [p.name for p in parts]
+
+    # Save and reload
+    out = tmp_path / "test.kicad_sym"
+    lib.save(out)
+    reloaded = SymbolLibrary.load(out)
+
+    # All symbols survived round-trip
+    assert reloaded.symbols() == [p.name for p in parts]
+
+    # Properties correct on each symbol
+    for part in parts:
+        sym = reloaded.get_symbol(part.name)
+        assert sym is not None
+
+        props = build_properties(part)
+        for child in sym:
+            if (
+                isinstance(child, list)
+                and child
+                and child[0] == "property"
+                and len(child) > 2
+                and child[1] == "Value"
+            ):
+                assert child[2] == props["Value"]
+                break
+
+    # Jellybean resistor has graphic sub-symbols with pins
+    r_sym = reloaded.get_symbol(jellybean_part.name)
+    assert r_sym is not None
+    pin_count = sum(
+        len(find_all(subsym, "pin")) for subsym in find_all(r_sym, "symbol")
+    )
+    assert pin_count == 2
+
+    # Proprietary IC is a stub -- no pins
+    ic_sym = reloaded.get_symbol(proprietary_part.name)
+    assert ic_sym is not None
+    ic_pin_count = sum(
+        len(find_all(subsym, "pin")) for subsym in find_all(ic_sym, "symbol")
+    )
+    assert ic_pin_count == 0
+
+    # symbol_reference produces correct lib:name strings
+    for part in parts:
+        ref = symbol_reference(part.category, part.name)
+        filename = library_filename(part.category)
+        assert ref.startswith(filename.removesuffix(".kicad_sym"))
+        assert ref.endswith(f":{part.name}")

--- a/tests/kicad/test_mapping.py
+++ b/tests/kicad/test_mapping.py
@@ -1,0 +1,27 @@
+"""Tests for category-to-library mapping."""
+
+from __future__ import annotations
+
+from kist.kicad.mapping import CATEGORY_LIBRARY, library_filename, symbol_reference
+from kist.models import Category
+
+
+def test_category_library_covers_all_categories():
+    """Every Category member has a mapping entry."""
+    assert set(CATEGORY_LIBRARY.keys()) == set(Category)
+
+
+def test_library_filename_returns_kicad_sym():
+    assert library_filename(Category.RES) == "00k-Resistors.kicad_sym"
+    assert library_filename(Category.IC) == "05k-ICs.kicad_sym"
+    assert library_filename(Category.MISC) == "15k-Misc.kicad_sym"
+
+
+def test_symbol_reference_format():
+    ref = symbol_reference(Category.RES, "RES-10K-1PCT-0603")
+    assert ref == "00k-Resistors:RES-10K-1PCT-0603"
+
+
+def test_symbol_reference_with_ic():
+    ref = symbol_reference(Category.IC, "IC-STM32F405RGT6-LQFP64")
+    assert ref == "05k-ICs:IC-STM32F405RGT6-LQFP64"

--- a/tests/kicad/test_symbols.py
+++ b/tests/kicad/test_symbols.py
@@ -1,0 +1,293 @@
+"""Tests for SymbolLibrary read/write and symbol manipulation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kist.kicad.symbols import SymbolLibrary
+from kist.sexpr import Atom, dumps, find_one
+
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "kicad"
+DEVICE_RCL = FIXTURES / "Device_RCL.kicad_sym"
+
+
+# -- load ---
+
+
+def test_load_device_rcl_symbols():
+    lib = SymbolLibrary.load(DEVICE_RCL)
+    names = lib.symbols()
+    assert names == ["C", "L", "R"]
+
+
+def test_load_rejects_wrong_tag(tmp_path):
+    bad = tmp_path / "bad.kicad_sym"
+    bad.write_text('(footprint "test")\n')
+    with pytest.raises(Exception, match="kicad_symbol_lib"):
+        SymbolLibrary.load(bad)
+
+
+# -- save / round-trip ---
+
+
+def test_load_save_reload_structural_equality(tmp_path):
+    lib = SymbolLibrary.load(DEVICE_RCL)
+    out = tmp_path / "out.kicad_sym"
+    lib.save(out)
+
+    reloaded = SymbolLibrary.load(out)
+    assert reloaded.symbols() == lib.symbols()
+
+    # Structural equality: same sexpr tree after round-trip
+    for name in lib.symbols():
+        orig_sym = lib.get_symbol(name)
+        reload_sym = reloaded.get_symbol(name)
+        assert orig_sym is not None
+        assert reload_sym is not None
+        assert dumps(reload_sym) == dumps(orig_sym)
+
+
+# -- empty ---
+
+
+def test_empty_round_trip(tmp_path):
+    lib = SymbolLibrary.empty()
+    assert lib.symbols() == []
+
+    out = tmp_path / "empty.kicad_sym"
+    lib.save(out)
+
+    reloaded = SymbolLibrary.load(out)
+    assert reloaded.symbols() == []
+
+
+def test_empty_has_generator_metadata():
+    lib = SymbolLibrary.empty()
+    tree = lib._tree
+    gen = find_one(tree, "generator")
+    assert gen is not None
+    assert gen[1] == "kist"
+
+
+# -- set_symbol / get_symbol ---
+
+
+def test_set_get_round_trip():
+    lib = SymbolLibrary.empty()
+    sym = [
+        Atom("symbol"),
+        Atom("MY_PART", quoted=True),
+        [Atom("in_bom"), Atom("yes")],
+    ]
+    lib.set_symbol("MY_PART", sym)
+
+    got = lib.get_symbol("MY_PART")
+    assert got is not None
+    assert got[1] == "MY_PART"
+    assert lib.symbols() == ["MY_PART"]
+
+
+def test_set_symbol_replaces_existing():
+    lib = SymbolLibrary.empty()
+    sym_v1 = [
+        Atom("symbol"),
+        Atom("X", quoted=True),
+        [Atom("in_bom"), Atom("yes")],
+    ]
+    sym_v2 = [
+        Atom("symbol"),
+        Atom("X", quoted=True),
+        [Atom("in_bom"), Atom("no")],
+    ]
+    lib.set_symbol("X", sym_v1)
+    lib.set_symbol("X", sym_v2)
+
+    assert lib.symbols() == ["X"]
+    got = lib.get_symbol("X")
+    assert got is not None
+    bom = find_one(got, "in_bom")
+    assert bom is not None
+    assert bom[1] == "no"
+
+
+def test_get_symbol_returns_none_for_missing():
+    lib = SymbolLibrary.empty()
+    assert lib.get_symbol("NOPE") is None
+
+
+# -- remove_symbol ---
+
+
+def test_remove_symbol_returns_true_and_removes():
+    lib = SymbolLibrary.load(DEVICE_RCL)
+    assert "R" in lib.symbols()
+    assert lib.remove_symbol("R") is True
+    assert "R" not in lib.symbols()
+
+
+def test_remove_symbol_returns_false_for_missing():
+    lib = SymbolLibrary.empty()
+    assert lib.remove_symbol("NOPE") is False
+
+
+# -- update_properties ---
+
+
+def test_update_properties_patches_existing_value():
+    lib = SymbolLibrary.load(DEVICE_RCL)
+    lib.update_properties("R", {"Value": "10k"})
+
+    sym = lib.get_symbol("R")
+    assert sym is not None
+    # Find the Value property
+    for child in sym:
+        if (
+            isinstance(child, list)
+            and child
+            and child[0] == "property"
+            and len(child) > 2
+            and child[1] == "Value"
+        ):
+            assert child[2] == "10k"
+            # (at ...) and (effects ...) should still be present
+            subtags = [c[0] for c in child if isinstance(c, list) and c]
+            assert "at" in subtags
+            assert "effects" in subtags
+            break
+    else:
+        pytest.fail("Value property not found")
+
+
+def test_update_properties_adds_new_property():
+    lib = SymbolLibrary.load(DEVICE_RCL)
+    lib.update_properties("R", {"MPN": "RC0603FR-0710KL"})
+
+    sym = lib.get_symbol("R")
+    assert sym is not None
+    for child in sym:
+        if (
+            isinstance(child, list)
+            and child
+            and child[0] == "property"
+            and len(child) > 2
+            and child[1] == "MPN"
+        ):
+            assert child[2] == "RC0603FR-0710KL"
+            break
+    else:
+        pytest.fail("MPN property not found after update_properties")
+
+
+# -- Round-trip patching (clean diff verification) ---
+
+
+def test_patch_value_only_changes_one_line(tmp_path):
+    """Load, patch a single property, save -- only the patched value differs."""
+    original = SymbolLibrary.load(DEVICE_RCL)
+    patched = SymbolLibrary.load(DEVICE_RCL)
+    patched.update_properties("R", {"Value": "10k"})
+
+    orig_out = tmp_path / "original.kicad_sym"
+    patch_out = tmp_path / "patched.kicad_sym"
+    original.save(orig_out)
+    patched.save(patch_out)
+
+    orig_lines = orig_out.read_text().splitlines()
+    patch_lines = patch_out.read_text().splitlines()
+
+    # Same number of lines -- structure unchanged
+    assert len(orig_lines) == len(patch_lines)
+
+    # Exactly one line differs
+    diffs = [
+        (i, o, p)
+        for i, (o, p) in enumerate(zip(orig_lines, patch_lines, strict=True))
+        if o != p
+    ]
+    assert len(diffs) == 1
+    idx, old_line, new_line = diffs[0]
+    assert '"R"' in old_line
+    assert '"10k"' in new_line
+
+
+def test_patch_preserves_unrelated_symbols(tmp_path):
+    """Patching one symbol doesn't alter the serialised form of others."""
+    original = SymbolLibrary.load(DEVICE_RCL)
+    patched = SymbolLibrary.load(DEVICE_RCL)
+    patched.update_properties("R", {"Value": "10k", "Description": "10k resistor"})
+
+    for name in ["C", "L"]:
+        orig_sym = original.get_symbol(name)
+        patch_sym = patched.get_symbol(name)
+        assert orig_sym is not None
+        assert patch_sym is not None
+        assert dumps(orig_sym) == dumps(patch_sym)
+
+
+def test_patch_round_trips_through_file(tmp_path):
+    """Patch, save, reload -- patched value persists, structure intact."""
+    lib = SymbolLibrary.load(DEVICE_RCL)
+    lib.update_properties("R", {"Value": "4.7k"})
+
+    out = tmp_path / "patched.kicad_sym"
+    lib.save(out)
+    reloaded = SymbolLibrary.load(out)
+
+    # Patched value persists
+    sym = reloaded.get_symbol("R")
+    assert sym is not None
+    for child in sym:
+        if (
+            isinstance(child, list)
+            and child
+            and child[0] == "property"
+            and len(child) > 2
+            and child[1] == "Value"
+        ):
+            assert child[2] == "4.7k"
+            break
+    else:
+        pytest.fail("Value property not found after reload")
+
+    # All symbols still present
+    assert reloaded.symbols() == ["C", "L", "R"]
+
+    # Save again -- output is byte-identical (stable serialisation)
+    out2 = tmp_path / "patched2.kicad_sym"
+    reloaded.save(out2)
+    assert out.read_text() == out2.read_text()
+
+
+def test_update_properties_raises_for_missing_symbol():
+    lib = SymbolLibrary.empty()
+    with pytest.raises(KeyError, match="NOPE"):
+        lib.update_properties("NOPE", {"Value": "x"})
+
+
+# -- Snapshot ---
+
+
+def test_empty_with_symbol_snapshot(snapshot):
+    lib = SymbolLibrary.empty()
+    sym = [
+        Atom("symbol"),
+        Atom("TEST-PART", quoted=True),
+        [Atom("in_bom"), Atom("yes")],
+        [Atom("on_board"), Atom("yes")],
+        [
+            Atom("property"),
+            Atom("Reference", quoted=True),
+            Atom("R", quoted=True),
+            [Atom("at"), Atom("0"), Atom("0"), Atom("0")],
+        ],
+        [
+            Atom("property"),
+            Atom("Value", quoted=True),
+            Atom("10k", quoted=True),
+            [Atom("at"), Atom("0"), Atom("0"), Atom("0")],
+        ],
+    ]
+    lib.set_symbol("TEST-PART", sym)
+    assert dumps(lib._tree) == snapshot

--- a/tests/kicad/test_templates.py
+++ b/tests/kicad/test_templates.py
@@ -1,0 +1,162 @@
+"""Tests for KiCad symbol templates."""
+
+from __future__ import annotations
+
+import pytest
+
+from kist.kicad.templates import (
+    build_properties,
+    capacitor_symbol,
+    inductor_symbol,
+    resistor_symbol,
+    stub_symbol,
+    symbol_for_part,
+)
+from kist.models import JellybeanPart, ProprietaryPart
+from kist.sexpr import dumps, find_all, parse_one
+
+# -- Helpers ---
+
+
+def _count_pins(sym: list) -> int:
+    """Count pin nodes across all sub-symbols."""
+    total = 0
+    for subsym in find_all(sym, "symbol"):
+        total += len(find_all(subsym, "pin"))
+    return total
+
+
+def _pin_types(sym: list) -> set[str]:
+    """Collect pin electrical types from all sub-symbols."""
+    types: set[str] = set()
+    for subsym in find_all(sym, "symbol"):
+        for pin in find_all(subsym, "pin"):
+            if len(pin) > 1:
+                types.add(str(pin[1]))
+    return types
+
+
+SAMPLE_PROPS = {
+    "Reference": "R",
+    "Value": "10k",
+    "Footprint": "Resistor_SMD:R_0603_1608Metric",
+    "Datasheet": "~",
+    "Description": "10k resistor",
+    "ki_keywords": "resistor",
+}
+
+
+# -- Round-trip (parseable output) ---
+
+
+@pytest.mark.parametrize(
+    "factory,name",
+    [
+        (resistor_symbol, "R-TEST"),
+        (capacitor_symbol, "C-TEST"),
+        (inductor_symbol, "L-TEST"),
+        (stub_symbol, "U-TEST"),
+    ],
+)
+def test_template_round_trips(factory, name):
+    """Every template produces output that parses back identically."""
+    sym = factory(name, SAMPLE_PROPS)
+    text = dumps(sym)
+    reparsed = parse_one(text)
+    assert dumps(reparsed) == text
+
+
+# -- Pin counts and types ---
+
+
+def test_resistor_has_two_passive_pins():
+    sym = resistor_symbol("R1", SAMPLE_PROPS)
+    assert _count_pins(sym) == 2
+    assert _pin_types(sym) == {"passive"}
+
+
+def test_capacitor_has_two_passive_pins():
+    sym = capacitor_symbol("C1", SAMPLE_PROPS)
+    assert _count_pins(sym) == 2
+    assert _pin_types(sym) == {"passive"}
+
+
+def test_inductor_has_two_passive_pins():
+    sym = inductor_symbol("L1", SAMPLE_PROPS)
+    assert _count_pins(sym) == 2
+    assert _pin_types(sym) == {"passive"}
+
+
+def test_stub_has_no_pins():
+    sym = stub_symbol("U1", SAMPLE_PROPS)
+    assert _count_pins(sym) == 0
+
+
+# -- build_properties ---
+
+
+def test_build_properties_jellybean(jellybean_part: JellybeanPart):
+    props = build_properties(jellybean_part)
+    assert props["Reference"] == "R"
+    assert props["Value"] == "10k"
+    assert props["Footprint"] == "Resistor_SMD:R_0603_1608Metric"
+    assert props["Datasheet"] == "~"  # no datasheet URL on fixture
+    assert props["Description"] == "10kΩ 1% 0603 thick film resistor"
+    assert "basic" in props["ki_keywords"]
+
+
+def test_build_properties_proprietary(proprietary_part: ProprietaryPart):
+    props = build_properties(proprietary_part)
+    assert props["Reference"] == "U"
+    assert props["Value"] == "STM32F405RGT6"
+    assert "arm" in props["ki_keywords"]
+    assert "cortex-m4" in props["ki_keywords"]
+
+
+def test_build_properties_semi_jellybean(semi_jellybean_part):
+    props = build_properties(semi_jellybean_part)
+    assert props["Reference"] == "U"
+    assert props["Value"] == "TL072"
+
+
+# -- symbol_for_part dispatch ---
+
+
+def test_symbol_for_part_resistor(jellybean_part: JellybeanPart):
+    sym = symbol_for_part(jellybean_part)
+    # Jellybean resistor gets full graphic template
+    assert _count_pins(sym) == 2
+    assert sym[1] == jellybean_part.name
+
+
+def test_symbol_for_part_ic(proprietary_part: ProprietaryPart):
+    sym = symbol_for_part(proprietary_part)
+    # IC gets a stub -- no pins
+    assert _count_pins(sym) == 0
+    assert sym[1] == proprietary_part.name
+
+
+# -- Snapshot tests ---
+
+
+def test_resistor_snapshot(snapshot):
+    sym = resistor_symbol("RES-10K", SAMPLE_PROPS)
+    assert dumps(sym) == snapshot
+
+
+def test_capacitor_snapshot(snapshot):
+    props = {**SAMPLE_PROPS, "Reference": "C", "Value": "100n"}
+    sym = capacitor_symbol("CAP-100N", props)
+    assert dumps(sym) == snapshot
+
+
+def test_inductor_snapshot(snapshot):
+    props = {**SAMPLE_PROPS, "Reference": "L", "Value": "10u"}
+    sym = inductor_symbol("IND-10U", props)
+    assert dumps(sym) == snapshot
+
+
+def test_stub_snapshot(snapshot):
+    props = {**SAMPLE_PROPS, "Reference": "U", "Value": "STM32"}
+    sym = stub_symbol("IC-STM32", props)
+    assert dumps(sym) == snapshot


### PR DESCRIPTION
## Summary

Adds the KiCad file-handling layer that `kist add` and `kist sync`
will build on. Kist can now read, write, and patch `.kicad_sym` files
with round-trip fidelity, generate schematic symbols for jellybean
passives, and map part categories to numbered library files.

## Changes

- S-expression parser/writer with round-trip quoting fidelity
- `SymbolLibrary` class for loading, saving, and mutating `.kicad_sym`
  files (symbol CRUD, in-place property patching)
- Symbol templates for R (US zigzag), C, L with graphics copied from
  KiCad 9.0 Device library; IEC rectangle resistor kept as alternative;
  stub template for non-passive parts
- Category-to-library mapping (ADR-002 §4) with `NNk-Name` convention
- Public API re-exported from `kist.kicad`

## Test plan

- `pytest tests/test_sexpr.py tests/kicad/ -v` -- 39 kicad + 90 sexpr
  tests pass
- Round-trip patching tests verify single-value patches produce
  minimal diffs (same line count, one line changed)
- Syrupy snapshots pin writer and template output
- `ruff check`, `ruff format --check`, `ty check` clean