### PR TITLE
CLI commands and sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ parts.db
 *.sqlite3
 .direnv/
 result
+tmp/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# Install: prek install
+# Run all: prek run --all-files
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.0
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty type check
+        entry: ty check
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
         # Tools
         jq
         just
+        prek
       ];
 
       shellHook = ''

--- a/src/kist/cli/app.py
+++ b/src/kist/cli/app.py
@@ -92,6 +92,91 @@ def add() -> None:
 
 
 @app.command()
-def search() -> None:
+def search(
+    query: str = typer.Argument(help="Search term."),
+) -> None:
     """Search for parts in the library."""
-    typer.echo("Not yet implemented.")
+    from rich.console import Console
+    from rich.table import Table
+
+    from kist.core.database import PartsDatabase
+    from kist.core.library import find_library
+    from kist.errors import LibraryNotFoundError
+
+    try:
+        library_root = find_library()
+    except LibraryNotFoundError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from None
+
+    db = PartsDatabase(library_root / "parts.json")
+    db.load()
+    results = db.search(query)
+
+    if not results:
+        typer.echo("No parts found.")
+        raise typer.Exit()
+
+    table = Table(show_header=True)
+    table.add_column("Name")
+    table.add_column("Tier")
+    table.add_column("Category")
+    table.add_column("Description")
+
+    for part in results:
+        table.add_row(part.name, part.tier, part.category, part.description)
+
+    Console().print(table)
+
+
+@app.command()
+def check() -> None:
+    """Validate part names and check for duplicates."""
+    from collections import defaultdict
+
+    from kist.core.database import PartsDatabase
+    from kist.core.library import find_library
+    from kist.core.naming import generate_name, get_identity
+    from kist.errors import LibraryNotFoundError
+
+    try:
+        library_root = find_library()
+    except LibraryNotFoundError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from None
+
+    db = PartsDatabase(library_root / "parts.json")
+    db.load()
+    parts = db.list_parts()
+
+    if not parts:
+        typer.echo("No parts to check.")
+        raise typer.Exit()
+
+    typer.echo(f"Checking {len(parts)} parts...")
+
+    issues = 0
+
+    # Check 1: name drift
+    for part in parts:
+        expected = generate_name(part)
+        if part.name != expected:
+            typer.echo(f'  Name mismatch: "{part.name}" should be "{expected}"')
+            issues += 1
+
+    # Check 2: identity duplicates
+    by_identity: dict[tuple[str, ...], list[str]] = defaultdict(list)
+    for part in parts:
+        by_identity[get_identity(part)].append(part.name)
+
+    for identity, names in by_identity.items():
+        if len(names) > 1:
+            joined = " and ".join(names)
+            typer.echo(f"  Duplicate identity: {joined} share {identity}")
+            issues += 1
+
+    if issues:
+        typer.echo(f"\n{issues} issue(s) found.")
+        raise typer.Exit(code=1)
+
+    typer.echo("All clean.")

--- a/src/kist/core/library.py
+++ b/src/kist/core/library.py
@@ -78,7 +78,7 @@ def link_library(target: Path, library: Path) -> Path:
     if ref_path.exists():
         raise LibraryExistsError(f"Already linked: {ref_path}")
 
-    rel_path = os.path.relpath(library, target)
+    rel_path = str(os.path.relpath(library, target))
     save_project_ref(ref_path, ProjectRef(library_path=rel_path))
 
     _create_lib_link(target / "lib", rel_path)

--- a/src/kist/core/sync.py
+++ b/src/kist/core/sync.py
@@ -1,0 +1,47 @@
+"""Sync parts database to KiCad symbol library files."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+from kist.core.database import PartsDatabase
+from kist.kicad.mapping import library_filename
+from kist.kicad.symbols import SymbolLibrary
+from kist.kicad.templates import symbol_for_part
+from kist.models import Category
+from kist.models.config import LibraryConfig
+
+
+def sync_symbols(
+    library_root: Path,
+    db: PartsDatabase,
+    config: LibraryConfig,
+) -> None:
+    """
+    Push part metadata from the PartsDatabase to .kicad_sym files.
+
+    Groups parts by category. For each category with parts, loads or
+    creates a SymbolLibrary, generates symbols via symbol_for_part(),
+    and saves. Idempotent.
+    """
+    symbols_dir = library_root / config.symbols_dir
+    symbols_dir.mkdir(parents=True, exist_ok=True)
+
+    # Group parts by category
+    by_category: dict[Category, list] = defaultdict(list)
+    for part in db.list_parts():
+        by_category[part.category].append(part)
+
+    for category, parts in by_category.items():
+        path = symbols_dir / library_filename(category)
+
+        if path.exists():
+            lib = SymbolLibrary.load(path)
+        else:
+            lib = SymbolLibrary.empty()
+
+        for part in parts:
+            lib.set_symbol(part.name, symbol_for_part(part))
+
+        lib.save(path)

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -1,0 +1,93 @@
+"""CLI tests for the check command."""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from kist.cli.app import app
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(tmp_path / "config"))
+
+
+def _init_library_with_parts(tmp_path, monkeypatch, parts: list[dict]):
+    """Initialise a library and inject parts."""
+    runner.invoke(app, ["init", "--path", str(tmp_path)])
+    monkeypatch.chdir(tmp_path)
+
+    parts_path = tmp_path / "parts.json"
+    data = json.loads(parts_path.read_text())
+    for i, part in enumerate(parts):
+        data["parts"][f"id-{i}"] = part
+    parts_path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+# --- check: all clean ---
+
+
+def test_check_all_clean(tmp_path, monkeypatch, jellybean_part):
+    _init_library_with_parts(
+        tmp_path,
+        monkeypatch,
+        [
+            jellybean_part.model_dump(mode="json", exclude_none=True),
+        ],
+    )
+    result = runner.invoke(app, ["check"])
+    assert result.exit_code == 0
+    assert "All clean" in result.output
+
+
+def test_check_empty_database(tmp_path, monkeypatch):
+    runner.invoke(app, ["init", "--path", str(tmp_path)])
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["check"])
+    assert result.exit_code == 0
+    assert "No parts to check" in result.output
+
+
+# --- check: name mismatch ---
+
+
+def test_check_name_mismatch(tmp_path, monkeypatch, jellybean_part):
+    part_data = jellybean_part.model_dump(mode="json", exclude_none=True)
+    part_data["name"] = "WRONG-NAME"
+
+    _init_library_with_parts(tmp_path, monkeypatch, [part_data])
+
+    result = runner.invoke(app, ["check"])
+    assert result.exit_code == 1
+    assert "Name mismatch" in result.output
+    assert "WRONG-NAME" in result.output
+
+
+# --- check: duplicate identity ---
+
+
+def test_check_duplicate_identity(tmp_path, monkeypatch, jellybean_part):
+    part_a = jellybean_part.model_dump(mode="json", exclude_none=True)
+    part_b = jellybean_part.model_dump(mode="json", exclude_none=True)
+    # Same specs but different names -- identity collision
+    part_b["name"] = "RES-10K-1PCT-0603-COPY"
+
+    _init_library_with_parts(tmp_path, monkeypatch, [part_a, part_b])
+
+    result = runner.invoke(app, ["check"])
+    assert result.exit_code == 1
+    assert "Duplicate identity" in result.output
+
+
+# --- check: library not found ---
+
+
+def test_check_library_not_found(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["check"])
+    assert result.exit_code == 1
+    assert "Not a kist library" in result.output

--- a/tests/cli/test_search.py
+++ b/tests/cli/test_search.py
@@ -1,0 +1,65 @@
+"""CLI tests for the search command."""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from kist.cli.app import app
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(tmp_path / "config"))
+
+
+@pytest.fixture
+def library(tmp_path, monkeypatch, jellybean_part, proprietary_part):
+    """Initialise a library with two parts and chdir into it."""
+    runner.invoke(app, ["init", "--path", str(tmp_path)])
+    monkeypatch.chdir(tmp_path)
+
+    # Inject parts directly into parts.json
+    parts_path = tmp_path / "parts.json"
+    data = json.loads(parts_path.read_text())
+    data["parts"]["id-1"] = jellybean_part.model_dump(mode="json", exclude_none=True)
+    data["parts"]["id-2"] = proprietary_part.model_dump(mode="json", exclude_none=True)
+    parts_path.write_text(json.dumps(data, indent=2) + "\n")
+
+    return tmp_path
+
+
+# --- search ---
+
+
+def test_search_with_matches(library):
+    result = runner.invoke(app, ["search", "10k"])
+    assert result.exit_code == 0
+    assert "RES-10K-1PCT-0603" in result.output
+
+
+def test_search_no_matches(library):
+    result = runner.invoke(app, ["search", "nonexistent-xyz"])
+    assert result.exit_code == 0
+    assert "No parts found" in result.output
+
+
+def test_search_by_description(library):
+    result = runner.invoke(app, ["search", "thick film"])
+    assert result.exit_code == 0
+    assert "RES-10K-1PCT-0603" in result.output
+
+
+def test_search_by_mpn(library):
+    result = runner.invoke(app, ["search", "STM32F405"])
+    assert result.exit_code == 0
+    assert "IC-STM32F405RGT6-LQFP64" in result.output
+
+
+def test_search_library_not_found(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["search", "anything"])
+    assert result.exit_code == 1
+    assert "Not a kist library" in result.output

--- a/tests/core/test_sync.py
+++ b/tests/core/test_sync.py
@@ -1,0 +1,209 @@
+"""Tests for syncing parts database to .kicad_sym files."""
+
+from pathlib import Path
+
+import pytest
+
+from kist.core.database import PartsDatabase, create_empty
+from kist.core.sync import sync_symbols
+from kist.kicad.mapping import library_filename
+from kist.kicad.symbols import SymbolLibrary
+from kist.models import (
+    Category,
+    JellybeanPart,
+    LibraryConfig,
+    Mounting,
+    ProprietaryPart,
+    RefDes,
+    Tier,
+)
+
+# --- fixtures and factories ---
+
+
+@pytest.fixture
+def library(tmp_path: Path) -> tuple[Path, PartsDatabase, LibraryConfig]:
+    """A minimal library directory with empty database and default config."""
+    root = tmp_path / "lib"
+    root.mkdir()
+    (root / "symbols").mkdir()
+    db_path = root / "parts.json"
+    create_empty(db_path)
+    db = PartsDatabase(db_path)
+    db.load()
+    config = LibraryConfig()
+    return root, db, config
+
+
+def _make_resistor(resistance: str, tolerance: str, package: str) -> JellybeanPart:
+    name = f"RES-TEST-{package}"
+    return JellybeanPart(
+        name=name,
+        tier=Tier.JELLYBEAN,
+        description=f"{resistance} {tolerance} {package} resistor",
+        category=Category.RES,
+        package=package,
+        mounting=Mounting.SMD,
+        symbol=f"00k-Resistors:{name}",
+        footprint=f"Resistor_SMD:R_{package}",
+        value="10k",
+        reference=RefDes.R,
+        specifications={"resistance": resistance, "tolerance": tolerance},
+    )
+
+
+def _make_capacitor(capacitance: str, voltage: str, package: str) -> JellybeanPart:
+    name = f"CAP-TEST-{package}"
+    return JellybeanPart(
+        name=name,
+        tier=Tier.JELLYBEAN,
+        description=f"{capacitance} {voltage} {package} capacitor",
+        category=Category.CAP,
+        package=package,
+        mounting=Mounting.SMD,
+        symbol=f"01k-Capacitors:{name}",
+        footprint=f"Capacitor_SMD:C_{package}",
+        value="100n",
+        reference=RefDes.C,
+        specifications={"capacitance": capacitance, "voltage_rating": voltage},
+    )
+
+
+# --- sync_symbols ---
+
+
+def test_empty_database_produces_no_files(library):
+    root, db, config = library
+    sync_symbols(root, db, config)
+    sym_dir = root / "symbols"
+    assert list(sym_dir.glob("*.kicad_sym")) == []
+
+
+def test_one_resistor_creates_symbol_file(library):
+    root, db, config = library
+    part = _make_resistor("10kΩ", "1%", "0603")
+    db.add(part)
+
+    sync_symbols(root, db, config)
+
+    path = root / "symbols" / library_filename(Category.RES)
+    assert path.exists()
+    lib = SymbolLibrary.load(path)
+    assert part.name in lib.symbols()
+
+
+def test_multiple_categories_create_multiple_files(library):
+    root, db, config = library
+    res = _make_resistor("10kΩ", "1%", "0603")
+    cap = _make_capacitor("100nF", "50V", "0402")
+    db.add(res)
+    db.add(cap)
+
+    sync_symbols(root, db, config)
+
+    res_path = root / "symbols" / library_filename(Category.RES)
+    cap_path = root / "symbols" / library_filename(Category.CAP)
+    assert res_path.exists()
+    assert cap_path.exists()
+
+    res_lib = SymbolLibrary.load(res_path)
+    assert res.name in res_lib.symbols()
+
+    cap_lib = SymbolLibrary.load(cap_path)
+    assert cap.name in cap_lib.symbols()
+
+
+# --- idempotency and updates ---
+
+
+def test_sync_is_idempotent(library):
+    root, db, config = library
+    part = _make_resistor("4.7kΩ", "5%", "0805")
+    db.add(part)
+
+    sync_symbols(root, db, config)
+    path = root / "symbols" / library_filename(Category.RES)
+    first_content = path.read_text()
+
+    sync_symbols(root, db, config)
+    second_content = path.read_text()
+
+    assert first_content == second_content
+
+
+def test_updated_part_reflected_after_resync(library):
+    root, db, config = library
+    part = _make_resistor("10kΩ", "1%", "0603")
+    ipn = db.add(part)
+
+    sync_symbols(root, db, config)
+
+    # Update description by replacing the part
+    updated = part.model_copy(update={"description": "Updated description"})
+    db._parts[ipn] = updated
+    db.save()
+
+    sync_symbols(root, db, config)
+
+    path = root / "symbols" / library_filename(Category.RES)
+    lib = SymbolLibrary.load(path)
+    sym = lib.get_symbol(part.name)
+    assert sym is not None
+    # Check the Description property was updated
+    for child in sym:
+        if (
+            isinstance(child, list)
+            and child
+            and child[0] == "property"
+            and len(child) > 2
+            and child[1] == "Description"
+        ):
+            assert child[2] == "Updated description"
+            break
+
+
+# --- edge cases ---
+
+
+def test_proprietary_part_creates_stub_symbol(library):
+    root, db, config = library
+    part = ProprietaryPart(
+        name="IC-STM32F405-LQFP64",
+        tier=Tier.PROPRIETARY,
+        description="ARM Cortex-M4 MCU",
+        category=Category.IC,
+        package="LQFP-64",
+        mpn="STM32F405RGT6",
+        manufacturer="STMicroelectronics",
+        symbol="05k-ICs:IC-STM32F405-LQFP64",
+        footprint="Package_QFP:LQFP-64_10x10mm_P0.5mm",
+        value="STM32F405RGT6",
+        reference=RefDes.U,
+    )
+    db.add(part)
+
+    sync_symbols(root, db, config)
+
+    path = root / "symbols" / library_filename(Category.IC)
+    assert path.exists()
+    lib = SymbolLibrary.load(path)
+    assert part.name in lib.symbols()
+
+
+def test_creates_symbols_dir_if_missing(tmp_path):
+    root = tmp_path / "lib"
+    root.mkdir()
+    # No symbols/ dir created
+    db_path = root / "parts.json"
+    create_empty(db_path)
+    db = PartsDatabase(db_path)
+    db.load()
+    config = LibraryConfig()
+
+    part = _make_resistor("1kΩ", "5%", "0402")
+    db.add(part)
+
+    sync_symbols(root, db, config)
+
+    path = root / "symbols" / library_filename(Category.RES)
+    assert path.exists()


### PR DESCRIPTION
## Summary

Add the sync layer and non-interactive CLI commands (`search`, `check`).

## Changes

- `core/sync.py` -- `sync_symbols()` pushes part metadata from the database to `.kicad_sym` files, one per category, idempotent
- `cli: search` -- substring search across parts with Rich table output
- `cli: check` -- validates name drift and identity duplicates

## Test plan

- `pytest tests/core/test_sync.py` -- 7 tests (empty db, single/multi-category, idempotency, updates, stub symbols, missing dir creation)
- `pytest tests/cli/test_search.py` -- 5 tests (matches, no matches, by description, by MPN, library not found)
- `pytest tests/cli/test_check.py` -- 5 tests (all clean, empty db, name mismatch, duplicate identity, library not found)

## Notes

Interactive `add` command shelved -- the real entry path is `kist add <url>` via DigiKey API, not manual prompts. That depends on ADR-004 (configurable categories) landing first.