### PR TITLE
Add TUI app shell with screens, header, and CLI wiring

### DIFF
--- a/docs/adr/005-tui-state-management.md
+++ b/docs/adr/005-tui-state-management.md
@@ -1,0 +1,327 @@
+# ADR-005: TUI State Management
+
+**Status**: Draft
+**Date**: 2026-02-14
+
+## Context
+
+The TUI has grown to include browse, add, edit/delete, settings, and
+category management screens. As screens were added, a problematic
+pattern emerged: screens reach into the app instance to get
+`library_path`, then independently load config and create database
+instances to perform I/O.
+
+```python
+# This pattern appears 6+ times across screens/modals
+app: KistApp = self.app  # type: ignore[assignment]
+library_path = app.library_path
+config = load_library_config(library_path)
+db = PartsDatabase(library_path / "parts.json")
+db.load()
+db.add(part)
+```
+
+### Problems
+
+1. **Tight coupling** -- screens depend on the concrete `KistApp` class
+   and require a `# type: ignore` cast to access `library_path`.
+
+2. **Scattered I/O** -- database and config operations are duplicated
+   across AddScreen, DetailModal, BrowseScreen, SettingsModal, and
+   CategoryManagerModal. Each screen independently loads config and
+   creates database instances.
+
+3. **No single owner** -- there is no clear boundary between
+   "presentation" and "persistence". Screens handle form validation,
+   part construction, database saving, and user notification all in
+   one method.
+
+4. **Config reloaded unnecessarily** -- library config is loaded from
+   disk on every save/edit/delete operation, even though it rarely
+   changes during a session. When it does change (settings modal),
+   the app should know about it.
+
+### Upcoming requirements
+
+Two planned features make this refactor urgent rather than optional:
+
+- **Sync on save** -- every part mutation must regenerate
+  `.kicad_sym` files. This logic already exists in
+  `core.sync.sync_symbols()` and must not be duplicated across
+  screens.
+- **Git integration** -- part add/edit/delete should auto-commit.
+  This requires a single point where all mutations flow through,
+  so the commit message can describe the operation.
+
+Together these mean every part mutation triggers a pipeline (DB
+write, symbol sync, git commit, UI refresh) that must be owned by
+one component. If screens perform their own I/O, each screen would
+need to duplicate this pipeline.
+
+### Current state usage
+
+Every screen that does I/O follows the same three steps:
+
+1. Get `library_path` from app
+2. `load_library_config(library_path)` to get config
+3. `PartsDatabase(library_path / "parts.json").load()` to get database
+
+What screens actually need from this:
+
+- **AddScreen / DetailModal**: `config.categories` and
+  `config.separator` for `build_part_from_form()`, plus a way to
+  persist the result.
+- **BrowseScreen**: the list of parts (already uses a reactive watcher
+  on `library_path`).
+- **SettingsModal / CategoryManagerModal**: config read/write (these
+  are config editors, so direct config access makes sense).
+
+### Reference patterns
+
+Three Textual apps were surveyed:
+
+- **toad** -- screens use `getters.app(ToadApp)` for typed access and
+  call app methods directly (`self.app.settings.set()`,
+  `self.app.save_settings()`). App owns persistence. Uses
+  `data_bind()` to propagate reactive UI state from app to screens
+  to widgets. No messages for persistence.
+- **posting** -- modals return data via typed `dismiss()`, parent does
+  I/O. Settings accessed via a `ContextVar` (no prop drilling).
+  Models own their own `save_to_disk()` methods.
+- **Bagels** -- screens do I/O directly in callbacks via stateless
+  manager functions. Most coupled of the three.
+
+The toad pattern -- typed app getter, direct method calls,
+reactive propagation -- is the closest match for kist's needs.
+
+## Decision
+
+### 1. App owns config as reactive state
+
+`KistApp` loads library config once at startup and exposes it as a
+reactive attribute. Screens that need config (for form building,
+category lists, etc.) read it from the app rather than loading it
+themselves.
+
+```python
+class KistApp(App):
+    library_path: reactive[Path | None] = reactive(None)
+    library_config: reactive[LibraryConfig | None] = reactive(None)
+
+    def _discover_library(self) -> None:
+        result = find_library()
+        self.library_path = result.library_root
+        self.library_config = load_library_config(result.library_root)
+```
+
+When config changes (e.g. settings modal saves), the app reloads it
+and the reactive system propagates the update.
+
+### 2. Screens use typed app getter
+
+Screens declare a typed app getter using Textual's `getters.app()`
+instead of casting `self.app`:
+
+```python
+from textual import getters
+
+class AddScreen(Screen):
+    app = getters.app(KistApp)
+```
+
+This eliminates `# type: ignore` comments and provides proper type
+checking. Screens can access `self.app.library_config` directly for
+read-only config data like categories and separator.
+
+### 3. Persistence via app methods
+
+`KistApp` exposes methods for all part mutation operations. Screens
+call these directly via the typed `self.app` getter. Errors propagate
+via normal exceptions, so screens can handle them with try/except
+and retain control over their own UI flow (clearing forms, showing
+notifications).
+
+```python
+class KistApp(App):
+    parts_version: reactive[int] = reactive(0)
+
+    def save_part(self, part: Part, replacing: Ipn | None = None) -> None:
+        """Persist a part and run the post-mutation pipeline."""
+        db = PartsDatabase(self.library_path / "parts.json")
+        db.load()
+        if replacing:
+            db.remove(replacing)
+        db.add(part)
+        self._after_mutation()
+
+    def delete_part(self, ipn: Ipn) -> None:
+        """Remove a part and run the post-mutation pipeline."""
+        db = PartsDatabase(self.library_path / "parts.json")
+        db.load()
+        db.remove(ipn)
+        self._after_mutation()
+
+    def _after_mutation(self) -> None:
+        """Post-mutation side effects: sync, git, UI refresh."""
+        if self.library_config:
+            sync_symbols(self.library_path, ...)
+        # git_commit(self.library_path, description)  # future
+        self.parts_version += 1
+```
+
+Screens call these methods and handle errors locally:
+
+```python
+class AddScreen(Screen):
+    app = getters.app(KistApp)
+
+    def action_save(self) -> None:
+        config = self.app.library_config
+        part = build_part_from_form(d, config.categories, config.separator)
+        try:
+            self.app.save_part(part)
+        except DuplicatePartError:
+            self.notify(f"Already exists: {part.name}", severity="error")
+            return
+        self.notify(f"Saved: {part.name}")
+        form.clear()
+```
+
+A message-based approach was considered and rejected. Messages
+decouple the request from execution, but screens need synchronous
+feedback to control their own UI flow (clearing forms on success,
+showing specific error messages). Messages would require either
+response messages or callbacks to flow errors back, adding
+indirection without meaningful benefit. The toad reference app
+validates that direct method calls scale to applications more
+complex than kist.
+
+### 4. Mutation pipeline
+
+Every part mutation runs through `_after_mutation()`, which handles
+side effects that screens should not know about:
+
+- **Symbol sync** -- regenerate `.kicad_sym` files from the database.
+- **Git commit** -- stage and commit changed files (future).
+- **UI refresh** -- increment `parts_version` so watching screens
+  reload.
+
+This pipeline is the primary reason persistence must be centralised.
+Adding a new post-mutation step (e.g. operation logging) requires a
+change in one method, not in every screen.
+
+### 5. Screen responsibilities
+
+After this change, screens are responsible for:
+
+- **Composing UI** -- layout, widgets, bindings
+- **Form validation** -- checking required fields, calling
+  `build_part_from_form()` with config from app
+- **Calling app methods** -- `self.app.save_part()`,
+  `self.app.delete_part()`, `self.app.save_library_config()`
+- **Error handling** -- catching exceptions from app methods,
+  notifying the user
+- **Reacting to state changes** -- via reactive watchers
+
+Screens are NOT responsible for:
+
+- Loading config from disk
+- Creating or managing database instances
+- Knowing the library path (except for display purposes)
+- Sync, git, or any post-mutation side effects
+
+### 6. Config editors
+
+SettingsModal manages two separate configs:
+
+- **Global config** (theme) -- applied immediately via
+  `self.app.theme`, persisted to the user config directory. Theme
+  is the only global setting and is self-contained within the
+  modal; no reactive attribute needed.
+- **Library config** (prefix, separator, suppliers, directories) --
+  saved via an app method (`self.app.save_library_config(config)`)
+  so the app can update its reactive `library_config` and trigger
+  downstream effects.
+
+CategoryManagerModal modifies library config on each add/edit/delete.
+It should receive config as a constructor argument for initial
+display, rather than loading from disk in `on_mount`, and call the
+app method to persist changes.
+
+### 7. Database stays ephemeral
+
+`PartsDatabase` instances are cheap (JSON file, sync I/O). The app
+creates a fresh instance for each operation rather than holding a
+long-lived connection. This avoids stale state when `parts.json`
+is modified outside the TUI (by CLI commands or text editors).
+
+`BrowseScreen` holds an in-memory snapshot (`_all_parts`) that may
+diverge from disk if the CLI modifies `parts.json` externally. This
+is acceptable -- the TUI is the primary editing interface during a
+session, and external changes are picked up on next launch or when
+`parts_version` changes. File watching can be added later if needed.
+
+### 8. PartForm category source
+
+`PartForm` currently builds its category `Select` options from the
+hardcoded `WELL_KNOWN_CATEGORIES` constant rather than from library
+config. As part of this refactor, the form must be updated to accept
+categories as a parameter so it reflects the library's actual
+category definitions. This also means `PartForm` needs to refresh
+its options when `library_config` changes (e.g. after
+CategoryManagerModal saves).
+
+### 9. Async considerations
+
+Symbol sync and git operations may be slow for large libraries. If
+profiling shows `_after_mutation` blocks the UI, it can be converted
+to a Textual `@work` method. The direct method call pattern supports
+this -- `save_part` would become async and screens would `await` it,
+or the post-mutation pipeline alone would be offloaded to a worker
+while the screen receives its synchronous success/failure result
+immediately.
+
+## Consequences
+
+### Positive
+
+- Screens become presentation-only -- easier to test and reason about.
+- The `# type: ignore[assignment]` pattern is eliminated.
+- Config is loaded once and shared, not reloaded per operation.
+- Database I/O is centralised in the app, making it trivial to add
+  sync-on-save, git integration, and future post-mutation steps.
+- Error handling stays in the screen via try/except -- no indirection.
+
+### Negative
+
+- Screens depend on `KistApp`'s method signatures. Renaming or
+  changing a method requires updating callers (though
+  `getters.app()` makes these usages easy to find).
+- Config editors still need some direct config access, creating a
+  slight asymmetry with other screens.
+
+### Neutral
+
+- Existing tests for screens need updating to mock app methods
+  instead of mocking database access directly.
+
+## Implementation
+
+The refactor can be done incrementally:
+
+1. Add `library_config` reactive and `parts_version` reactive to
+   `KistApp`, load config on discovery.
+2. Add `getters.app(KistApp)` to all screens and modals, removing
+   `# type: ignore` casts.
+3. Add `save_part()`, `delete_part()`, and `save_library_config()`
+   methods to `KistApp` with `_after_mutation()` pipeline.
+4. Migrate AddScreen to call `self.app.save_part()`. Update
+   `PartForm` to accept categories as a parameter sourced from
+   `self.app.library_config`.
+5. Migrate DetailModal save/delete to call app methods.
+6. Migrate BrowseScreen refresh to watch `parts_version` instead
+   of relying on the DetailModal dismiss callback.
+7. Migrate SettingsModal and CategoryManagerModal to call
+   `self.app.save_library_config()`.
+8. Move `_run_check` and `_run_sync` in `app.py` to use the
+   reactive `library_config` instead of loading config from disk.

--- a/src/kist/cli/app.py
+++ b/src/kist/cli/app.py
@@ -109,12 +109,12 @@ def search(
     from kist.errors import LibraryNotFoundError
 
     try:
-        library_root = find_library()
+        result = find_library()
     except LibraryNotFoundError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1) from None
 
-    db = PartsDatabase(library_root / "parts.json")
+    db = PartsDatabase(result.library_root / "parts.json")
     db.load()
     results = db.search(query)
 
@@ -144,13 +144,13 @@ def check() -> None:
     from kist.errors import LibraryNotFoundError
 
     try:
-        library_root = find_library()
+        result = find_library()
     except LibraryNotFoundError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1) from None
 
-    config = load_library_config(library_root)
-    db = PartsDatabase(library_root / "parts.json")
+    config = load_library_config(result.library_root)
+    db = PartsDatabase(result.library_root / "parts.json")
     db.load()
 
     if not db.list_parts():

--- a/src/kist/cli/app.py
+++ b/src/kist/cli/app.py
@@ -172,3 +172,32 @@ def check() -> None:
         raise typer.Exit(code=1)
 
     typer.echo("All clean.")
+
+
+@app.command()
+def sync() -> None:
+    """Sync KiCad symbol files and lib tables with the parts database."""
+    from kist.core.config import load_library_config
+    from kist.core.database import PartsDatabase
+    from kist.core.library import find_library
+    from kist.core.sync import sync_sym_lib_table, sync_symbols
+    from kist.errors import LibraryNotFoundError
+
+    try:
+        result = find_library()
+    except LibraryNotFoundError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from None
+
+    config = load_library_config(result.library_root)
+    db = PartsDatabase(result.library_root / "parts.json")
+    db.load()
+
+    symbol_files = sync_symbols(result.library_root, db, config)
+    typer.echo(f"Synced {len(symbol_files)} symbol libraries.")
+
+    if result.project_dir:
+        sync_sym_lib_table(result.project_dir, symbol_files, config)
+        typer.echo(f"Updated sym-lib-table in {result.project_dir}")
+    else:
+        typer.echo("No project directory found; skipped sym-lib-table.")

--- a/src/kist/cli/app.py
+++ b/src/kist/cli/app.py
@@ -137,12 +137,10 @@ def search(
 @app.command()
 def check() -> None:
     """Validate part names and check for duplicates."""
-    from collections import defaultdict
-
+    from kist.core.check import check_library
     from kist.core.config import load_library_config
     from kist.core.database import PartsDatabase
     from kist.core.library import find_library
-    from kist.core.naming import generate_name, get_identity
     from kist.errors import LibraryNotFoundError
 
     try:
@@ -154,37 +152,23 @@ def check() -> None:
     config = load_library_config(library_root)
     db = PartsDatabase(library_root / "parts.json")
     db.load()
-    parts = db.list_parts()
 
-    if not parts:
+    if not db.list_parts():
         typer.echo("No parts to check.")
         raise typer.Exit()
 
-    typer.echo(f"Checking {len(parts)} parts...")
+    typer.echo(f"Checking {len(db.list_parts())} parts...")
 
-    issues = 0
-    categories = config.categories
+    issues = check_library(db, config)
 
-    # Check 1: name drift
-    for part in parts:
-        expected = generate_name(part, categories, config.separator)
-        if part.name != expected:
-            typer.echo(f'  Name mismatch: "{part.name}" should be "{expected}"')
-            issues += 1
-
-    # Check 2: identity duplicates
-    by_identity: dict[tuple[str, ...], list[str]] = defaultdict(list)
-    for part in parts:
-        by_identity[get_identity(part, categories)].append(part.name)
-
-    for identity, names in by_identity.items():
-        if len(names) > 1:
-            joined = " and ".join(names)
-            typer.echo(f"  Duplicate identity: {joined} share {identity}")
-            issues += 1
+    for issue in issues:
+        if issue.kind == "name_drift":
+            typer.echo(f"  Name mismatch: {issue.message}")
+        elif issue.kind == "duplicate_identity":
+            typer.echo(f"  Duplicate identity: {issue.message}")
 
     if issues:
-        typer.echo(f"\n{issues} issue(s) found.")
+        typer.echo(f"\n{len(issues)} issue(s) found.")
         raise typer.Exit(code=1)
 
     typer.echo("All clean.")

--- a/src/kist/cli/app.py
+++ b/src/kist/cli/app.py
@@ -25,8 +25,9 @@ def main(
         raise typer.Exit()
 
     if ctx.invoked_subcommand is None:
-        # No subcommand — launch TUI
-        typer.echo("TUI not yet implemented. Use --help for CLI commands.")
+        from kist.tui.app import run_tui
+
+        run_tui()
         raise typer.Exit()
 
 
@@ -86,9 +87,13 @@ def link(
 
 
 @app.command()
-def add() -> None:
+def add(
+    url_or_mpn: str | None = typer.Argument(None, help="URL or MPN to fetch."),
+) -> None:
     """Add a part to the library."""
-    typer.echo("Not yet implemented.")
+    from kist.tui.app import run_tui
+
+    run_tui(start_screen="add", url_or_mpn=url_or_mpn)
 
 
 @app.command()

--- a/src/kist/core/check.py
+++ b/src/kist/core/check.py
@@ -1,0 +1,60 @@
+"""Library health checks -- name drift and duplicate identity detection."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+
+from kist.core.database import PartsDatabase
+from kist.core.naming import generate_name, get_identity
+from kist.models.config import LibraryConfig
+
+
+@dataclass
+class CheckIssue:
+    """A single issue found during library validation."""
+
+    kind: str  # "name_drift" | "duplicate_identity"
+    message: str
+    parts: list[str]
+
+
+def check_library(db: PartsDatabase, config: LibraryConfig) -> list[CheckIssue]:
+    """
+    Validate part names and check for identity duplicates.
+
+    Returns a list of issues found. An empty list means the library is clean.
+    """
+    parts = db.list_parts()
+    if not parts:
+        return []
+
+    issues: list[CheckIssue] = []
+    categories = config.categories
+
+    # Single pass: check name drift and build identity map
+    by_identity: dict[tuple[str, ...], list[str]] = defaultdict(list)
+    for part in parts:
+        expected = generate_name(part, categories, config.separator)
+        if part.name != expected:
+            issues.append(
+                CheckIssue(
+                    kind="name_drift",
+                    message=f'"{part.name}" should be "{expected}"',
+                    parts=[part.name],
+                )
+            )
+        by_identity[get_identity(part, categories)].append(part.name)
+
+    for identity, names in by_identity.items():
+        if len(names) > 1:
+            joined = " and ".join(names)
+            issues.append(
+                CheckIssue(
+                    kind="duplicate_identity",
+                    message=f"{joined} share {identity}",
+                    parts=list(names),
+                )
+            )
+
+    return issues

--- a/src/kist/core/config.py
+++ b/src/kist/core/config.py
@@ -125,8 +125,7 @@ def load_provider_mapping(provider_name: str) -> ProviderMappingConfig:
 
     If no TOML file exists, returns the provider's built-in defaults.
     Dict fields (categories, parameters, mounting) are merged key-by-key.
-    List fields (ignore_parameters) and scalars are replaced entirely
-    if present in the TOML.
+    Scalars are replaced entirely if present in the TOML.
     """
     # Load built-in defaults from the provider module
     module_path = _PROVIDER_DEFAULTS.get(provider_name)

--- a/src/kist/core/config.py
+++ b/src/kist/core/config.py
@@ -11,6 +11,7 @@ import tomlkit.exceptions
 
 from kist.errors import ConfigError
 from kist.models.config import GlobalConfig, LibraryConfig, ProjectRef
+from kist.providers.models import ProviderMappingConfig
 
 KIST_MARKER = ".kist"
 PROJECT_REF = "kist.toml"
@@ -108,3 +109,53 @@ def save_project_ref(path: Path, ref: ProjectRef) -> None:
     """Write a kist.toml project reference."""
     doc = tomlkit.dumps(ref.model_dump())
     path.write_text(doc)
+
+
+# -- Provider mapping config ------------------------------------------------
+
+# Lazy import to avoid circular deps at module level
+_PROVIDER_DEFAULTS: dict[str, str] = {
+    "digikey": "kist.providers.digikey",
+}
+
+
+def load_provider_mapping(provider_name: str) -> ProviderMappingConfig:
+    """
+    Load mapping config for a provider, merging user TOML over defaults.
+
+    If no TOML file exists, returns the provider's built-in defaults.
+    Dict fields (categories, parameters, mounting) are merged key-by-key.
+    List fields (ignore_parameters) and scalars are replaced entirely
+    if present in the TOML.
+    """
+    # Load built-in defaults from the provider module
+    module_path = _PROVIDER_DEFAULTS.get(provider_name)
+    if module_path is None:
+        raise ConfigError(f"Unknown provider: {provider_name}")
+
+    import importlib
+
+    mod = importlib.import_module(module_path)
+    defaults: ProviderMappingConfig = mod.default_mapping()
+
+    # Check for user overrides
+    toml_path = _get_config_dir() / "providers" / f"{provider_name}.toml"
+    if not toml_path.exists():
+        return defaults
+
+    try:
+        user_data = dict(tomlkit.loads(toml_path.read_text()))
+    except (OSError, tomlkit.exceptions.ParseError) as exc:
+        raise ConfigError(f"Failed to read provider config {toml_path}: {exc}") from exc
+
+    # Merge: dicts overlay key-by-key, lists/scalars replace
+    merged = defaults.model_dump()
+    for key, value in user_data.items():
+        if key not in merged:
+            continue  # ignore unknown keys
+        if isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = {**merged[key], **value}
+        else:
+            merged[key] = value
+
+    return ProviderMappingConfig.model_validate(merged)

--- a/src/kist/core/config.py
+++ b/src/kist/core/config.py
@@ -38,6 +38,15 @@ def load_global_config() -> GlobalConfig:
         raise ConfigError(f"Failed to read global config {path}: {exc}") from exc
 
 
+def save_global_config(config: GlobalConfig) -> None:
+    """Write global config to the user config directory."""
+    config_dir = _get_config_dir()
+    config_dir.mkdir(parents=True, exist_ok=True)
+    path = config_dir / LIBRARY_CONFIG
+    doc = tomlkit.dumps(config.model_dump(exclude_none=True))
+    path.write_text(doc)
+
+
 def resolve_init_config(**overrides: str | list[str] | None) -> LibraryConfig:
     """Merge built-in defaults, global config, and CLI overrides."""
     global_cfg = load_global_config()

--- a/src/kist/core/database.py
+++ b/src/kist/core/database.py
@@ -56,7 +56,9 @@ class PartsDatabase:
 
         parts: dict[Ipn, Part] = {}
         for uid, part_data in raw.get("parts", {}).items():
-            parts[Ipn(uid)] = _part_adapter.validate_python(part_data)
+            part = _part_adapter.validate_python(part_data)
+            part.ipn = Ipn(uid)
+            parts[Ipn(uid)] = part
 
         self._parts = parts
         self._name_index = {part.name: uid for uid, part in parts.items()}
@@ -91,6 +93,7 @@ class PartsDatabase:
             raise DuplicatePartError(f"Part name already exists: {part.name}")
 
         ipn = Ipn(str(uuid.uuid4()))
+        part.ipn = ipn
         self._parts[ipn] = part
         self._name_index[part.name] = ipn
         self.save()

--- a/src/kist/core/library.py
+++ b/src/kist/core/library.py
@@ -5,20 +5,30 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import uuid
 from pathlib import Path
+from typing import NamedTuple
 
 from kist.core.categories import WELL_KNOWN_CATEGORIES
 from kist.core.config import (
     KIST_MARKER,
     PROJECT_REF,
+    load_library_config,
     load_project_ref,
     resolve_init_config,
     save_library_config,
     save_project_ref,
 )
 from kist.core.database import create_empty
-from kist.errors import LibraryExistsError, LibraryNotFoundError
+from kist.errors import ConfigError, LibraryExistsError, LibraryNotFoundError
 from kist.models.config import CategoryDef, ProjectRef
+
+
+class DiscoveryResult(NamedTuple):
+    """Result of library discovery, with optional project context."""
+
+    library_root: Path
+    project_dir: Path | None = None
 
 
 def init_library(
@@ -47,6 +57,7 @@ def init_library(
         models_dir=models_dir,
         blocks_dir=blocks_dir,
     )
+    config.library_id = str(uuid.uuid4())
     config.categories = (
         categories if categories is not None else dict(WELL_KNOWN_CATEGORIES)
     )
@@ -83,8 +94,12 @@ def link_library(target: Path, library: Path) -> Path:
     if ref_path.exists():
         raise LibraryExistsError(f"Already linked: {ref_path}")
 
+    lib_config = load_library_config(library)
     rel_path = str(os.path.relpath(library, target))
-    save_project_ref(ref_path, ProjectRef(library_path=rel_path))
+    save_project_ref(
+        ref_path,
+        ProjectRef(library_path=rel_path, library_id=lib_config.library_id),
+    )
 
     _create_lib_link(target / "lib", rel_path)
 
@@ -116,24 +131,31 @@ def _create_lib_link(link: Path, target: str) -> None:
         pass
 
 
-def find_library(start: Path | None = None) -> Path:
+def find_library(start: Path | None = None) -> DiscoveryResult:
     """
     Walk up from *start* to find the nearest kist library.
 
-    Returns the library root directory.
+    Returns a :class:`DiscoveryResult` with the library root and,
+    when discovered via a project reference (``kist.toml``), the
+    project directory.
+
+    When the library is found directly (via ``.kist/``), also checks
+    the parent directory for a ``kist.toml`` that points back to it,
+    so ``kist sync`` works from inside the library.
     """
     current = (start or Path.cwd()).resolve()
 
     while True:
         if (current / KIST_MARKER).is_dir():
-            return current
+            project_dir = _find_project_for_library(current)
+            return DiscoveryResult(current, project_dir)
 
         ref_path = current / PROJECT_REF
         if ref_path.is_file():
             ref = load_project_ref(ref_path)
             library = (current / ref.library_path).resolve()
             if (library / KIST_MARKER).is_dir():
-                return library
+                return DiscoveryResult(library, current)
             raise LibraryNotFoundError(
                 f"{ref_path} points to {ref.library_path}, "
                 f"but {library} is not a kist library."
@@ -141,10 +163,30 @@ def find_library(start: Path | None = None) -> Path:
 
         parent = current.parent
         if parent == current:
-            # Reached filesystem root (Path("/").parent == Path("/"))
             raise LibraryNotFoundError(
                 f"Not a kist library (or any parent up to {current}).\n"
                 "Run 'kist init' to create a new library, or\n"
                 "'kist link <path>' to link to an existing one."
             )
         current = parent
+
+
+def _find_project_for_library(library_root: Path) -> Path | None:
+    """
+    Check the parent directory for a ``kist.toml`` pointing to *library_root*.
+
+    Handles the single-board case where the library is at ``project/lib/``
+    and the project ref is at ``project/kist.toml``.
+    """
+    parent = library_root.parent
+    ref_path = parent / PROJECT_REF
+    if not ref_path.is_file():
+        return None
+    try:
+        ref = load_project_ref(ref_path)
+    except ConfigError:
+        return None
+    resolved = (parent / ref.library_path).resolve()
+    if resolved == library_root:
+        return parent
+    return None

--- a/src/kist/core/sync.py
+++ b/src/kist/core/sync.py
@@ -6,26 +6,33 @@ from collections import defaultdict
 from pathlib import Path
 
 from kist.core.database import PartsDatabase
+from kist.kicad.lib_table import generate_sym_lib_table, update_sym_lib_table
 from kist.kicad.mapping import library_filename
 from kist.kicad.symbols import SymbolLibrary
 from kist.kicad.templates import symbol_for_part
 from kist.models.config import LibraryConfig
+
+SYM_LIB_TABLE = "sym-lib-table"
 
 
 def sync_symbols(
     library_root: Path,
     db: PartsDatabase,
     config: LibraryConfig,
-) -> None:
+) -> list[Path]:
     """
     Push part metadata from the PartsDatabase to .kicad_sym files.
 
     Groups parts by category. For each category with parts, loads or
     creates a SymbolLibrary, generates symbols via symbol_for_part(),
     and saves. Idempotent.
+
+    Returns the list of .kicad_sym files written.
     """
     symbols_dir = library_root / config.symbols_dir
     symbols_dir.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
 
     # Group parts by category
     by_category: dict[str, list] = defaultdict(list)
@@ -48,3 +55,40 @@ def sync_symbols(
             lib.set_symbol(part.name, symbol_for_part(part, config.categories))
 
         lib.save(path)
+        written.append(path)
+
+    return written
+
+
+def sync_sym_lib_table(
+    project_dir: Path,
+    symbol_files: list[Path],
+    config: LibraryConfig,
+) -> None:
+    """
+    Write or update the sym-lib-table in *project_dir*.
+
+    If a sym-lib-table already exists, kist-managed entries are
+    replaced while preserving non-kist entries. Otherwise a fresh
+    table is generated.
+    """
+    table_path = project_dir / SYM_LIB_TABLE
+
+    if table_path.exists():
+        existing = table_path.read_text(encoding="utf-8")
+        content = update_sym_lib_table(
+            existing,
+            symbol_files,
+            config.symbols_dir,
+            config.library_prefix,
+            config.separator,
+        )
+    else:
+        content = generate_sym_lib_table(
+            symbol_files,
+            config.symbols_dir,
+            config.library_prefix,
+            config.separator,
+        )
+
+    table_path.write_text(content, encoding="utf-8", newline="\n")

--- a/src/kist/kicad/lib_table.py
+++ b/src/kist/kicad/lib_table.py
@@ -1,0 +1,116 @@
+"""
+KiCad lib table generation and update.
+
+Produces ``sym-lib-table`` (and eventually ``fp-lib-table``) files
+using the S-expression format KiCad expects. Kist-managed entries
+are identified by the library prefix + separator (e.g. ``00k-``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kist.sexpr import Atom, dumps, parse_one
+
+# -- Constants ---
+
+_VERSION = "7"
+
+
+# -- Entry construction ---
+
+
+def _lib_entry(name: str, uri: str) -> list:
+    """
+    Build a single ``(lib ...)`` S-expression node.
+    """
+    return [
+        Atom("lib"),
+        [Atom("name"), Atom(name, quoted=True)],
+        [Atom("type"), Atom("KiCad", quoted=True)],
+        [Atom("uri"), Atom(uri, quoted=True)],
+        [Atom("options"), Atom("", quoted=True)],
+        [Atom("descr"), Atom("", quoted=True)],
+    ]
+
+
+def _is_kist_entry(node: list, prefix: str, separator: str) -> bool:
+    """True if this ``(lib ...)`` node is kist-managed."""
+    if not node or node[0] != "lib":
+        return False
+    for child in node[1:]:
+        if isinstance(child, list) and child and child[0] == "name" and len(child) > 1:
+            return str(child[1]).startswith(f"{prefix}{separator}")
+    return False
+
+
+# -- Generation ---
+
+
+def generate_sym_lib_table(
+    symbol_files: list[Path],
+    symbols_dir: str,
+    library_prefix: str,
+    separator: str,
+) -> str:
+    """
+    Generate sym-lib-table content for kist-managed symbol libraries.
+
+    *symbol_files* are ``.kicad_sym`` paths (only the stem is used).
+    *symbols_dir* is the relative directory name (e.g. ``"symbols"``).
+    URIs use ``${KIPRJMOD}/lib/<symbols_dir>/<filename>``.
+
+    Returns the S-expression string ready to write to disk.
+    """
+    entries = []
+    for path in sorted(symbol_files):
+        name = path.stem
+        uri = f"${{KIPRJMOD}}/lib/{symbols_dir}/{path.name}"
+        entries.append(_lib_entry(name, uri))
+
+    tree: list = [
+        Atom("sym_lib_table"),
+        [Atom("version"), Atom(_VERSION)],
+        *entries,
+    ]
+    return dumps(tree)
+
+
+# -- Update (merge) ---
+
+
+def update_sym_lib_table(
+    existing_content: str,
+    symbol_files: list[Path],
+    symbols_dir: str,
+    library_prefix: str,
+    separator: str,
+) -> str:
+    """
+    Merge kist entries into an existing sym-lib-table.
+
+    Removes all kist-managed ``(lib ...)`` entries (identified by
+    *library_prefix* + *separator*), appends fresh entries for
+    *symbol_files*, and preserves everything else.
+    """
+    tree = parse_one(existing_content)
+    if not isinstance(tree, list) or not tree or tree[0] != "sym_lib_table":
+        msg = f"Expected (sym_lib_table ...), got {tree[0]!r}"
+        raise ValueError(msg)
+
+    # Remove existing kist entries
+    tree[:] = [
+        node
+        for node in tree
+        if not (
+            isinstance(node, list) and _is_kist_entry(node, library_prefix, separator)
+        )
+    ]
+
+    # Append new kist entries
+    for path in sorted(symbol_files):
+        name = path.stem
+        uri = f"${{KIPRJMOD}}/lib/{symbols_dir}/{path.name}"
+        tree.append(_lib_entry(name, uri))
+
+    return dumps(tree)

--- a/src/kist/models/config.py
+++ b/src/kist/models/config.py
@@ -33,6 +33,7 @@ class LibraryConfig(BaseModel):
     """Per-library config, always has concrete values -- resolved at init time."""
 
     version: int = 1
+    library_id: str = ""
     library_prefix: str = "00k"
     separator: str = "-"
     symbols_dir: str = "symbols"
@@ -76,3 +77,4 @@ class ProjectRef(BaseModel):
 
     version: int = 1
     library_path: str
+    library_id: str = ""

--- a/src/kist/models/config.py
+++ b/src/kist/models/config.py
@@ -63,7 +63,7 @@ class ProvidersConfig(BaseModel):
 class GlobalConfig(BaseModel):
     """User-level defaults. All fields optional with built-in defaults."""
 
-    theme: str = "kist-dark"
+    theme: str = "null"
     symbols_dir: str = "symbols"
     footprints_dir: str = "footprints"
     models_dir: str = "3dmodels"

--- a/src/kist/models/config.py
+++ b/src/kist/models/config.py
@@ -62,6 +62,7 @@ class ProvidersConfig(BaseModel):
 class GlobalConfig(BaseModel):
     """User-level defaults. All fields optional with built-in defaults."""
 
+    theme: str = "kist-dark"
     symbols_dir: str = "symbols"
     footprints_dir: str = "footprints"
     models_dir: str = "3dmodels"

--- a/src/kist/models/part.py
+++ b/src/kist/models/part.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Annotated, Literal, NewType
 
-from pydantic import BaseModel, ConfigDict, Discriminator, HttpUrl
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, HttpUrl
 
 Ipn = NewType("Ipn", str)
 
@@ -39,6 +39,7 @@ class PartBase(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    ipn: Ipn | None = Field(default=None, exclude=True)
     name: str
     description: str
     category: str

--- a/src/kist/providers/__init__.py
+++ b/src/kist/providers/__init__.py
@@ -1,0 +1,88 @@
+"""Provider dispatch -- detect provider from input and fetch product data."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from kist.errors import ProviderError
+from kist.providers.digikey import DigiKeyClient, parse_digikey_url
+from kist.providers.models import ProviderProduct
+
+if TYPE_CHECKING:
+    from kist.models.config import GlobalConfig
+    from kist.providers.models import ProviderMappingConfig
+
+# Host patterns that identify a provider from a URL.
+_HOST_PROVIDERS: dict[str, str] = {
+    "digikey": "digikey",
+}
+
+
+def detect_provider(url_or_mpn: str) -> tuple[str, str]:
+    """
+    Return (provider_name, identifier) from a URL or bare MPN.
+
+    For URLs, the host is matched against known providers. The
+    identifier is extracted by the provider's URL parser.
+
+    For bare input (no scheme/host), defaults to "digikey".
+
+    Raises ProviderError for URLs with unrecognised hosts.
+    """
+    parsed = urlparse(url_or_mpn.strip())
+
+    if not parsed.scheme and not parsed.netloc:
+        # Bare MPN -- default provider
+        return "digikey", url_or_mpn.strip()
+
+    # Match host against known providers
+    host = (parsed.netloc or "").lower()
+    for pattern, provider in _HOST_PROVIDERS.items():
+        if pattern in host:
+            if provider == "digikey":
+                return provider, parse_digikey_url(url_or_mpn)
+            return provider, url_or_mpn.strip()
+
+    raise ProviderError(f"Unrecognised supplier URL: {url_or_mpn}")
+
+
+def fetch_product(url_or_mpn: str) -> ProviderProduct:
+    """
+    Detect provider, load credentials and mapping, fetch product.
+
+    This is the single entry point the TUI uses. It handles:
+    1. Provider detection from the input
+    2. Credential loading from global config / env vars
+    3. Mapping config loading (built-in defaults + user TOML)
+    4. API call via the provider client
+    """
+    from kist.core.config import load_global_config, load_provider_mapping
+
+    provider_name, identifier = detect_provider(url_or_mpn)
+    global_cfg = load_global_config()
+    mapping = load_provider_mapping(provider_name)
+
+    if provider_name == "digikey":
+        return _fetch_digikey(identifier, mapping, global_cfg)
+
+    raise ProviderError(f"Provider not implemented: {provider_name}")
+
+
+def _fetch_digikey(
+    product_number: str,
+    mapping: ProviderMappingConfig,
+    global_cfg: GlobalConfig,
+) -> ProviderProduct:
+    """Build DigiKey client from credentials and fetch product details."""
+    dk_cfg = global_cfg.providers.digikey
+
+    client_id = os.environ.get("KIST_DIGIKEY_CLIENT_ID") or dk_cfg.client_id
+    client_secret = os.environ.get("KIST_DIGIKEY_CLIENT_SECRET") or dk_cfg.client_secret
+
+    if not client_id or not client_secret:
+        raise ProviderError("DigiKey credentials not configured")
+
+    client = DigiKeyClient(client_id, client_secret)
+    return client.fetch_product(product_number, mapping)

--- a/src/kist/providers/digikey.py
+++ b/src/kist/providers/digikey.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 import httpx
 
 from kist.errors import DigiKeyError
-from kist.providers.models import DigiKeyProduct
+from kist.providers.models import ProviderMappingConfig, ProviderProduct
 
 # -- URLs -------------------------------------------------------------------
 
@@ -17,10 +17,21 @@ SANDBOX_URL = "https://sandbox-api.digikey.com"
 REQUEST_TIMEOUT = 30  # seconds
 
 # -- Parameter mapping ------------------------------------------------------
-# Maps DigiKey ParameterText names to kist spec field names.
-# Parameters not in this map are preserved as-is in DigiKeyProduct.parameters.
+# Maps raw DigiKey ParameterText names to normalised target names.
+#
+# The target name determines how the parameter is routed:
+#   "package"      --> ProviderProduct.package  (top-level field)
+#   "mounting"     --> ProviderProduct.mounting  (top-level field)
+#   in ignore list --> dropped
+#   anything else  --> ProviderProduct.parameters[target]
+#
+# Parameters not in this map pass through with their raw name.
 
 PARAMETER_MAP: dict[str, str] = {
+    # Extracted to top-level fields
+    "Package / Case": "package",
+    "Mounting Type": "mounting",
+    # Spec parameters
     "Resistance": "resistance",
     "Tolerance": "tolerance",
     "Capacitance": "capacitance",
@@ -86,9 +97,27 @@ CATEGORY_MAP: dict[str, str] = {
     "Transformers": "TFRM",
 }
 
-# Parameter names that map to top-level DigiKeyProduct fields
-_PACKAGE_PARAMS = {"Package / Case"}
-_MOUNTING_PARAMS = {"Mounting Type"}
+# -- Mounting value normalisation -------------------------------------------
+# Maps raw DigiKey mounting strings to canonical values.
+
+MOUNTING_MAP: dict[str, str] = {
+    "Surface Mount": "smd",
+    "Through Hole": "tht",
+}
+
+# Target names that route to top-level ProviderProduct fields
+# instead of the parameters dict.
+_EXTRACT_FIELDS = frozenset({"package", "mounting"})
+
+
+def default_mapping() -> ProviderMappingConfig:
+    """Return built-in DigiKey mapping defaults."""
+    return ProviderMappingConfig(
+        supplier_name="DigiKey",
+        categories=dict(CATEGORY_MAP),
+        parameters=dict(PARAMETER_MAP),
+        mounting=dict(MOUNTING_MAP),
+    )
 
 
 # -- URL parsing -------------------------------------------------------------
@@ -118,64 +147,90 @@ def parse_digikey_url(url: str) -> str:
 # -- Response mapping --------------------------------------------------------
 
 
-def _find_category(category_node: dict | None) -> str | None:
+def _find_category(
+    category_node: dict | None, categories: dict[str, str]
+) -> str | None:
     """Walk the category tree and return the first kist category match."""
     if not category_node:
         return None
     name = category_node.get("Name", "")
-    if name in CATEGORY_MAP:
-        return CATEGORY_MAP[name]
+    if name in categories:
+        return categories[name]
     # Check children -- DigiKey nests subcategories under the parent
     for child in category_node.get("ChildCategories", []):
         child_name = child.get("Name", "")
-        if child_name in CATEGORY_MAP:
-            return CATEGORY_MAP[child_name]
+        if child_name in categories:
+            return categories[child_name]
     return None
 
 
-def _map_product(data: dict, digikey_pn: str) -> DigiKeyProduct:
-    """Map a raw Product dict from the DigiKey API to DigiKeyProduct."""
+def _map_product(
+    data: dict,
+    product_number: str,
+    mapping: ProviderMappingConfig,
+) -> ProviderProduct:
+    """Map a raw Product dict from the DigiKey API to ProviderProduct."""
     product = data.get("Product", data)
 
     description_obj = product.get("Description", {})
     manufacturer_obj = product.get("Manufacturer", {})
 
-    # Build parameters dict, extracting package and mounting
+    ignore = set(mapping.ignore_parameters)
+
+    # Pipeline: normalise parameter names, then route.
+    #   "package"      --> product.package
+    #   "mounting"     --> product.mounting (value normalised via mapping.mounting)
+    #   in ignore set  --> dropped
+    #   anything else  --> product.parameters[target]
     parameters: dict[str, str] = {}
     package: str | None = None
     mounting: str | None = None
 
     for param in product.get("Parameters", []):
-        param_text = param.get("ParameterText", "")
-        value_text = param.get("ValueText", "")
-        if not param_text or not value_text:
+        raw_name = param.get("ParameterText", "")
+        value = param.get("ValueText", "")
+        if not raw_name or not value:
             continue
 
-        if param_text in _PACKAGE_PARAMS:
-            package = value_text
-        elif param_text in _MOUNTING_PARAMS:
-            mounting = value_text
+        # 1. Normalise name
+        target = mapping.parameters.get(raw_name, raw_name)
 
-        # Map to kist spec name if known, otherwise keep original
-        key = PARAMETER_MAP.get(param_text, param_text)
-        parameters[key] = value_text
+        # 2. Route
+        if target == "package":
+            package = value
+        elif target == "mounting":
+            mounting = value
+        elif target in ignore:
+            continue
+        else:
+            parameters[target] = value
+
+    # Normalise mounting value
+    if mounting:
+        mounting = mapping.mounting.get(mounting)
 
     # Get first variation's DigiKey part number if we don't have one
-    dk_pn = digikey_pn
+    dk_pn = product_number
     variations = product.get("ProductVariations", [])
     if variations:
         dk_pn = variations[0].get("DigiKeyProductNumber", dk_pn)
 
-    category = _find_category(product.get("Category"))
+    category = _find_category(product.get("Category"), mapping.categories)
 
-    return DigiKeyProduct(
+    # Normalise protocol-relative datasheet URLs
+    datasheet_url = product.get("DatasheetUrl")
+    if datasheet_url and datasheet_url.startswith("//"):
+        datasheet_url = "https:" + datasheet_url
+
+    return ProviderProduct(
         mpn=product.get("ManufacturerProductNumber", ""),
         manufacturer=manufacturer_obj.get("Name", ""),
         description=description_obj.get("ProductDescription", ""),
         detailed_description=description_obj.get("DetailedDescription", ""),
-        digikey_pn=dk_pn,
-        digikey_url=product.get("ProductUrl"),
-        datasheet_url=product.get("DatasheetUrl"),
+        supplier_name=mapping.supplier_name,
+        supplier_sku=dk_pn,
+        supplier_url=product.get("ProductUrl"),
+        datasheet_url=datasheet_url,
         category=category,
         parameters=parameters,
         unit_price=product.get("UnitPrice"),
@@ -238,12 +293,19 @@ class DigiKeyClient:
         self._token = access_token
         return access_token
 
-    def fetch_product(self, product_number: str) -> DigiKeyProduct:
+    def fetch_product(
+        self,
+        product_number: str,
+        mapping: ProviderMappingConfig | None = None,
+    ) -> ProviderProduct:
         """
         Fetch product details from the DigiKey v4 API.
 
         Token is obtained lazily and reused across calls.
         """
+        if mapping is None:
+            mapping = default_mapping()
+
         token = self._ensure_token()
 
         resp = httpx.get(
@@ -262,4 +324,4 @@ class DigiKeyClient:
                 f"Product details request failed ({resp.status_code}): {resp.text}"
             )
 
-        return _map_product(resp.json(), product_number)
+        return _map_product(resp.json(), product_number, mapping)

--- a/src/kist/providers/digikey.py
+++ b/src/kist/providers/digikey.py
@@ -25,37 +25,87 @@ REQUEST_TIMEOUT = 30  # seconds
 #   in ignore list --> dropped
 #   anything else  --> ProviderProduct.parameters[target]
 #
-# Parameters not in this map pass through with their raw name.
+# Methodology: extracted by fetching 86 products across two real BOMs via
+# the DigiKey v4 API, then analysing parameter frequency and usefulness.
+# Re-run on a wider data set to discover new parameter names worth mapping.
 
 PARAMETER_MAP: dict[str, str] = {
     # Extracted to top-level fields
     "Package / Case": "package",
     "Mounting Type": "mounting",
-    # Spec parameters
+    # -- Passive specs ----------------------------------------------------------
     "Resistance": "resistance",
     "Tolerance": "tolerance",
     "Capacitance": "capacitance",
     "Inductance": "inductance",
+    "Temperature Coefficient": "temp_coefficient",
+    "Composition": "composition",
+    "Power (Watts)": "power_rating",
+    "ESR (Equivalent Series Resistance)": "esr",
+    # -- Voltage ----------------------------------------------------------------
     "Voltage - Rated": "voltage_rating",
     "Voltage - Reverse Standoff (Typ)": "standoff_voltage",
     "Voltage - Zener (Nom) (Vz)": "zener_voltage",
     "Voltage - Collector Emitter Breakdown (Max)": "vceo",
     "Voltage - Drain to Source (Vdss)": "vds_max",
-    "Current - Collector (Ic) (Max)": "ic_max",
-    "Current - Drain (Id) (Max)": "id_max",
+    "Voltage - Breakdown (Min)": "breakdown_voltage",
+    "Voltage - Clamping (Max) @ Ipp": "clamping_voltage",
+    "Voltage - Supply": "voltage_supply",
+    "Voltage - Output (Min/Fixed)": "voltage_output",
+    "Voltage - Output (Max)": "voltage_output_max",
+    "Voltage - Input (Min)": "voltage_input_min",
+    "Voltage - Input (Max)": "voltage_input_max",
+    # -- Current ----------------------------------------------------------------
     "Current Rating (Amps)": "current_rating",
     "Current - Peak Pulse (10/1000\u00b5s)": "peak_current",
     "Forward Current (If)": "forward_current",
-    "Power - Max": "power_rating",
+    "Current - Collector (Ic) (Max)": "ic_max",
+    "Current - Drain (Id) (Max)": "id_max",
+    "Current - Output": "current_output",
+    "Current - Saturation (Isat)": "isat",
+    "Hold Current (Ih)": "hold_current",
+    # -- Power ------------------------------------------------------------------
+    "Power - Max": "power_max",
     "Peak Pulse Power (Tp=8/20\u00b5s)": "peak_power",
+    "Power - Peak Pulse": "peak_power_pulse",
+    # -- Inductor specs ---------------------------------------------------------
+    "DC Resistance (DCR)": "dcr",
+    "Q @ Freq": "q_factor",
+    # -- Frequency --------------------------------------------------------------
     "Frequency": "frequency",
     "Frequency - Self Resonant": "srf",
+    "Frequency Tolerance": "frequency_tolerance",
     "Load Capacitance": "load_capacitance",
     "Impedance @ Frequency": "impedance",
     "Impedance": "impedance_100mhz",
-    "Hold Current (Ih)": "hold_current",
+    # -- IC / regulator ---------------------------------------------------------
+    "Topology": "topology",
+    "Protocol": "protocol",
+    "Output Configuration": "output_config",
+    # -- Misc -------------------------------------------------------------------
     "Color": "colour",
 }
+
+# -- Ignored parameters --------------------------------------------------------
+# Parameters dropped entirely after name normalisation.  These are either
+# boilerplate (present on nearly every product) or physical dimensions that
+# don't help with part selection.
+
+IGNORE_PARAMETERS: list[str] = [
+    "Operating Temperature",
+    "Features",
+    "Supplier Device Package",
+    "Size / Dimension",
+    "Height - Seated (Max)",
+    "Ratings",
+    "Failure Rate",
+    "Applications",
+    "Thickness (Max)",
+    "Lead Spacing",
+    "Lead Style",
+    "Number of Terminations",
+    "DigiKey Programmable",
+]
 
 # -- Category mapping -------------------------------------------------------
 # Best-effort mapping from DigiKey category names to kist category codes.
@@ -63,6 +113,7 @@ PARAMETER_MAP: dict[str, str] = {
 # Unknown categories return None -- the TUI will let the user pick.
 
 CATEGORY_MAP: dict[str, str] = {
+    # -- Passives ---------------------------------------------------------------
     "Resistors": "RES",
     "Chip Resistor - Surface Mount": "RES",
     "Through Hole Resistors": "RES",
@@ -74,24 +125,58 @@ CATEGORY_MAP: dict[str, str] = {
     "Inductors, Coils, Chokes": "IND",
     "Fixed Inductors": "IND",
     "Ferrite Beads and Chips": "IND",
+    "Filters": "IND",
+    "EMI/RFI Filters (LC, RC Networks)": "IND",
+    # -- Diodes / TVS -----------------------------------------------------------
     "Diodes - Rectifiers - Single": "DIO",
     "Diodes - Zener - Single": "DIO",
     "TVS - Diodes": "DIO",
+    "Transient Voltage Suppressors (TVS)": "DIO",
+    "Circuit Protection": "DIO",
     "LEDs": "DIO",
+    # -- Transistors -------------------------------------------------------------
     "Transistors - MOSFETs": "TRAN",
     "Transistors - BJTs": "TRAN",
     "Transistors - FETs, MOSFETs - Single": "TRAN",
     "Transistors - Bipolar (BJT) - Single": "TRAN",
+    # -- ICs (including subcategories) ------------------------------------------
     "Integrated Circuits (ICs)": "IC",
+    "Power Management (PMIC)": "IC",
+    "Data Acquisition": "IC",
+    "Embedded": "IC",
+    "Interface": "IC",
+    "Logic": "IC",
+    "Memory": "IC",
+    "RF and Wireless": "IC",
+    "RF Transceiver ICs": "IC",
+    "RF Transceiver Modules and Modems": "IC",
+    "RF Front End (LNA + PA)": "IC",
+    "Sensors, Transducers": "IC",
+    "Humidity, Moisture Sensors": "IC",
+    "Magnetic Sensors": "IC",
+    "Motion Sensors": "IC",
+    # -- Connectors --------------------------------------------------------------
     "Connectors": "CONN",
     "Connectors, Interconnects": "CONN",
+    "Rectangular Connectors": "CONN",
     "Rectangular Connectors - Headers, Male Pins": "CONN",
     "Rectangular Connectors - Free Hanging, Panel Mount": "CONN",
     "USB, DVI, HDMI Connectors": "CONN",
+    "Coaxial Connectors (RF)": "CONN",
+    "FFC, FPC (Flat Flexible) Connectors": "CONN",
+    "Memory Connectors": "CONN",
+    "Terminal Blocks": "CONN",
+    "Cable Assemblies": "CONN",
+    "Flat Flex Ribbon Jumpers, Cables": "CONN",
+    # -- Switches / Relays ------------------------------------------------------
     "Switches": "SW",
+    "Slide Switches": "SW",
     "Relays": "REL",
+    # -- Crystals / Oscillators -------------------------------------------------
     "Crystals": "XTAL",
+    "Crystals, Oscillators, Resonators": "XTAL",
     "Oscillators": "XTAL",
+    # -- Fuses / Transformers ---------------------------------------------------
     "Fuses": "FUSE",
     "PTC Resettable Fuses": "FUSE",
     "Transformers": "TFRM",
@@ -102,7 +187,10 @@ CATEGORY_MAP: dict[str, str] = {
 
 MOUNTING_MAP: dict[str, str] = {
     "Surface Mount": "smd",
+    "Surface Mount, MLCC": "smd",
+    "Surface Mount, Right Angle": "smd",
     "Through Hole": "tht",
+    "Surface Mount, Right Angle; Through Hole": "tht",
 }
 
 # Target names that route to top-level ProviderProduct fields
@@ -116,6 +204,7 @@ def default_mapping() -> ProviderMappingConfig:
         supplier_name="DigiKey",
         categories=dict(CATEGORY_MAP),
         parameters=dict(PARAMETER_MAP),
+        ignore_parameters=list(IGNORE_PARAMETERS),
         mounting=dict(MOUNTING_MAP),
     )
 

--- a/src/kist/providers/digikey.py
+++ b/src/kist/providers/digikey.py
@@ -22,8 +22,8 @@ REQUEST_TIMEOUT = 30  # seconds
 # The target name determines how the parameter is routed:
 #   "package"      --> ProviderProduct.package  (top-level field)
 #   "mounting"     --> ProviderProduct.mounting  (top-level field)
-#   in ignore list --> dropped
-#   anything else  --> ProviderProduct.parameters[target]
+#   mapped target  --> ProviderProduct.parameters[target]
+#   not in map     --> dropped (whitelist approach)
 #
 # Methodology: extracted by fetching 86 products across two real BOMs via
 # the DigiKey v4 API, then analysing parameter frequency and usefulness.
@@ -85,27 +85,6 @@ PARAMETER_MAP: dict[str, str] = {
     # -- Misc -------------------------------------------------------------------
     "Color": "colour",
 }
-
-# -- Ignored parameters --------------------------------------------------------
-# Parameters dropped entirely after name normalisation.  These are either
-# boilerplate (present on nearly every product) or physical dimensions that
-# don't help with part selection.
-
-IGNORE_PARAMETERS: list[str] = [
-    "Operating Temperature",
-    "Features",
-    "Supplier Device Package",
-    "Size / Dimension",
-    "Height - Seated (Max)",
-    "Ratings",
-    "Failure Rate",
-    "Applications",
-    "Thickness (Max)",
-    "Lead Spacing",
-    "Lead Style",
-    "Number of Terminations",
-    "DigiKey Programmable",
-]
 
 # -- Category mapping -------------------------------------------------------
 # Best-effort mapping from DigiKey category names to kist category codes.
@@ -193,10 +172,6 @@ MOUNTING_MAP: dict[str, str] = {
     "Surface Mount, Right Angle; Through Hole": "tht",
 }
 
-# Target names that route to top-level ProviderProduct fields
-# instead of the parameters dict.
-_EXTRACT_FIELDS = frozenset({"package", "mounting"})
-
 
 def default_mapping() -> ProviderMappingConfig:
     """Return built-in DigiKey mapping defaults."""
@@ -204,7 +179,6 @@ def default_mapping() -> ProviderMappingConfig:
         supplier_name="DigiKey",
         categories=dict(CATEGORY_MAP),
         parameters=dict(PARAMETER_MAP),
-        ignore_parameters=list(IGNORE_PARAMETERS),
         mounting=dict(MOUNTING_MAP),
     )
 
@@ -264,13 +238,11 @@ def _map_product(
     description_obj = product.get("Description", {})
     manufacturer_obj = product.get("Manufacturer", {})
 
-    ignore = set(mapping.ignore_parameters)
-
     # Pipeline: normalise parameter names, then route.
     #   "package"      --> product.package
     #   "mounting"     --> product.mounting (value normalised via mapping.mounting)
-    #   in ignore set  --> dropped
-    #   anything else  --> product.parameters[target]
+    #   mapped target  --> product.parameters[target]
+    #   not in map     --> dropped (whitelist approach)
     parameters: dict[str, str] = {}
     package: str | None = None
     mounting: str | None = None
@@ -281,16 +253,16 @@ def _map_product(
         if not raw_name or not value:
             continue
 
-        # 1. Normalise name
-        target = mapping.parameters.get(raw_name, raw_name)
+        # Only keep parameters that are explicitly mapped
+        target = mapping.parameters.get(raw_name)
+        if target is None:
+            continue
 
-        # 2. Route
+        # Route to the right destination
         if target == "package":
             package = value
         elif target == "mounting":
             mounting = value
-        elif target in ignore:
-            continue
         else:
             parameters[target] = value
 

--- a/src/kist/providers/models.py
+++ b/src/kist/providers/models.py
@@ -5,20 +5,51 @@ from __future__ import annotations
 from pydantic import BaseModel
 
 
-class DigiKeyProduct(BaseModel):
+class ProviderMappingConfig(BaseModel):
     """
-    Normalised product data from the DigiKey v4 API.
+    Mapping configuration for a supplier provider.
+
+    Controls how raw API responses are translated into ProviderProduct
+    fields. Built-in defaults ship with each provider module; users can
+    override via TOML in the config directory.
+
+    The ``parameters`` dict maps raw API parameter names to normalised
+    target names. Target names determine routing:
+
+    - ``"package"`` and ``"mounting"`` are extracted to top-level
+      ProviderProduct fields (and excluded from the parameters dict).
+    - All other targets land in ``ProviderProduct.parameters``.
+    - Unmapped parameters pass through with their raw name.
+
+    The ``ignore_parameters`` list contains normalised target names
+    that should be dropped entirely (checked after normalisation).
+
+    The ``mounting`` dict normalises raw mounting values to canonical
+    strings (e.g. ``"Surface Mount"`` --> ``"smd"``).
+    """
+
+    supplier_name: str = ""
+    categories: dict[str, str] = {}
+    parameters: dict[str, str] = {}
+    ignore_parameters: list[str] = []
+    mounting: dict[str, str] = {}
+
+
+class ProviderProduct(BaseModel):
+    """
+    Normalised product data from a supplier API.
 
     Fields are mapped from the raw API response so downstream code
-    (TUI, part creation) doesn't depend on DigiKey's schema directly.
+    (TUI, part creation) doesn't depend on any provider's schema.
     """
 
     mpn: str
     manufacturer: str
     description: str
     detailed_description: str
-    digikey_pn: str
-    digikey_url: str | None = None
+    supplier_name: str
+    supplier_sku: str
+    supplier_url: str | None = None
     datasheet_url: str | None = None
     category: str | None = None
     parameters: dict[str, str] = {}

--- a/src/kist/providers/models.py
+++ b/src/kist/providers/models.py
@@ -14,15 +14,13 @@ class ProviderMappingConfig(BaseModel):
     override via TOML in the config directory.
 
     The ``parameters`` dict maps raw API parameter names to normalised
-    target names. Target names determine routing:
+    target names.  Only mapped parameters are kept (whitelist approach).
+    Target names determine routing:
 
     - ``"package"`` and ``"mounting"`` are extracted to top-level
       ProviderProduct fields (and excluded from the parameters dict).
     - All other targets land in ``ProviderProduct.parameters``.
-    - Unmapped parameters pass through with their raw name.
-
-    The ``ignore_parameters`` list contains normalised target names
-    that should be dropped entirely (checked after normalisation).
+    - Parameters not in the map are dropped.
 
     The ``mounting`` dict normalises raw mounting values to canonical
     strings (e.g. ``"Surface Mount"`` --> ``"smd"``).
@@ -31,7 +29,6 @@ class ProviderMappingConfig(BaseModel):
     supplier_name: str = ""
     categories: dict[str, str] = {}
     parameters: dict[str, str] = {}
-    ignore_parameters: list[str] = []
     mounting: dict[str, str] = {}
 
 

--- a/src/kist/tui/__init__.py
+++ b/src/kist/tui/__init__.py
@@ -1,0 +1,1 @@
+"""Kist terminal user interface."""

--- a/src/kist/tui/app.py
+++ b/src/kist/tui/app.py
@@ -58,7 +58,8 @@ class KistApp(App):
 
     def _discover_library(self) -> None:
         try:
-            self.library_path = find_library()
+            result = find_library()
+            self.library_path = result.library_root
         except LibraryNotFoundError:
             self.library_path = None
 

--- a/src/kist/tui/app.py
+++ b/src/kist/tui/app.py
@@ -13,7 +13,7 @@ from textual.screen import Screen
 from kist.core.config import load_global_config
 from kist.core.library import find_library
 from kist.errors import LibraryNotFoundError
-from kist.tui.themes import KIST_DARK
+from kist.tui.themes import NULL_THEME
 
 
 class KistApp(App):
@@ -43,13 +43,13 @@ class KistApp(App):
         return BrowseScreen()
 
     def on_mount(self) -> None:
-        self.register_theme(KIST_DARK)
+        self.register_theme(NULL_THEME)
         # Apply saved theme from global config
         global_cfg = load_global_config()
         if global_cfg.theme in self.available_themes:
             self.theme = global_cfg.theme
         else:
-            self.theme = "kist-dark"
+            self.theme = "null"
         self._discover_library()
         if self._start_screen == "add":
             from kist.tui.screens.add import AddScreen

--- a/src/kist/tui/app.py
+++ b/src/kist/tui/app.py
@@ -1,0 +1,91 @@
+"""Kist TUI application."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from textual.app import App, SystemCommand
+from textual.content import Content
+from textual.reactive import reactive
+from textual.screen import Screen
+
+from kist.core.library import find_library
+from kist.errors import LibraryNotFoundError
+from kist.tui.themes import KIST_DARK
+
+
+class KistApp(App):
+    """Terminal interface for managing a kist parts library."""
+
+    CSS_PATH = "kist.tcss"
+    ENABLE_COMMAND_PALETTE = True
+
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+    ]
+
+    library_path: reactive[Path | None] = reactive(None)
+
+    def __init__(
+        self,
+        start_screen: str | None = None,
+        url_or_mpn: str | None = None,
+    ) -> None:
+        super().__init__()
+        self._start_screen = start_screen
+        self._url_or_mpn = url_or_mpn
+
+    def get_default_screen(self) -> Screen:
+        from kist.tui.screens.browse import BrowseScreen
+
+        return BrowseScreen()
+
+    def on_mount(self) -> None:
+        self.register_theme(KIST_DARK)
+        self.theme = "kist-dark"
+        self._discover_library()
+        if self._start_screen == "add":
+            from kist.tui.screens.add import AddScreen
+
+            self.push_screen(AddScreen(url_or_mpn=self._url_or_mpn))
+
+    def _discover_library(self) -> None:
+        try:
+            self.library_path = find_library()
+        except LibraryNotFoundError:
+            self.library_path = None
+
+    def format_title(self, title: str, sub_title: str) -> Content:
+        """
+        Format title with ` -- ` separator instead of unicode em-dash.
+        """
+        if sub_title:
+            return Content.assemble(
+                title,
+                (" -- ", "dim"),
+                (sub_title, "dim"),
+            )
+        return Content(title)
+
+    def get_system_commands(self, screen: Screen) -> Iterable[SystemCommand]:
+        yield from super().get_system_commands(screen)
+        yield SystemCommand(
+            "Add part",
+            "Add a new part to the library",
+            self._push_add_screen,
+        )
+
+    def _push_add_screen(self) -> None:
+        from kist.tui.screens.add import AddScreen
+
+        self.push_screen(AddScreen())
+
+
+def run_tui(
+    start_screen: str | None = None,
+    url_or_mpn: str | None = None,
+) -> None:
+    """Entry point for launching the TUI from the CLI."""
+    app = KistApp(start_screen=start_screen, url_or_mpn=url_or_mpn)
+    app.run()

--- a/src/kist/tui/app.py
+++ b/src/kist/tui/app.py
@@ -10,9 +10,16 @@ from textual.content import Content
 from textual.reactive import reactive
 from textual.screen import Screen
 
+from kist.core.check import check_library
 from kist.core.config import load_global_config
+from kist.core.config import load_library_config as _load_library_config
+from kist.core.config import save_library_config as _save_library_config
+from kist.core.database import PartsDatabase
 from kist.core.library import find_library
+from kist.core.sync import sync_symbols
 from kist.errors import LibraryNotFoundError
+from kist.models.config import LibraryConfig
+from kist.models.part import Ipn, Part
 from kist.tui.themes import NULL_THEME
 
 
@@ -27,6 +34,8 @@ class KistApp(App):
     ]
 
     library_path: reactive[Path | None] = reactive(None)
+    library_config: reactive[LibraryConfig | None] = reactive(None)
+    parts_version: reactive[int] = reactive(0)
 
     def __init__(
         self,
@@ -60,8 +69,43 @@ class KistApp(App):
         try:
             result = find_library()
             self.library_path = result.library_root
+            self.library_config = _load_library_config(result.library_root)
         except LibraryNotFoundError:
             self.library_path = None
+            self.library_config = None
+
+    # -- Mutation methods ---
+
+    def save_part(self, part: Part, replacing: Ipn | None = None) -> None:
+        """Persist a part and run the post-mutation pipeline."""
+        assert self.library_path is not None
+        db = PartsDatabase(self.library_path / "parts.json")
+        db.load()
+        if replacing:
+            db.remove(replacing)
+        db.add(part)
+        self._after_mutation(db)
+
+    def delete_part(self, ipn: Ipn) -> None:
+        """Remove a part and run the post-mutation pipeline."""
+        assert self.library_path is not None
+        db = PartsDatabase(self.library_path / "parts.json")
+        db.load()
+        db.remove(ipn)
+        self._after_mutation(db)
+
+    def update_library_config(self, config: LibraryConfig) -> None:
+        """Save library config to disk and update the reactive attribute."""
+        assert self.library_path is not None
+        _save_library_config(self.library_path, config)
+        self.library_config = config
+
+    def _after_mutation(self, db: PartsDatabase) -> None:
+        """Post-mutation side effects: sync, UI refresh."""
+        assert self.library_path is not None
+        if self.library_config:
+            sync_symbols(self.library_path, db, self.library_config)
+        self.parts_version += 1
 
     def format_title(self, title: str, sub_title: str) -> Content:
         """
@@ -123,30 +167,21 @@ class KistApp(App):
             self.push_screen(CategoryManagerModal(self.library_path))
 
     def _run_check(self) -> None:
-        from kist.core.check import check_library
-        from kist.core.config import load_library_config
-        from kist.core.database import PartsDatabase
         from kist.tui.modals.check import LibraryCheckModal
 
-        if not self.library_path:
+        if not self.library_path or not self.library_config:
             return
-        config = load_library_config(self.library_path)
         db = PartsDatabase(self.library_path / "parts.json")
         db.load()
-        issues = check_library(db, config)
+        issues = check_library(db, self.library_config)
         self.push_screen(LibraryCheckModal(issues))
 
     def _run_sync(self) -> None:
-        from kist.core.config import load_library_config
-        from kist.core.database import PartsDatabase
-        from kist.core.sync import sync_symbols
-
-        if not self.library_path:
+        if not self.library_path or not self.library_config:
             return
-        config = load_library_config(self.library_path)
         db = PartsDatabase(self.library_path / "parts.json")
         db.load()
-        sync_symbols(self.library_path, db, config)
+        sync_symbols(self.library_path, db, self.library_config)
         count = len(db.list_parts())
         self.notify(f"Synced {count} part{'s' if count != 1 else ''} to KiCad")
 

--- a/src/kist/tui/app.py
+++ b/src/kist/tui/app.py
@@ -10,6 +10,7 @@ from textual.content import Content
 from textual.reactive import reactive
 from textual.screen import Screen
 
+from kist.core.config import load_global_config
 from kist.core.library import find_library
 from kist.errors import LibraryNotFoundError
 from kist.tui.themes import KIST_DARK
@@ -43,7 +44,12 @@ class KistApp(App):
 
     def on_mount(self) -> None:
         self.register_theme(KIST_DARK)
-        self.theme = "kist-dark"
+        # Apply saved theme from global config
+        global_cfg = load_global_config()
+        if global_cfg.theme in self.available_themes:
+            self.theme = global_cfg.theme
+        else:
+            self.theme = "kist-dark"
         self._discover_library()
         if self._start_screen == "add":
             from kist.tui.screens.add import AddScreen
@@ -75,11 +81,73 @@ class KistApp(App):
             "Add a new part to the library",
             self._push_add_screen,
         )
+        yield SystemCommand(
+            "Settings",
+            "Open settings",
+            self._push_settings,
+        )
+        if self.library_path:
+            yield SystemCommand(
+                "Sync to KiCad",
+                "Push parts database to .kicad_sym files",
+                self._run_sync,
+            )
+            yield SystemCommand(
+                "Check library",
+                "Validate part names and check for duplicates",
+                self._run_check,
+            )
+            yield SystemCommand(
+                "Manage categories",
+                "Add, edit, or delete category definitions",
+                self._push_category_manager,
+            )
+
+    # -- Command handlers ---
 
     def _push_add_screen(self) -> None:
         from kist.tui.screens.add import AddScreen
 
         self.push_screen(AddScreen())
+
+    def _push_settings(self) -> None:
+        from kist.tui.modals.settings import SettingsModal
+
+        self.push_screen(SettingsModal(self.library_path))
+
+    def _push_category_manager(self) -> None:
+        from kist.tui.modals.categories import CategoryManagerModal
+
+        if self.library_path:
+            self.push_screen(CategoryManagerModal(self.library_path))
+
+    def _run_check(self) -> None:
+        from kist.core.check import check_library
+        from kist.core.config import load_library_config
+        from kist.core.database import PartsDatabase
+        from kist.tui.modals.check import LibraryCheckModal
+
+        if not self.library_path:
+            return
+        config = load_library_config(self.library_path)
+        db = PartsDatabase(self.library_path / "parts.json")
+        db.load()
+        issues = check_library(db, config)
+        self.push_screen(LibraryCheckModal(issues))
+
+    def _run_sync(self) -> None:
+        from kist.core.config import load_library_config
+        from kist.core.database import PartsDatabase
+        from kist.core.sync import sync_symbols
+
+        if not self.library_path:
+            return
+        config = load_library_config(self.library_path)
+        db = PartsDatabase(self.library_path / "parts.json")
+        db.load()
+        sync_symbols(self.library_path, db, config)
+        count = len(db.list_parts())
+        self.notify(f"Synced {count} part{'s' if count != 1 else ''} to KiCad")
 
 
 def run_tui(

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -52,3 +52,191 @@ Screen {
 .module-container:focus-within {
     border: round $accent;
 }
+
+/* -- Compact form widgets (Posting-style) --- */
+
+PartForm {
+    & Input {
+        padding: 0 1;
+        height: 1;
+        border: none;
+        &:focus {
+            padding-left: 0;
+            border-left: outer $surface-lighten-1;
+        }
+    }
+    & Select {
+        height: 1;
+        border: none;
+        padding: 0;
+        & SelectCurrent {
+            height: 1;
+            border: none;
+            padding: 0 1;
+        }
+    }
+    & Button {
+        padding: 0 1;
+        height: 1;
+        border: none;
+        min-width: 0;
+    }
+    & Checkbox {
+        height: 1;
+        padding: 0 1;
+        border: none;
+    }
+}
+
+/* -- PartForm layout --- */
+
+.form-field {
+    height: 1;
+    margin: 0 1;
+}
+
+.field-label {
+    width: 16;
+    padding: 0 1 0 0;
+    text-align: right;
+    text-opacity: 70%;
+}
+
+.field-value {
+    width: 1fr;
+}
+
+.field-value-ro {
+    width: 1fr;
+    padding: 0;
+}
+
+.section {
+    border: round $accent 40%;
+    border-title-color: $text-accent 50%;
+    border-title-align: right;
+    height: auto;
+    margin: 1 0 0 0;
+    padding: 0 1;
+    &:focus-within {
+        border: round $accent 100%;
+        border-title-color: $foreground;
+        border-title-style: bold;
+    }
+}
+
+.form-actions {
+    margin: 1 1;
+    height: auto;
+}
+
+.empty-message {
+    width: 1fr;
+    height: 1fr;
+    content-align: center middle;
+    text-opacity: 40%;
+    hatch: right $surface-lighten-1 70%;
+}
+
+.spacer {
+    height: 1;
+}
+
+#notes {
+    height: 1fr;
+}
+
+/* -- PartForm grid: 2x2 layout --- */
+
+#form-top {
+    height: 1fr;
+}
+
+#form-bottom {
+    height: 1fr;
+}
+
+#section-general {
+    width: 1fr;
+    height: 1fr;
+    overflow-y: auto;
+}
+
+#section-supplier {
+    width: 1fr;
+    height: 1fr;
+}
+
+#section-kicad {
+    width: 1fr;
+    height: 1fr;
+}
+
+#section-specs {
+    width: 1fr;
+    height: 1fr;
+}
+
+
+#specs-table {
+    height: auto;
+    width: 1fr;
+    margin: 0 2;
+    &:focus {
+        margin: 0 1 0 0;
+        border-left: inner $accent;
+    }
+}
+
+#specs-actions {
+    dock: bottom;
+    height: 1;
+    & Input {
+        width: 1fr;
+        margin: 0 1;
+    }
+    & Button {
+        background: $accent;
+        color: $text;
+        text-style: none;
+        width: auto;
+        margin: 0 3 0 0;
+        padding: 0 2;
+        &:hover {
+            text-style: bold;
+        }
+    }
+}
+
+/* -- Suppliers table --- */
+
+#suppliers-table {
+    height: auto;
+    width: 1fr;
+    margin: 0 1;
+    &:focus {
+        margin: 0 0 0 0;
+        border-left: inner $accent;
+    }
+}
+
+#suppliers-actions {
+    dock: bottom;
+    height: 1;
+    & Input {
+        width: 1fr;
+        margin: 0 1;
+    }
+    & Button {
+        background: $accent;
+        color: $text;
+        text-style: none;
+        width: auto;
+        margin: 0 1 0 0;
+        padding: 0 2;
+        &:hover {
+            text-style: bold;
+        }
+    }
+}
+

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -332,6 +332,33 @@ CategoryFormModal {
     margin: 1 0 0 0;
 }
 
+/* -- Category manager modal --- */
+
+CategoryManagerModal {
+    align: center middle;
+}
+
+#catmgr-container {
+    width: 90%;
+    max-width: 100;
+    height: 80%;
+    border: round $accent;
+    border-title-color: $foreground;
+    border-title-style: bold;
+    background: $surface;
+    padding: 1 2;
+}
+
+#catmgr-title {
+    text-style: bold;
+    margin: 0 0 1 0;
+}
+
+#catmgr-table {
+    height: 1fr;
+    width: 1fr;
+}
+
 /* -- Check modal --- */
 
 LibraryCheckModal {

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -81,7 +81,7 @@ Screen {
 
 /* -- Compact form widgets (Posting-style) --- */
 
-PartForm, CategoryFormModal {
+PartForm, CategoryFormModal, SettingsModal {
     & Input {
         padding: 0 1;
         height: 1;
@@ -327,6 +327,37 @@ CategoryFormModal {
 }
 
 #catform-buttons {
+    height: auto;
+    align: right middle;
+    margin: 1 0 0 0;
+}
+
+/* -- Settings modal --- */
+
+SettingsModal {
+    align: center middle;
+}
+
+#settings-container {
+    width: 70;
+    max-height: 85%;
+    border: round $accent;
+    border-title-color: $foreground;
+    border-title-style: bold;
+    background: $surface;
+    padding: 1 2;
+}
+
+#settings-title {
+    text-style: bold;
+    margin: 0 0 1 0;
+}
+
+#settings-scroll {
+    height: 1fr;
+}
+
+#settings-buttons {
     height: auto;
     align: right middle;
     margin: 1 0 0 0;

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -1,0 +1,18 @@
+Screen {
+    background: $background;
+}
+
+#placeholder {
+    width: 100%;
+    height: 1fr;
+    content-align: center middle;
+    text-opacity: 60%;
+}
+
+.module-container {
+    border: round $panel;
+}
+
+.module-container:focus-within {
+    border: round $accent;
+}

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -273,6 +273,46 @@ PartForm {
     }
 }
 
+/* -- Check modal --- */
+
+LibraryCheckModal {
+    align: center middle;
+}
+
+#check-container {
+    width: 80%;
+    max-width: 90;
+    max-height: 80%;
+    border: round $accent;
+    border-title-color: $foreground;
+    border-title-style: bold;
+    background: $surface;
+    padding: 1 2;
+}
+
+#check-header {
+    width: 1fr;
+    text-style: bold;
+    margin: 0 0 1 0;
+}
+
+#check-results {
+    height: auto;
+    max-height: 100%;
+}
+
+.check-kind {
+    color: $warning;
+    padding: 0 0 0 2;
+}
+
+.check-detail {
+    padding: 0 0 0 4;
+    margin: 0 0 1 0;
+    text-opacity: 80%;
+    text-overflow: fold;
+}
+
 /* -- Detail modal --- */
 
 DetailModal {

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -273,3 +273,19 @@ PartForm {
     }
 }
 
+/* -- Detail modal --- */
+
+DetailModal {
+    align: center middle;
+}
+
+#detail-container {
+    width: 90%;
+    height: 90%;
+    border: round $accent;
+    border-title-color: $foreground;
+    border-title-style: bold;
+    background: $surface;
+    padding: 0 1;
+}
+

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -289,3 +289,31 @@ DetailModal {
     padding: 0 1;
 }
 
+/* -- Confirm modal --- */
+
+ConfirmModal {
+    align: center middle;
+}
+
+#confirm-container {
+    width: 50;
+    height: auto;
+    border: round $accent;
+    background: $surface;
+    padding: 1 2;
+}
+
+#confirm-message {
+    width: 1fr;
+    content-align: center middle;
+    margin: 0 0 1 0;
+}
+
+#confirm-buttons {
+    height: auto;
+    align: center middle;
+    & Button {
+        margin: 0 1;
+    }
+}
+

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -81,7 +81,7 @@ Screen {
 
 /* -- Compact form widgets (Posting-style) --- */
 
-PartForm {
+PartForm, CategoryFormModal {
     & Input {
         padding: 0 1;
         height: 1;
@@ -271,6 +271,65 @@ PartForm {
             text-style: bold;
         }
     }
+}
+
+/* -- Category form modal --- */
+
+CategoryFormModal {
+    align: center middle;
+}
+
+#catform-container {
+    width: 70;
+    max-height: 85%;
+    border: round $accent;
+    border-title-color: $foreground;
+    border-title-style: bold;
+    background: $surface;
+    padding: 1 2;
+}
+
+#catform-title {
+    text-style: bold;
+    margin: 0 0 1 0;
+}
+
+#catform-scroll {
+    height: auto;
+    max-height: 100%;
+}
+
+#section-subcategories {
+    height: 1fr;
+    overflow-y: auto;
+}
+
+#subcat-table {
+    height: auto;
+    width: 1fr;
+    margin: 0 1;
+    &:focus {
+        margin: 0 0 0 0;
+        border-left: inner $accent;
+    }
+}
+
+#subcat-actions {
+    dock: bottom;
+    height: 1;
+    margin: 0 1;
+    & Input {
+        width: 1fr;
+    }
+    & Button {
+        width: auto;
+    }
+}
+
+#catform-buttons {
+    height: auto;
+    align: right middle;
+    margin: 1 0 0 0;
 }
 
 /* -- Check modal --- */

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -79,13 +79,6 @@ Screen {
     }
 }
 
-#loading-indicator {
-    width: 100%;
-    height: 1fr;
-    content-align: center middle;
-    text-opacity: 60%;
-}
-
 /* -- Compact form widgets (Posting-style) --- */
 
 PartForm {

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -114,6 +114,10 @@ PartForm {
     }
 }
 
+PartForm {
+    height: 1fr;
+}
+
 /* -- PartForm layout --- */
 
 .form-field {
@@ -191,16 +195,19 @@ PartForm {
 #section-supplier {
     width: 1fr;
     height: 1fr;
+    overflow-y: auto;
 }
 
 #section-kicad {
     width: 1fr;
     height: 1fr;
+    overflow-y: auto;
 }
 
 #section-specs {
     width: 1fr;
     height: 1fr;
+    overflow-y: auto;
 }
 
 

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -2,7 +2,43 @@ Screen {
     background: $background;
 }
 
-#placeholder {
+#sidebar {
+    width: 25;
+    height: 1fr;
+    border: none;
+    border-right: tall $panel;
+    background: transparent;
+    padding: 0 1;
+    &:focus {
+        border: none;
+        border-right: tall $panel;
+        background-tint: $foreground 5%;
+    }
+}
+
+#main-panel {
+    width: 1fr;
+    height: 1fr;
+    padding: 0 1 0 0;
+}
+
+#search {
+    dock: top;
+    height: 3;
+    border: tall $panel;
+    background: transparent;
+    margin: 1 1 1 1;
+    padding: 0 1;
+    &:focus {
+        border: tall $border;
+    }
+}
+
+#parts-table {
+    margin: 0 2;
+}
+
+#empty-state {
     width: 100%;
     height: 1fr;
     content-align: center middle;

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -53,6 +53,39 @@ Screen {
     border: round $accent;
 }
 
+/* -- Add screen URL bar and loading --- */
+
+#url-bar {
+    height: 1;
+    margin: 1 1 0 1;
+}
+
+#url-label {
+    width: 16;
+    text-align: right;
+    padding: 0 1 0 0;
+    text-opacity: 70%;
+}
+
+#url-input {
+    width: 1fr;
+    height: 1;
+    border: none;
+    background: transparent;
+    padding: 0 1;
+    &:focus {
+        padding-left: 0;
+        border-left: outer $surface-lighten-1;
+    }
+}
+
+#loading-indicator {
+    width: 100%;
+    height: 1fr;
+    content-align: center middle;
+    text-opacity: 60%;
+}
+
 /* -- Compact form widgets (Posting-style) --- */
 
 PartForm {

--- a/src/kist/tui/modals/__init__.py
+++ b/src/kist/tui/modals/__init__.py
@@ -1,0 +1,1 @@
+"""Modal screens for the kist TUI."""

--- a/src/kist/tui/modals/categories.py
+++ b/src/kist/tui/modals/categories.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, DataTable, Input, Label, Select
 
+from kist.core.config import load_library_config, save_library_config
+from kist.core.database import PartsDatabase
 from kist.models.config import CategoryDef
 
 # Symbol templates that ship with kist
@@ -226,3 +230,114 @@ class CategoryFormModal(ModalScreen[tuple[str, CategoryDef] | None]):
 
     def action_cancel(self) -> None:
         self.dismiss(None)
+
+
+class CategoryManagerModal(ModalScreen):
+    """
+    Table of all library categories with CRUD operations.
+
+    Changes are saved immediately to ``.kist/config.toml``.
+    """
+
+    BINDINGS = [
+        Binding("escape", "close", "Close"),
+        Binding("a", "add", "Add"),
+        Binding("e", "edit", "Edit"),
+        Binding("d", "delete", "Delete"),
+    ]
+
+    def __init__(self, library_path: Path) -> None:
+        super().__init__()
+        self._library_path = library_path
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="catmgr-container"):
+            yield Label("Categories", id="catmgr-title")
+            yield DataTable(id="catmgr-table")
+
+    def on_mount(self) -> None:
+        table = self.query_one("#catmgr-table", DataTable)
+        table.add_columns("Code", "Name", "RefDes", "Key Specs", "Template")
+        table.cursor_type = "row"
+        table.zebra_stripes = True
+        self._reload_table()
+
+    def _reload_table(self) -> None:
+        """Reload category data from the library config."""
+        table = self.query_one("#catmgr-table", DataTable)
+        table.clear()
+        config = load_library_config(self._library_path)
+        for code, cat in config.categories.items():
+            specs = ", ".join(cat.key_specs) if cat.key_specs else ""
+            template = cat.symbol_template or ""
+            table.add_row(code, cat.name, cat.refdes, specs, template, key=code)
+
+    def _selected_code(self) -> str | None:
+        """Return the category code of the currently selected row."""
+        table = self.query_one("#catmgr-table", DataTable)
+        if table.row_count == 0:
+            return None
+        row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
+        return str(row_key.value)
+
+    # -- Actions ---
+
+    def action_add(self) -> None:
+        self.app.push_screen(
+            CategoryFormModal(),
+            callback=self._on_form_result,
+        )
+
+    def action_edit(self) -> None:
+        code = self._selected_code()
+        if not code:
+            return
+        config = load_library_config(self._library_path)
+        cat = config.categories.get(code)
+        if not cat:
+            return
+        self.app.push_screen(
+            CategoryFormModal(edit=(code, cat)),
+            callback=self._on_form_result,
+        )
+
+    def _on_form_result(self, result: tuple[str, CategoryDef] | None) -> None:
+        if result is None:
+            return
+        code, cat_def = result
+        config = load_library_config(self._library_path)
+        config.categories[code] = cat_def
+        save_library_config(self._library_path, config)
+        self._reload_table()
+
+    def action_delete(self) -> None:
+        code = self._selected_code()
+        if not code:
+            return
+
+        # Warn if parts exist in this category
+        db = PartsDatabase(self._library_path / "parts.json")
+        db.load()
+        count = sum(1 for p in db.list_parts() if p.category == code)
+        if count:
+            msg = f"Delete {code}? {count} part{'s' if count != 1 else ''} use this category."
+        else:
+            msg = f"Delete category {code}?"
+
+        from kist.tui.screens.detail import ConfirmModal
+
+        self.app.push_screen(
+            ConfirmModal(msg),
+            callback=lambda confirmed: self._on_delete_confirmed(confirmed, code),
+        )
+
+    def _on_delete_confirmed(self, confirmed: bool | None, code: str) -> None:
+        if not confirmed:
+            return
+        config = load_library_config(self._library_path)
+        config.categories.pop(code, None)
+        save_library_config(self._library_path, config)
+        self._reload_table()
+
+    def action_close(self) -> None:
+        self.dismiss()

--- a/src/kist/tui/modals/categories.py
+++ b/src/kist/tui/modals/categories.py
@@ -1,0 +1,228 @@
+"""Category form and manager modals."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, DataTable, Input, Label, Select
+
+from kist.models.config import CategoryDef
+
+# Symbol templates that ship with kist
+TEMPLATE_OPTIONS: list[tuple[str, str]] = [
+    ("None", ""),
+    ("Resistor", "resistor"),
+    ("Capacitor", "capacitor"),
+    ("Inductor", "inductor"),
+]
+
+
+class CategoryFormModal(ModalScreen[tuple[str, CategoryDef] | None]):
+    """
+    Form for creating or editing a single category definition.
+
+    Dismiss result: ``(code, CategoryDef)`` on save, ``None`` on cancel.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+        Binding("ctrl+s", "save", "Save"),
+    ]
+
+    def __init__(
+        self,
+        edit: tuple[str, CategoryDef] | None = None,
+    ) -> None:
+        super().__init__()
+        self._edit = edit
+
+    def compose(self) -> ComposeResult:
+        editing = self._edit is not None
+        title = "Edit Category" if editing else "New Category"
+
+        with Vertical(id="catform-container"):
+            yield Label(title, id="catform-title")
+            # Category fields
+            with Horizontal(classes="form-field"):
+                yield Label("Code", classes="field-label")
+                yield Input(
+                    id="cat-code",
+                    classes="field-value",
+                    placeholder="e.g. OPTO",
+                    disabled=editing,
+                )
+            with Horizontal(classes="form-field"):
+                yield Label("Name", classes="field-label")
+                yield Input(
+                    id="cat-name",
+                    classes="field-value",
+                    placeholder="e.g. Optocouplers",
+                )
+            with Horizontal(classes="form-field"):
+                yield Label("Ref Designator", classes="field-label")
+                yield Input(
+                    id="cat-refdes",
+                    classes="field-value",
+                    placeholder="e.g. U",
+                )
+            with Horizontal(classes="form-field"):
+                yield Label("Key Specs", classes="field-label")
+                yield Input(
+                    id="cat-keyspecs",
+                    classes="field-value",
+                    placeholder="Comma-separated spec names",
+                )
+            with Horizontal(classes="form-field"):
+                yield Label("Value Field", classes="field-label")
+                yield Input(
+                    id="cat-valuefield",
+                    classes="field-value",
+                    placeholder="Spec name for value generation",
+                )
+            with Horizontal(classes="form-field"):
+                yield Label("Template", classes="field-label")
+                yield Select(
+                    TEMPLATE_OPTIONS,
+                    id="cat-template",
+                    classes="field-value",
+                    prompt="Select template",
+                )
+
+            # Subcategories section -- fills remaining space
+            with Vertical(classes="section", id="section-subcategories"):
+                yield Label(
+                    "No subcategories", id="subcat-empty", classes="empty-message"
+                )
+                yield DataTable(id="subcat-table")
+                with Horizontal(id="subcat-actions"):
+                    yield Input(
+                        id="subcat-code",
+                        placeholder="Code",
+                        classes="field-value",
+                    )
+                    yield Input(
+                        id="subcat-name",
+                        placeholder="Name",
+                        classes="field-value",
+                    )
+                    yield Button("Add", id="add-subcat", variant="default")
+
+            # Action buttons
+            with Horizontal(id="catform-buttons"):
+                yield Button("Cancel", id="catform-cancel", variant="default")
+                yield Button(
+                    "Save" if editing else "Create",
+                    id="catform-save",
+                    variant="primary",
+                )
+
+    def on_mount(self) -> None:
+        self.query_one("#section-subcategories").border_title = "Subcategories"
+
+        table = self.query_one("#subcat-table", DataTable)
+        table.add_columns("Code", "Name")
+        table.show_header = True
+        table.cursor_type = "row"
+        table.display = False
+
+        if self._edit is not None:
+            code, cat = self._edit
+            self._populate_from_edit(code, cat)
+
+    def _populate_from_edit(self, code: str, cat: CategoryDef) -> None:
+        """Fill form fields from an existing CategoryDef."""
+        self.query_one("#cat-code", Input).value = code
+        self.query_one("#cat-name", Input).value = cat.name
+        self.query_one("#cat-refdes", Input).value = cat.refdes
+        self.query_one("#cat-keyspecs", Input).value = ", ".join(cat.key_specs)
+
+        if isinstance(cat.value_field, list):
+            self.query_one("#cat-valuefield", Input).value = ", ".join(cat.value_field)
+        elif cat.value_field:
+            self.query_one("#cat-valuefield", Input).value = cat.value_field
+
+        if cat.symbol_template:
+            self.query_one("#cat-template", Select).value = cat.symbol_template
+
+        for sub_code, sub_name in cat.subcategory_names.items():
+            self._add_subcat_to_table(sub_code, sub_name)
+
+    # -- Subcategory management ---
+
+    def _add_subcat_to_table(self, code: str, name: str) -> None:
+        table = self.query_one("#subcat-table", DataTable)
+        table.add_row(code, name)
+        self._update_subcat_empty()
+
+    def _update_subcat_empty(self) -> None:
+        table = self.query_one("#subcat-table", DataTable)
+        empty = table.row_count == 0
+        self.query_one("#subcat-empty").display = empty
+        table.display = not empty
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "add-subcat":
+            self._submit_subcat()
+        elif event.button.id == "catform-save":
+            self.action_save()
+        elif event.button.id == "catform-cancel":
+            self.action_cancel()
+
+    def _submit_subcat(self) -> None:
+        code_input = self.query_one("#subcat-code", Input)
+        name_input = self.query_one("#subcat-name", Input)
+        code = code_input.value.strip().upper()
+        name = name_input.value.strip()
+        if not code or not name:
+            return
+        self._add_subcat_to_table(code, name)
+        code_input.value = ""
+        name_input.value = ""
+        code_input.focus()
+
+    # -- Actions ---
+
+    def action_save(self) -> None:
+        code = self.query_one("#cat-code", Input).value.strip().upper()
+        name = self.query_one("#cat-name", Input).value.strip()
+        refdes = self.query_one("#cat-refdes", Input).value.strip()
+
+        if not code or not name or not refdes:
+            self.notify("Code, Name, and Ref Designator are required", severity="error")
+            return
+
+        key_specs_raw = self.query_one("#cat-keyspecs", Input).value.strip()
+        key_specs = [s.strip() for s in key_specs_raw.split(",") if s.strip()]
+
+        value_field_raw = self.query_one("#cat-valuefield", Input).value.strip()
+        value_field: str | list[str] | None = None
+        if value_field_raw:
+            parts = [s.strip() for s in value_field_raw.split(",") if s.strip()]
+            value_field = parts[0] if len(parts) == 1 else parts
+
+        template_val = self.query_one("#cat-template", Select).value
+        symbol_template = (
+            str(template_val) if template_val != Select.BLANK and template_val else None
+        )
+
+        # Collect subcategories from table
+        subcategory_names: dict[str, str] = {}
+        table = self.query_one("#subcat-table", DataTable)
+        for row_key in table.rows:
+            row = table.get_row(row_key)
+            subcategory_names[str(row[0])] = str(row[1])
+
+        cat_def = CategoryDef(
+            name=name,
+            refdes=refdes,
+            key_specs=key_specs,
+            subcategory_names=subcategory_names,
+            value_field=value_field,
+            symbol_template=symbol_template,
+        )
+        self.dismiss((code, cat_def))
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)

--- a/src/kist/tui/modals/categories.py
+++ b/src/kist/tui/modals/categories.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from textual import getters
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
@@ -13,6 +14,7 @@ from textual.widgets import Button, DataTable, Input, Label, Select
 from kist.core.config import load_library_config, save_library_config
 from kist.core.database import PartsDatabase
 from kist.models.config import CategoryDef
+from kist.tui.app import KistApp
 
 # Symbol templates that ship with kist
 TEMPLATE_OPTIONS: list[tuple[str, str]] = [
@@ -238,6 +240,8 @@ class CategoryManagerModal(ModalScreen):
 
     Changes are saved immediately to ``.kist/config.toml``.
     """
+
+    app = getters.app(KistApp)
 
     BINDINGS = [
         Binding("escape", "close", "Close"),

--- a/src/kist/tui/modals/categories.py
+++ b/src/kist/tui/modals/categories.py
@@ -11,7 +11,6 @@ from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, DataTable, Input, Label, Select
 
-from kist.core.config import load_library_config, save_library_config
 from kist.core.database import PartsDatabase
 from kist.models.config import CategoryDef
 from kist.tui.app import KistApp
@@ -270,7 +269,9 @@ class CategoryManagerModal(ModalScreen):
         """Reload category data from the library config."""
         table = self.query_one("#catmgr-table", DataTable)
         table.clear()
-        config = load_library_config(self._library_path)
+        config = self.app.library_config
+        if config is None:
+            return
         for code, cat in config.categories.items():
             specs = ", ".join(cat.key_specs) if cat.key_specs else ""
             template = cat.symbol_template or ""
@@ -296,7 +297,9 @@ class CategoryManagerModal(ModalScreen):
         code = self._selected_code()
         if not code:
             return
-        config = load_library_config(self._library_path)
+        config = self.app.library_config
+        if config is None:
+            return
         cat = config.categories.get(code)
         if not cat:
             return
@@ -309,9 +312,11 @@ class CategoryManagerModal(ModalScreen):
         if result is None:
             return
         code, cat_def = result
-        config = load_library_config(self._library_path)
+        config = self.app.library_config
+        if config is None:
+            return
         config.categories[code] = cat_def
-        save_library_config(self._library_path, config)
+        self.app.update_library_config(config)
         self._reload_table()
 
     def action_delete(self) -> None:
@@ -338,9 +343,11 @@ class CategoryManagerModal(ModalScreen):
     def _on_delete_confirmed(self, confirmed: bool | None, code: str) -> None:
         if not confirmed:
             return
-        config = load_library_config(self._library_path)
+        config = self.app.library_config
+        if config is None:
+            return
         config.categories.pop(code, None)
-        save_library_config(self._library_path, config)
+        self.app.update_library_config(config)
         self._reload_table()
 
     def action_close(self) -> None:

--- a/src/kist/tui/modals/check.py
+++ b/src/kist/tui/modals/check.py
@@ -1,0 +1,49 @@
+"""Library check results modal."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Label, Static
+
+from kist.core.check import CheckIssue
+
+ISSUE_LABELS: dict[str, str] = {
+    "name_drift": "Name drift",
+    "duplicate_identity": "Duplicate identity",
+}
+
+
+class LibraryCheckModal(ModalScreen):
+    """
+    Modal displaying library check results.
+
+    Shows a summary header and a scrollable list of issues.
+    """
+
+    BINDINGS = [
+        Binding("escape", "close", "Close"),
+    ]
+
+    def __init__(self, issues: list[CheckIssue]) -> None:
+        super().__init__()
+        self._issues = issues
+
+    def compose(self) -> ComposeResult:
+        n = len(self._issues)
+        header = f"{n} issue{'s' if n != 1 else ''} found" if n else "All clean"
+
+        with Vertical(id="check-container"):
+            yield Label(header, id="check-header")
+            with VerticalScroll(id="check-results"):
+                if not self._issues:
+                    yield Label("No issues found.", id="check-empty")
+                for issue in self._issues:
+                    kind_label = ISSUE_LABELS.get(issue.kind, issue.kind)
+                    yield Label(f"! {kind_label}", classes="check-kind")
+                    yield Static(issue.message, classes="check-detail")
+
+    def action_close(self) -> None:
+        self.dismiss()

--- a/src/kist/tui/modals/settings.py
+++ b/src/kist/tui/modals/settings.py
@@ -11,12 +11,7 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, Select
 
-from kist.core.config import (
-    load_global_config,
-    load_library_config,
-    save_global_config,
-    save_library_config,
-)
+from kist.core.config import load_global_config, save_global_config
 from kist.tui.app import KistApp
 
 
@@ -133,11 +128,11 @@ class SettingsModal(ModalScreen):
         global_cfg = load_global_config()
         self.query_one("#setting-theme", Select).value = global_cfg.theme
 
-        if self._library_path is not None:
+        lib_cfg = self.app.library_config
+        if self._library_path is not None and lib_cfg is not None:
             self.query_one("#section-library").border_title = "Library"
             self.query_one("#section-directories").border_title = "Directories"
 
-            lib_cfg = load_library_config(self._library_path)
             self.query_one("#setting-prefix", Input).value = lib_cfg.library_prefix
             self.query_one("#setting-separator", Input).value = lib_cfg.separator
             self.query_one("#setting-suppliers", Input).value = ", ".join(
@@ -174,8 +169,8 @@ class SettingsModal(ModalScreen):
         save_global_config(global_cfg)
 
         # Save library fields if a library is open
-        if self._library_path is not None:
-            lib_cfg = load_library_config(self._library_path)
+        lib_cfg = self.app.library_config
+        if self._library_path is not None and lib_cfg is not None:
             lib_cfg.library_prefix = self.query_one(
                 "#setting-prefix", Input
             ).value.strip()
@@ -195,7 +190,7 @@ class SettingsModal(ModalScreen):
             lib_cfg.models_dir = self.query_one(
                 "#setting-models-dir", Input
             ).value.strip()
-            save_library_config(self._library_path, lib_cfg)
+            self.app.update_library_config(lib_cfg)
 
         self._previous_theme = self.app.theme or "null"
         self.dismiss()

--- a/src/kist/tui/modals/settings.py
+++ b/src/kist/tui/modals/settings.py
@@ -1,0 +1,201 @@
+"""Settings modal -- user preferences and library configuration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, Select
+
+from kist.core.config import (
+    load_global_config,
+    load_library_config,
+    save_global_config,
+    save_library_config,
+)
+
+
+def _theme_options() -> list[tuple[str, str]]:
+    """Build select options from Textual's registered themes."""
+    # Textual ships built-in themes; we add kist-dark alongside them.
+    # The full list is discovered at runtime from the app, but for the
+    # select widget we use a curated list of well-known themes.
+    return [
+        ("kist-dark", "kist-dark"),
+        ("textual-dark", "textual-dark"),
+        ("textual-light", "textual-light"),
+        ("nord", "nord"),
+        ("gruvbox", "gruvbox"),
+        ("catppuccin-mocha", "catppuccin-mocha"),
+        ("dracula", "dracula"),
+        ("tokyo-night", "tokyo-night"),
+        ("monokai", "monokai"),
+        ("flexoki", "flexoki"),
+        ("catppuccin-latte", "catppuccin-latte"),
+        ("solarized-light", "solarized-light"),
+    ]
+
+
+class SettingsModal(ModalScreen):
+    """
+    Scrollable settings form with appearance and library configuration.
+
+    Theme changes apply immediately as a live preview. Cancel reverts
+    the theme to its previous value.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+        Binding("ctrl+s", "save", "Save"),
+    ]
+
+    def __init__(self, library_path: Path | None = None) -> None:
+        super().__init__()
+        self._library_path = library_path
+        self._previous_theme: str = ""
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="settings-container"):
+            yield Label("Settings", id="settings-title")
+            with VerticalScroll(id="settings-scroll"):
+                # Appearance section
+                with Vertical(classes="section", id="section-appearance"):
+                    with Horizontal(classes="form-field"):
+                        yield Label("Theme", classes="field-label")
+                        yield Select(
+                            _theme_options(),
+                            id="setting-theme",
+                            classes="field-value",
+                            prompt="Select theme",
+                        )
+
+                # Library section (only when a library is open)
+                if self._library_path is not None:
+                    with Vertical(classes="section", id="section-library"):
+                        with Horizontal(classes="form-field"):
+                            yield Label("Prefix", classes="field-label")
+                            yield Input(
+                                id="setting-prefix",
+                                classes="field-value",
+                            )
+                        with Horizontal(classes="form-field"):
+                            yield Label("Separator", classes="field-label")
+                            yield Input(
+                                id="setting-separator",
+                                classes="field-value",
+                            )
+                        with Horizontal(classes="form-field"):
+                            yield Label("Suppliers", classes="field-label")
+                            yield Input(
+                                id="setting-suppliers",
+                                classes="field-value",
+                                placeholder="Comma-separated",
+                            )
+
+                    # Directories section
+                    with Vertical(classes="section", id="section-directories"):
+                        with Horizontal(classes="form-field"):
+                            yield Label("Symbols", classes="field-label")
+                            yield Input(
+                                id="setting-symbols-dir",
+                                classes="field-value",
+                            )
+                        with Horizontal(classes="form-field"):
+                            yield Label("Footprints", classes="field-label")
+                            yield Input(
+                                id="setting-footprints-dir",
+                                classes="field-value",
+                            )
+                        with Horizontal(classes="form-field"):
+                            yield Label("3D Models", classes="field-label")
+                            yield Input(
+                                id="setting-models-dir",
+                                classes="field-value",
+                            )
+
+            # Action buttons
+            with Horizontal(id="settings-buttons"):
+                yield Button("Cancel", id="settings-cancel", variant="default")
+                yield Button("Save", id="settings-save", variant="primary")
+
+    def on_mount(self) -> None:
+        self.query_one("#section-appearance").border_title = "Appearance"
+
+        # Load current values
+        self._previous_theme = self.app.theme or "kist-dark"
+        global_cfg = load_global_config()
+        self.query_one("#setting-theme", Select).value = global_cfg.theme
+
+        if self._library_path is not None:
+            self.query_one("#section-library").border_title = "Library"
+            self.query_one("#section-directories").border_title = "Directories"
+
+            lib_cfg = load_library_config(self._library_path)
+            self.query_one("#setting-prefix", Input).value = lib_cfg.library_prefix
+            self.query_one("#setting-separator", Input).value = lib_cfg.separator
+            self.query_one("#setting-suppliers", Input).value = ", ".join(
+                lib_cfg.suppliers
+            )
+            self.query_one("#setting-symbols-dir", Input).value = lib_cfg.symbols_dir
+            self.query_one(
+                "#setting-footprints-dir", Input
+            ).value = lib_cfg.footprints_dir
+            self.query_one("#setting-models-dir", Input).value = lib_cfg.models_dir
+
+    # -- Live theme preview ---
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        if event.select.id == "setting-theme" and event.value != Select.BLANK:
+            self.app.theme = str(event.value)
+
+    # -- Button handlers ---
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "settings-save":
+            self.action_save()
+        elif event.button.id == "settings-cancel":
+            self.action_cancel()
+
+    # -- Actions ---
+
+    def action_save(self) -> None:
+        # Save appearance to global config
+        global_cfg = load_global_config()
+        theme_val = self.query_one("#setting-theme", Select).value
+        if theme_val != Select.BLANK:
+            global_cfg.theme = str(theme_val)
+        save_global_config(global_cfg)
+
+        # Save library fields if a library is open
+        if self._library_path is not None:
+            lib_cfg = load_library_config(self._library_path)
+            lib_cfg.library_prefix = self.query_one(
+                "#setting-prefix", Input
+            ).value.strip()
+            lib_cfg.separator = self.query_one(
+                "#setting-separator", Input
+            ).value.strip()
+            suppliers_raw = self.query_one("#setting-suppliers", Input).value.strip()
+            lib_cfg.suppliers = [
+                s.strip() for s in suppliers_raw.split(",") if s.strip()
+            ]
+            lib_cfg.symbols_dir = self.query_one(
+                "#setting-symbols-dir", Input
+            ).value.strip()
+            lib_cfg.footprints_dir = self.query_one(
+                "#setting-footprints-dir", Input
+            ).value.strip()
+            lib_cfg.models_dir = self.query_one(
+                "#setting-models-dir", Input
+            ).value.strip()
+            save_library_config(self._library_path, lib_cfg)
+
+        self._previous_theme = self.app.theme or "kist-dark"
+        self.dismiss()
+
+    def action_cancel(self) -> None:
+        self.app.theme = self._previous_theme
+        self.dismiss()

--- a/src/kist/tui/modals/settings.py
+++ b/src/kist/tui/modals/settings.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from textual import getters
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
@@ -16,15 +17,16 @@ from kist.core.config import (
     save_global_config,
     save_library_config,
 )
+from kist.tui.app import KistApp
 
 
 def _theme_options() -> list[tuple[str, str]]:
     """Build select options from Textual's registered themes."""
-    # Textual ships built-in themes; we add kist-dark alongside them.
+    # Textual ships built-in themes; we add null alongside them.
     # The full list is discovered at runtime from the app, but for the
     # select widget we use a curated list of well-known themes.
     return [
-        ("kist-dark", "kist-dark"),
+        ("null", "null"),
         ("textual-dark", "textual-dark"),
         ("textual-light", "textual-light"),
         ("nord", "nord"),
@@ -46,6 +48,8 @@ class SettingsModal(ModalScreen):
     Theme changes apply immediately as a live preview. Cancel reverts
     the theme to its previous value.
     """
+
+    app = getters.app(KistApp)
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel"),
@@ -125,7 +129,7 @@ class SettingsModal(ModalScreen):
         self.query_one("#section-appearance").border_title = "Appearance"
 
         # Load current values
-        self._previous_theme = self.app.theme or "kist-dark"
+        self._previous_theme = self.app.theme or "null"
         global_cfg = load_global_config()
         self.query_one("#setting-theme", Select).value = global_cfg.theme
 
@@ -193,7 +197,7 @@ class SettingsModal(ModalScreen):
             ).value.strip()
             save_library_config(self._library_path, lib_cfg)
 
-        self._previous_theme = self.app.theme or "kist-dark"
+        self._previous_theme = self.app.theme or "null"
         self.dismiss()
 
     def action_cancel(self) -> None:

--- a/src/kist/tui/save.py
+++ b/src/kist/tui/save.py
@@ -1,0 +1,129 @@
+"""Shared save logic for building a Part from form data."""
+
+from __future__ import annotations
+
+from kist.core.naming import generate_description, generate_name, generate_value
+from kist.models.config import CategoryDef
+from kist.models.part import (
+    JellybeanPart,
+    Part,
+    ProprietaryPart,
+    SemiJellybeanPart,
+    SupplierInfo,
+    Tier,
+)
+
+
+class ValidationNotice(Exception):
+    """User-facing validation message raised during part construction."""
+
+
+def build_part_from_form(
+    d: dict,
+    categories: dict[str, CategoryDef],
+    separator: str = "-",
+) -> Part:
+    """
+    Build a fully-named Part from a PartForm dict and library config.
+
+    Validates required fields, constructs the tier-appropriate Part subclass,
+    and generates name/value/description. Raises ``ValidationNotice`` for
+    missing required fields.
+    """
+    tier = d.get("tier")
+    if not tier:
+        raise ValidationNotice("Tier is required")
+
+    category = d.get("category")
+    if not category:
+        raise ValidationNotice("Category is required")
+
+    # Build SupplierInfo objects from flat dicts
+    suppliers = {
+        name: SupplierInfo(sku=info["sku"], url=info.get("url"))
+        for name, info in d.get("suppliers", {}).items()
+    }
+
+    cat_def = categories.get(category)
+    reference = cat_def.refdes if cat_def else "U"
+
+    # Normalise protocol-relative datasheet URLs
+    datasheet = d.get("datasheet")
+    if datasheet and datasheet.startswith("//"):
+        datasheet = "https:" + datasheet
+
+    # Fields shared by all tiers; name/value filled after generation
+    common = {
+        "name": "",
+        "value": "",
+        "reference": reference,
+        "category": category,
+        "subcategory": d.get("subcategory"),
+        "package": d.get("package") or None,
+        "mounting": d.get("mounting"),
+        "description": d.get("description", ""),
+        "tags": d.get("tags", []),
+        "specifications": d.get("specifications"),
+        "suppliers": suppliers,
+        "symbol": d.get("symbol", ""),
+        "footprint": d.get("footprint", ""),
+        "keywords": d.get("keywords", []),
+        "datasheet": datasheet,
+        "notes": d.get("notes"),
+    }
+
+    part = _build_part(tier, d, common)
+
+    # Generate name, value, description
+    part.name = generate_name(part, categories, separator)
+    part.value = generate_value(part, categories)
+    if isinstance(part, JellybeanPart):
+        part.description = generate_description(part, categories)
+
+    return part
+
+
+def _build_part(
+    tier: str,
+    d: dict,
+    common: dict,
+) -> ProprietaryPart | SemiJellybeanPart | JellybeanPart:
+    """Construct the tier-appropriate Part subclass from form data."""
+    if tier == Tier.PROPRIETARY:
+        mpn = d.get("mpn", "").strip()
+        manufacturer = d.get("manufacturer", "").strip()
+        if not mpn:
+            raise ValidationNotice("MPN is required for proprietary parts")
+        if not manufacturer:
+            raise ValidationNotice("Manufacturer is required")
+        return ProprietaryPart(
+            tier=Tier.PROPRIETARY,
+            mpn=mpn,
+            manufacturer=manufacturer,
+            **common,
+        )
+
+    if tier == Tier.SEMI_JELLYBEAN:
+        mpn = d.get("mpn", "").strip()
+        manufacturer = d.get("manufacturer", "").strip()
+        base_pn = d.get("base_pn", "").strip()
+        if not mpn:
+            raise ValidationNotice("MPN is required")
+        if not manufacturer:
+            raise ValidationNotice("Manufacturer is required")
+        if not base_pn:
+            raise ValidationNotice("Base PN is required for semi-jellybean parts")
+        return SemiJellybeanPart(
+            tier=Tier.SEMI_JELLYBEAN,
+            mpn=mpn,
+            manufacturer=manufacturer,
+            base_pn=base_pn,
+            **common,
+        )
+
+    # Jellybean
+    specs = d.get("specifications")
+    if not specs:
+        raise ValidationNotice("Specs are required for jellybean parts")
+    common["specifications"] = specs
+    return JellybeanPart(tier=Tier.JELLYBEAN, **common)

--- a/src/kist/tui/screens/__init__.py
+++ b/src/kist/tui/screens/__init__.py
@@ -1,0 +1,1 @@
+"""TUI screens."""

--- a/src/kist/tui/screens/add.py
+++ b/src/kist/tui/screens/add.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
 
-from textual import work
+from textual import getters, work
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal
@@ -17,15 +16,15 @@ from kist.core.config import load_library_config
 from kist.core.database import PartsDatabase
 from kist.errors import DuplicatePartError, ProviderError
 from kist.providers import detect_provider, fetch_product
+from kist.tui.app import KistApp
 from kist.tui.save import ValidationNotice, build_part_from_form
 from kist.tui.widgets.header import KistHeader
 from kist.tui.widgets.part_form import PartForm
 
-if TYPE_CHECKING:
-    from kist.tui.app import KistApp
-
 
 class AddScreen(Screen):
+    app = getters.app(KistApp)
+
     """Full-screen form for adding a new part."""
 
     TITLE = "Kist"
@@ -111,8 +110,7 @@ class AddScreen(Screen):
         form = self.query_one("#part-form", PartForm)
         d = form.to_dict()
 
-        app: KistApp = self.app  # type: ignore[assignment]
-        library_path = app.library_path
+        library_path = self.app.library_path
         if not library_path:
             self.notify("No library found -- run kist init first", severity="error")
             return

--- a/src/kist/tui/screens/add.py
+++ b/src/kist/tui/screens/add.py
@@ -1,0 +1,45 @@
+"""Add screen -- add a new part to the library."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Label
+
+from kist import __version__
+from kist.tui.widgets.header import KistHeader
+
+
+class AddScreen(Screen):
+    """Full-screen form for adding a new part."""
+
+    TITLE = "Kist"
+    SUB_TITLE = f"v{__version__}"
+
+    BINDINGS = [
+        Binding("escape", "pop_screen", "Back"),
+        Binding("ctrl+s", "save", "Save"),
+    ]
+
+    def __init__(
+        self,
+        url_or_mpn: str | None = None,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._url_or_mpn = url_or_mpn
+
+    def compose(self) -> ComposeResult:
+        yield KistHeader(icon="\N{PACKAGE}", page_title="Add Part")
+        text = f"Add part: {self._url_or_mpn}" if self._url_or_mpn else "Add part"
+        yield Label(text, id="placeholder")
+        yield Footer()
+
+    def action_save(self) -> None:
+        self.notify("Save not yet implemented.", severity="warning")
+
+    def action_pop_screen(self) -> None:
+        self.app.pop_screen()

--- a/src/kist/tui/screens/add.py
+++ b/src/kist/tui/screens/add.py
@@ -12,8 +12,6 @@ from textual.screen import Screen
 from textual.widgets import Footer, Input, Label
 
 from kist import __version__
-from kist.core.config import load_library_config
-from kist.core.database import PartsDatabase
 from kist.errors import DuplicatePartError, ProviderError
 from kist.providers import detect_provider, fetch_product
 from kist.tui.app import KistApp
@@ -110,12 +108,10 @@ class AddScreen(Screen):
         form = self.query_one("#part-form", PartForm)
         d = form.to_dict()
 
-        library_path = self.app.library_path
-        if not library_path:
+        config = self.app.library_config
+        if not config:
             self.notify("No library found -- run kist init first", severity="error")
             return
-
-        config = load_library_config(library_path)
 
         try:
             part = build_part_from_form(d, config.categories, config.separator)
@@ -128,11 +124,8 @@ class AddScreen(Screen):
             self.notify(f"Invalid part data: {msg}", severity="error")
             return
 
-        # Persist
-        db = PartsDatabase(library_path / "parts.json")
-        db.load()
         try:
-            db.add(part)
+            self.app.save_part(part)
         except DuplicatePartError:
             self.notify(f"Part already exists: {part.name}", severity="error")
             return

--- a/src/kist/tui/screens/add.py
+++ b/src/kist/tui/screens/add.py
@@ -26,7 +26,7 @@ from kist.models.part import (
     Tier,
 )
 from kist.providers.digikey import DigiKeyClient, parse_digikey_url
-from kist.providers.models import DigiKeyProduct
+from kist.providers.models import ProviderProduct
 from kist.tui.widgets.header import KistHeader
 from kist.tui.widgets.part_form import PartForm
 
@@ -111,7 +111,7 @@ class AddScreen(Screen):
             form = self.query_one("#part-form", PartForm)
             form.load_from_provider(product)
 
-    def _fetch_product(self) -> DigiKeyProduct:
+    def _fetch_product(self) -> ProviderProduct:
         """Blocking: parse URL/MPN, load credentials, call DigiKey API."""
         assert self._url_or_mpn is not None  # set by _start_fetch before worker
         product_number = parse_digikey_url(self._url_or_mpn)

--- a/src/kist/tui/screens/add.py
+++ b/src/kist/tui/screens/add.py
@@ -85,8 +85,9 @@ class AddScreen(Screen):
             self.notify(str(exc), severity="error")
             return
 
-        self.notify(f"Fetching {identifier} from {provider_name}...")
-        self.query_one("#part-form", PartForm).loading = True
+        form = self.query_one("#part-form", PartForm)
+        form.clear()
+        form.loading = True
         self._fetch_worker()
 
     @work(exclusive=True)

--- a/src/kist/tui/screens/add.py
+++ b/src/kist/tui/screens/add.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import TYPE_CHECKING
 
 from textual import work
@@ -14,10 +13,10 @@ from textual.screen import Screen
 from textual.widgets import Footer, Input, Label, Static
 
 from kist import __version__
-from kist.core.config import load_global_config, load_library_config
+from kist.core.config import load_library_config
 from kist.core.database import PartsDatabase
 from kist.core.naming import generate_description, generate_name, generate_value
-from kist.errors import DigiKeyError, DuplicatePartError
+from kist.errors import DuplicatePartError, ProviderError
 from kist.models.part import (
     JellybeanPart,
     ProprietaryPart,
@@ -25,8 +24,7 @@ from kist.models.part import (
     SupplierInfo,
     Tier,
 )
-from kist.providers.digikey import DigiKeyClient, parse_digikey_url
-from kist.providers.models import ProviderProduct
+from kist.providers import detect_provider, fetch_product
 from kist.tui.widgets.header import KistHeader
 from kist.tui.widgets.part_form import PartForm
 
@@ -59,7 +57,7 @@ class AddScreen(Screen):
         yield KistHeader(icon="\N{PACKAGE}", page_title="Add Part")
         with Horizontal(id="url-bar"):
             yield Label("URL / MPN", id="url-label")
-            yield Input(id="url-input", placeholder="Paste DigiKey URL or enter MPN")
+            yield Input(id="url-input", placeholder="Paste supplier URL or enter MPN")
         yield Static("", id="loading-indicator")
         yield PartForm(mode="editable", id="part-form")
         yield Footer()
@@ -81,16 +79,16 @@ class AddScreen(Screen):
     # -- Fetch worker ---
 
     def _start_fetch(self, url_or_mpn: str) -> None:
-        """Parse the input and kick off a background fetch."""
+        """Validate input and kick off a background fetch."""
         self._url_or_mpn = url_or_mpn
         try:
-            product_number = parse_digikey_url(url_or_mpn)
-        except DigiKeyError as exc:
+            provider_name, identifier = detect_provider(url_or_mpn)
+        except ProviderError as exc:
             self.notify(str(exc), severity="error")
             return
 
         loading = self.query_one("#loading-indicator", Static)
-        loading.update(f"Fetching {product_number} from DigiKey...")
+        loading.update(f"Fetching {identifier} from {provider_name}...")
         self.query_one("#loading-indicator").display = True
         self.query_one("#part-form").display = False
         self._fetch_worker()
@@ -98,9 +96,10 @@ class AddScreen(Screen):
     @work(exclusive=True)
     async def _fetch_worker(self) -> None:
         """Async worker: run blocking API call in a thread, populate form."""
+        assert self._url_or_mpn is not None
         try:
-            product = await asyncio.to_thread(self._fetch_product)
-        except DigiKeyError as exc:
+            product = await asyncio.to_thread(fetch_product, self._url_or_mpn)
+        except ProviderError as exc:
             self._show_form()
             self.notify(str(exc), severity="error")
         except Exception as exc:
@@ -110,22 +109,6 @@ class AddScreen(Screen):
             self._show_form()
             form = self.query_one("#part-form", PartForm)
             form.load_from_provider(product)
-
-    def _fetch_product(self) -> ProviderProduct:
-        """Blocking: parse URL/MPN, load credentials, call DigiKey API."""
-        assert self._url_or_mpn is not None  # set by _start_fetch before worker
-        product_number = parse_digikey_url(self._url_or_mpn)
-        global_cfg = load_global_config()
-        dk_cfg = global_cfg.providers.digikey
-        # Env vars first, config file as fallback
-        client_id = os.environ.get("KIST_DIGIKEY_CLIENT_ID") or dk_cfg.client_id
-        client_secret = (
-            os.environ.get("KIST_DIGIKEY_CLIENT_SECRET") or dk_cfg.client_secret
-        )
-        if not client_id or not client_secret:
-            raise DigiKeyError("DigiKey credentials not configured")
-        client = DigiKeyClient(client_id, client_secret)
-        return client.fetch_product(product_number)
 
     def _show_form(self) -> None:
         """Hide loading indicator and restore the form."""

--- a/src/kist/tui/screens/add.py
+++ b/src/kist/tui/screens/add.py
@@ -52,6 +52,9 @@ class AddScreen(Screen):
         yield Footer()
 
     def on_mount(self) -> None:
+        config = self.app.library_config
+        if config:
+            self.query_one("#part-form", PartForm).set_categories(config.categories)
         if self._url_or_mpn:
             self.query_one("#url-input", Input).value = self._url_or_mpn
             self._start_fetch(self._url_or_mpn)

--- a/src/kist/tui/screens/add.py
+++ b/src/kist/tui/screens/add.py
@@ -15,16 +15,9 @@ from textual.widgets import Footer, Input, Label
 from kist import __version__
 from kist.core.config import load_library_config
 from kist.core.database import PartsDatabase
-from kist.core.naming import generate_description, generate_name, generate_value
 from kist.errors import DuplicatePartError, ProviderError
-from kist.models.part import (
-    JellybeanPart,
-    ProprietaryPart,
-    SemiJellybeanPart,
-    SupplierInfo,
-    Tier,
-)
 from kist.providers import detect_provider, fetch_product
+from kist.tui.save import ValidationNotice, build_part_from_form
 from kist.tui.widgets.header import KistHeader
 from kist.tui.widgets.part_form import PartForm
 
@@ -118,16 +111,6 @@ class AddScreen(Screen):
         form = self.query_one("#part-form", PartForm)
         d = form.to_dict()
 
-        tier = d.get("tier")
-        if not tier:
-            self.notify("Tier is required", severity="error")
-            return
-
-        category = d.get("category")
-        if not category:
-            self.notify("Category is required", severity="error")
-            return
-
         app: KistApp = self.app  # type: ignore[assignment]
         library_path = app.library_path
         if not library_path:
@@ -135,45 +118,10 @@ class AddScreen(Screen):
             return
 
         config = load_library_config(library_path)
-        categories = config.categories
-
-        # Build SupplierInfo objects from flat dicts
-        suppliers = {
-            name: SupplierInfo(sku=info["sku"], url=info.get("url"))
-            for name, info in d.get("suppliers", {}).items()
-        }
-
-        cat_def = categories.get(category)
-        reference = cat_def.refdes if cat_def else "U"
-
-        # Normalise protocol-relative datasheet URLs
-        datasheet = d.get("datasheet")
-        if datasheet and datasheet.startswith("//"):
-            datasheet = "https:" + datasheet
-
-        # Fields shared by all tiers; name/value filled after generation
-        common = {
-            "name": "",
-            "value": "",
-            "reference": reference,
-            "category": category,
-            "subcategory": d.get("subcategory"),
-            "package": d.get("package") or None,
-            "mounting": d.get("mounting"),
-            "description": d.get("description", ""),
-            "tags": d.get("tags", []),
-            "specifications": d.get("specifications"),
-            "suppliers": suppliers,
-            "symbol": d.get("symbol", ""),
-            "footprint": d.get("footprint", ""),
-            "keywords": d.get("keywords", []),
-            "datasheet": datasheet,
-            "notes": d.get("notes"),
-        }
 
         try:
-            part = self._build_part(tier, d, common)
-        except _ValidationNotice as exc:
+            part = build_part_from_form(d, config.categories, config.separator)
+        except ValidationNotice as exc:
             self.notify(str(exc), severity="error")
             return
         except Exception as exc:
@@ -181,12 +129,6 @@ class AddScreen(Screen):
             msg = str(exc).replace("[", "\\[")
             self.notify(f"Invalid part data: {msg}", severity="error")
             return
-
-        # Generate name, value, description
-        part.name = generate_name(part, categories, config.separator)
-        part.value = generate_value(part, categories)
-        if isinstance(part, JellybeanPart):
-            part.description = generate_description(part, categories)
 
         # Persist
         db = PartsDatabase(library_path / "parts.json")
@@ -203,55 +145,5 @@ class AddScreen(Screen):
         url_input.value = ""
         url_input.focus()
 
-    @staticmethod
-    def _build_part(
-        tier: str,
-        d: dict,
-        common: dict,
-    ) -> ProprietaryPart | SemiJellybeanPart | JellybeanPart:
-        """Construct the tier-appropriate Part subclass from form data."""
-        if tier == Tier.PROPRIETARY:
-            mpn = d.get("mpn", "").strip()
-            manufacturer = d.get("manufacturer", "").strip()
-            if not mpn:
-                raise _ValidationNotice("MPN is required for proprietary parts")
-            if not manufacturer:
-                raise _ValidationNotice("Manufacturer is required")
-            return ProprietaryPart(
-                tier=Tier.PROPRIETARY,
-                mpn=mpn,
-                manufacturer=manufacturer,
-                **common,
-            )
-
-        if tier == Tier.SEMI_JELLYBEAN:
-            mpn = d.get("mpn", "").strip()
-            manufacturer = d.get("manufacturer", "").strip()
-            base_pn = d.get("base_pn", "").strip()
-            if not mpn:
-                raise _ValidationNotice("MPN is required")
-            if not manufacturer:
-                raise _ValidationNotice("Manufacturer is required")
-            if not base_pn:
-                raise _ValidationNotice("Base PN is required for semi-jellybean parts")
-            return SemiJellybeanPart(
-                tier=Tier.SEMI_JELLYBEAN,
-                mpn=mpn,
-                manufacturer=manufacturer,
-                base_pn=base_pn,
-                **common,
-            )
-
-        # Jellybean
-        specs = d.get("specifications")
-        if not specs:
-            raise _ValidationNotice("Specs are required for jellybean parts")
-        common["specifications"] = specs
-        return JellybeanPart(tier=Tier.JELLYBEAN, **common)
-
     def action_pop_screen(self) -> None:
         self.app.pop_screen()
-
-
-class _ValidationNotice(Exception):
-    """Internal: carries a user-facing validation message."""

--- a/src/kist/tui/screens/add.py
+++ b/src/kist/tui/screens/add.py
@@ -2,14 +2,36 @@
 
 from __future__ import annotations
 
+import asyncio
+import os
+from typing import TYPE_CHECKING
+
+from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding
+from textual.containers import Horizontal
 from textual.screen import Screen
-from textual.widgets import Footer
+from textual.widgets import Footer, Input, Label, Static
 
 from kist import __version__
+from kist.core.config import load_global_config, load_library_config
+from kist.core.database import PartsDatabase
+from kist.core.naming import generate_description, generate_name, generate_value
+from kist.errors import DigiKeyError, DuplicatePartError
+from kist.models.part import (
+    JellybeanPart,
+    ProprietaryPart,
+    SemiJellybeanPart,
+    SupplierInfo,
+    Tier,
+)
+from kist.providers.digikey import DigiKeyClient, parse_digikey_url
+from kist.providers.models import DigiKeyProduct
 from kist.tui.widgets.header import KistHeader
 from kist.tui.widgets.part_form import PartForm
+
+if TYPE_CHECKING:
+    from kist.tui.app import KistApp
 
 
 class AddScreen(Screen):
@@ -35,11 +57,222 @@ class AddScreen(Screen):
 
     def compose(self) -> ComposeResult:
         yield KistHeader(icon="\N{PACKAGE}", page_title="Add Part")
+        with Horizontal(id="url-bar"):
+            yield Label("URL / MPN", id="url-label")
+            yield Input(id="url-input", placeholder="Paste DigiKey URL or enter MPN")
+        yield Static("", id="loading-indicator")
         yield PartForm(mode="editable", id="part-form")
         yield Footer()
 
+    def on_mount(self) -> None:
+        self.query_one("#loading-indicator").display = False
+        if self._url_or_mpn:
+            self.query_one("#url-input", Input).value = self._url_or_mpn
+            self._start_fetch(self._url_or_mpn)
+
+    # -- URL input ---
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "url-input":
+            url_or_mpn = event.value.strip()
+            if url_or_mpn:
+                self._start_fetch(url_or_mpn)
+
+    # -- Fetch worker ---
+
+    def _start_fetch(self, url_or_mpn: str) -> None:
+        """Parse the input and kick off a background fetch."""
+        self._url_or_mpn = url_or_mpn
+        try:
+            product_number = parse_digikey_url(url_or_mpn)
+        except DigiKeyError as exc:
+            self.notify(str(exc), severity="error")
+            return
+
+        loading = self.query_one("#loading-indicator", Static)
+        loading.update(f"Fetching {product_number} from DigiKey...")
+        self.query_one("#loading-indicator").display = True
+        self.query_one("#part-form").display = False
+        self._fetch_worker()
+
+    @work(exclusive=True)
+    async def _fetch_worker(self) -> None:
+        """Async worker: run blocking API call in a thread, populate form."""
+        try:
+            product = await asyncio.to_thread(self._fetch_product)
+        except DigiKeyError as exc:
+            self._show_form()
+            self.notify(str(exc), severity="error")
+        except Exception as exc:
+            self._show_form()
+            self.notify(f"Fetch failed: {exc}", severity="error")
+        else:
+            self._show_form()
+            form = self.query_one("#part-form", PartForm)
+            form.load_from_provider(product)
+
+    def _fetch_product(self) -> DigiKeyProduct:
+        """Blocking: parse URL/MPN, load credentials, call DigiKey API."""
+        assert self._url_or_mpn is not None  # set by _start_fetch before worker
+        product_number = parse_digikey_url(self._url_or_mpn)
+        global_cfg = load_global_config()
+        dk_cfg = global_cfg.providers.digikey
+        # Env vars first, config file as fallback
+        client_id = os.environ.get("KIST_DIGIKEY_CLIENT_ID") or dk_cfg.client_id
+        client_secret = (
+            os.environ.get("KIST_DIGIKEY_CLIENT_SECRET") or dk_cfg.client_secret
+        )
+        if not client_id or not client_secret:
+            raise DigiKeyError("DigiKey credentials not configured")
+        client = DigiKeyClient(client_id, client_secret)
+        return client.fetch_product(product_number)
+
+    def _show_form(self) -> None:
+        """Hide loading indicator and restore the form."""
+        self.query_one("#loading-indicator").display = False
+        self.query_one("#part-form").display = True
+
+    # -- Save ---
+
     def action_save(self) -> None:
-        self.notify("Save not yet implemented.", severity="warning")
+        """Build Part from form, generate name, save to database."""
+        form = self.query_one("#part-form", PartForm)
+        d = form.to_dict()
+
+        tier = d.get("tier")
+        if not tier:
+            self.notify("Tier is required", severity="error")
+            return
+
+        category = d.get("category")
+        if not category:
+            self.notify("Category is required", severity="error")
+            return
+
+        app: KistApp = self.app  # type: ignore[assignment]
+        library_path = app.library_path
+        if not library_path:
+            self.notify("No library found -- run kist init first", severity="error")
+            return
+
+        config = load_library_config(library_path)
+        categories = config.categories
+
+        # Build SupplierInfo objects from flat dicts
+        suppliers = {
+            name: SupplierInfo(sku=info["sku"], url=info.get("url"))
+            for name, info in d.get("suppliers", {}).items()
+        }
+
+        cat_def = categories.get(category)
+        reference = cat_def.refdes if cat_def else "U"
+
+        # Normalise protocol-relative datasheet URLs
+        datasheet = d.get("datasheet")
+        if datasheet and datasheet.startswith("//"):
+            datasheet = "https:" + datasheet
+
+        # Fields shared by all tiers; name/value filled after generation
+        common = {
+            "name": "",
+            "value": "",
+            "reference": reference,
+            "category": category,
+            "subcategory": d.get("subcategory"),
+            "package": d.get("package") or None,
+            "mounting": d.get("mounting"),
+            "description": d.get("description", ""),
+            "tags": d.get("tags", []),
+            "specifications": d.get("specifications"),
+            "suppliers": suppliers,
+            "symbol": d.get("symbol", ""),
+            "footprint": d.get("footprint", ""),
+            "keywords": d.get("keywords", []),
+            "datasheet": datasheet,
+            "notes": d.get("notes"),
+        }
+
+        try:
+            part = self._build_part(tier, d, common)
+        except _ValidationNotice as exc:
+            self.notify(str(exc), severity="error")
+            return
+        except Exception as exc:
+            # Escape Rich markup chars in Pydantic validation errors
+            msg = str(exc).replace("[", "\\[")
+            self.notify(f"Invalid part data: {msg}", severity="error")
+            return
+
+        # Generate name, value, description
+        part.name = generate_name(part, categories, config.separator)
+        part.value = generate_value(part, categories)
+        if isinstance(part, JellybeanPart):
+            part.description = generate_description(part, categories)
+
+        # Persist
+        db = PartsDatabase(library_path / "parts.json")
+        db.load()
+        try:
+            db.add(part)
+        except DuplicatePartError:
+            self.notify(f"Part already exists: {part.name}", severity="error")
+            return
+
+        self.notify(f"Saved: {part.name}")
+        form.clear()
+        url_input = self.query_one("#url-input", Input)
+        url_input.value = ""
+        url_input.focus()
+
+    @staticmethod
+    def _build_part(
+        tier: str,
+        d: dict,
+        common: dict,
+    ) -> ProprietaryPart | SemiJellybeanPart | JellybeanPart:
+        """Construct the tier-appropriate Part subclass from form data."""
+        if tier == Tier.PROPRIETARY:
+            mpn = d.get("mpn", "").strip()
+            manufacturer = d.get("manufacturer", "").strip()
+            if not mpn:
+                raise _ValidationNotice("MPN is required for proprietary parts")
+            if not manufacturer:
+                raise _ValidationNotice("Manufacturer is required")
+            return ProprietaryPart(
+                tier=Tier.PROPRIETARY,
+                mpn=mpn,
+                manufacturer=manufacturer,
+                **common,
+            )
+
+        if tier == Tier.SEMI_JELLYBEAN:
+            mpn = d.get("mpn", "").strip()
+            manufacturer = d.get("manufacturer", "").strip()
+            base_pn = d.get("base_pn", "").strip()
+            if not mpn:
+                raise _ValidationNotice("MPN is required")
+            if not manufacturer:
+                raise _ValidationNotice("Manufacturer is required")
+            if not base_pn:
+                raise _ValidationNotice("Base PN is required for semi-jellybean parts")
+            return SemiJellybeanPart(
+                tier=Tier.SEMI_JELLYBEAN,
+                mpn=mpn,
+                manufacturer=manufacturer,
+                base_pn=base_pn,
+                **common,
+            )
+
+        # Jellybean
+        specs = d.get("specifications")
+        if not specs:
+            raise _ValidationNotice("Specs are required for jellybean parts")
+        common["specifications"] = specs
+        return JellybeanPart(tier=Tier.JELLYBEAN, **common)
 
     def action_pop_screen(self) -> None:
         self.app.pop_screen()
+
+
+class _ValidationNotice(Exception):
+    """Internal: carries a user-facing validation message."""

--- a/src/kist/tui/screens/add.py
+++ b/src/kist/tui/screens/add.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.screen import Screen
-from textual.widgets import Footer, Label
+from textual.widgets import Footer
 
 from kist import __version__
 from kist.tui.widgets.header import KistHeader
+from kist.tui.widgets.part_form import PartForm
 
 
 class AddScreen(Screen):
@@ -34,8 +35,7 @@ class AddScreen(Screen):
 
     def compose(self) -> ComposeResult:
         yield KistHeader(icon="\N{PACKAGE}", page_title="Add Part")
-        text = f"Add part: {self._url_or_mpn}" if self._url_or_mpn else "Add part"
-        yield Label(text, id="placeholder")
+        yield PartForm(mode="editable", id="part-form")
         yield Footer()
 
     def action_save(self) -> None:

--- a/src/kist/tui/screens/add.py
+++ b/src/kist/tui/screens/add.py
@@ -10,7 +10,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal
 from textual.screen import Screen
-from textual.widgets import Footer, Input, Label, Static
+from textual.widgets import Footer, Input, Label
 
 from kist import __version__
 from kist.core.config import load_library_config
@@ -58,12 +58,10 @@ class AddScreen(Screen):
         with Horizontal(id="url-bar"):
             yield Label("URL / MPN", id="url-label")
             yield Input(id="url-input", placeholder="Paste supplier URL or enter MPN")
-        yield Static("", id="loading-indicator")
         yield PartForm(mode="editable", id="part-form")
         yield Footer()
 
     def on_mount(self) -> None:
-        self.query_one("#loading-indicator").display = False
         if self._url_or_mpn:
             self.query_one("#url-input", Input).value = self._url_or_mpn
             self._start_fetch(self._url_or_mpn)
@@ -87,10 +85,8 @@ class AddScreen(Screen):
             self.notify(str(exc), severity="error")
             return
 
-        loading = self.query_one("#loading-indicator", Static)
-        loading.update(f"Fetching {identifier} from {provider_name}...")
-        self.query_one("#loading-indicator").display = True
-        self.query_one("#part-form").display = False
+        self.notify(f"Fetching {identifier} from {provider_name}...")
+        self.query_one("#part-form", PartForm).loading = True
         self._fetch_worker()
 
     @work(exclusive=True)
@@ -111,9 +107,8 @@ class AddScreen(Screen):
             form.load_from_provider(product)
 
     def _show_form(self) -> None:
-        """Hide loading indicator and restore the form."""
-        self.query_one("#loading-indicator").display = False
-        self.query_one("#part-form").display = True
+        """Clear loading state and restore the form."""
+        self.query_one("#part-form", PartForm).loading = False
 
     # -- Save ---
 

--- a/src/kist/tui/screens/browse.py
+++ b/src/kist/tui/screens/browse.py
@@ -2,13 +2,34 @@
 
 from __future__ import annotations
 
+from collections import Counter
+from pathlib import Path
+
 from textual.app import ComposeResult
 from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
 from textual.screen import Screen
-from textual.widgets import Footer, Label
+from textual.widgets import Footer, Input, Static
 
 from kist import __version__
+from kist.core.database import PartsDatabase
+from kist.models.part import Part, ProprietaryPart, SemiJellybeanPart
+from kist.tui.widgets.category_list import CategoryList
 from kist.tui.widgets.header import KistHeader
+from kist.tui.widgets.parts_table import PartsTable
+
+NO_LIBRARY_TEXT = (
+    "No library found.\n\n"
+    "Run [bold]kist init[/bold] to create one, or\n"
+    "[bold]kist link <path>[/bold] to connect to an existing library."
+)
+
+EMPTY_LIBRARY_TEXT = (
+    "\N{PACKAGE} Your library is empty.\n\n"
+    "Add your first part:\n"
+    "  [bold]kist add <url>[/bold]\n"
+    "  [bold]ctrl+p[/bold] --> Add part"
+)
 
 
 class BrowseScreen(Screen):
@@ -19,13 +40,140 @@ class BrowseScreen(Screen):
 
     BINDINGS = [
         Binding("q", "app.quit", "Quit"),
-        Binding("slash", "focus_search", "Search"),
+        Binding("slash", "focus_search", "Search", key_display="/"),
     ]
+
+    def __init__(
+        self,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._all_parts: list[Part] = []
+        self._selected_category: str | None = None
+        self._search_query: str = ""
 
     def compose(self) -> ComposeResult:
         yield KistHeader(icon="\N{PACKAGE}", page_title="Browse")
-        yield Label("Browse screen placeholder", id="placeholder")
+        with Horizontal():
+            yield CategoryList(id="sidebar")
+            with Vertical(id="main-panel"):
+                yield Input(placeholder="Search...", id="search")
+                yield PartsTable(id="parts-table")
+                yield Static(NO_LIBRARY_TEXT, id="empty-state", markup=True)
         yield Footer()
 
+    def on_mount(self) -> None:
+        self.watch(self.app, "library_path", self._on_library_changed)
+
+    def _on_library_changed(self, path: Path | None) -> None:
+        """React to the app discovering (or losing) a library."""
+        if path is None:
+            self._all_parts = []
+            self._show_empty_state(NO_LIBRARY_TEXT)
+            self.query_one("#sidebar", CategoryList).populate({})
+            return
+
+        db = PartsDatabase(path / "parts.json")
+        try:
+            db.load()
+        except Exception:
+            self._all_parts = []
+            self._show_empty_state(NO_LIBRARY_TEXT)
+            self.query_one("#sidebar", CategoryList).populate({})
+            return
+
+        self._all_parts = db.list_parts()
+
+        # Build category counts
+        counts: Counter[str] = Counter()
+        for part in self._all_parts:
+            counts[part.category] += 1
+
+        self.query_one("#sidebar", CategoryList).populate(dict(counts))
+
+        if not self._all_parts:
+            self._show_empty_state(EMPTY_LIBRARY_TEXT)
+        else:
+            self._apply_filters()
+
+    # -- Filtering -------------------------------------------------------------
+
+    def _apply_filters(self) -> None:
+        """Filter parts by selected category and search query, update table."""
+        filtered = self._all_parts
+
+        if self._selected_category is not None:
+            filtered = [p for p in filtered if p.category == self._selected_category]
+
+        if self._search_query:
+            q = self._search_query.lower()
+            filtered = [p for p in filtered if self._matches(p, q)]
+
+        table = self.query_one("#parts-table", PartsTable)
+        empty = self.query_one("#empty-state", Static)
+
+        if filtered:
+            table.display = True
+            empty.display = False
+            table.populate(filtered)
+        else:
+            table.display = False
+            empty.display = True
+            if self._all_parts:
+                empty.update("No parts match the current filter.")
+            else:
+                empty.update(EMPTY_LIBRARY_TEXT)
+
+    @staticmethod
+    def _matches(part: Part, query: str) -> bool:
+        """Substring match -- mirrors PartsDatabase._matches()."""
+        if query in part.name.lower():
+            return True
+        if query in part.description.lower():
+            return True
+        if any(query in tag.lower() for tag in part.tags):
+            return True
+        if isinstance(part, (ProprietaryPart, SemiJellybeanPart)):
+            if query in part.mpn.lower():
+                return True
+        if isinstance(part, SemiJellybeanPart):
+            if query in part.base_pn.lower():
+                return True
+        return False
+
+    # -- Empty state toggle ----------------------------------------------------
+
+    def _show_empty_state(self, text: str) -> None:
+        table = self.query_one("#parts-table", PartsTable)
+        empty = self.query_one("#empty-state", Static)
+        table.display = False
+        empty.display = True
+        empty.update(text)
+
+    # -- Event handlers --------------------------------------------------------
+
+    def on_category_list_selected(self, event: CategoryList.Selected) -> None:
+        self._selected_category = event.category
+        self._apply_filters()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id == "search":
+            self._search_query = event.value
+            self._apply_filters()
+
+    def on_data_table_row_selected(self, event: PartsTable.RowSelected) -> None:
+        self.notify(f"Selected: {event.row_key.value}", severity="information")
+
     def action_focus_search(self) -> None:
-        pass
+        self.query_one("#search", Input).focus()
+
+    def on_key(self, event) -> None:
+        """Clear search and refocus table on Escape from search input."""
+        if event.key == "escape":
+            search = self.query_one("#search", Input)
+            if search.has_focus:
+                search.value = ""
+                self.query_one("#parts-table", PartsTable).focus()
+                event.prevent_default()

--- a/src/kist/tui/screens/browse.py
+++ b/src/kist/tui/screens/browse.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import Counter
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -12,8 +13,12 @@ from textual.screen import Screen
 from textual.widgets import Footer, Input, Static
 
 from kist import __version__
+
+if TYPE_CHECKING:
+    from kist.tui.app import KistApp
 from kist.core.database import PartsDatabase
-from kist.models.part import Part, ProprietaryPart, SemiJellybeanPart
+from kist.models.part import Ipn, Part, ProprietaryPart, SemiJellybeanPart
+from kist.tui.screens.detail import DetailModal
 from kist.tui.widgets.category_list import CategoryList
 from kist.tui.widgets.header import KistHeader
 from kist.tui.widgets.parts_table import PartsTable
@@ -164,7 +169,18 @@ class BrowseScreen(Screen):
             self._apply_filters()
 
     def on_data_table_row_selected(self, event: PartsTable.RowSelected) -> None:
-        self.notify(f"Selected: {event.row_key.value}", severity="information")
+        ipn = Ipn(str(event.row_key.value))
+        part = next((p for p in self._all_parts if p.ipn == ipn), None)
+        if part:
+            self.app.push_screen(
+                DetailModal(part),
+                callback=self._on_detail_closed,
+            )  # type: ignore[arg-type]
+
+    def _on_detail_closed(self, changed: bool | None) -> None:
+        app: KistApp = self.app  # type: ignore[assignment]
+        if changed:
+            self._on_library_changed(app.library_path)
 
     def action_focus_search(self) -> None:
         self.query_one("#search", Input).focus()

--- a/src/kist/tui/screens/browse.py
+++ b/src/kist/tui/screens/browse.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from collections import Counter
 from pathlib import Path
-from typing import TYPE_CHECKING
 
+from textual import getters
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
@@ -13,11 +13,9 @@ from textual.screen import Screen
 from textual.widgets import Footer, Input, Static
 
 from kist import __version__
-
-if TYPE_CHECKING:
-    from kist.tui.app import KistApp
 from kist.core.database import PartsDatabase
 from kist.models.part import Ipn, Part, ProprietaryPart, SemiJellybeanPart
+from kist.tui.app import KistApp
 from kist.tui.screens.detail import DetailModal
 from kist.tui.widgets.category_list import CategoryList
 from kist.tui.widgets.header import KistHeader
@@ -39,6 +37,8 @@ EMPTY_LIBRARY_TEXT = (
 
 class BrowseScreen(Screen):
     """Main screen showing the parts library."""
+
+    app = getters.app(KistApp)
 
     TITLE = "Kist"
     SUB_TITLE = f"v{__version__}"
@@ -178,9 +178,8 @@ class BrowseScreen(Screen):
             )
 
     def _on_detail_closed(self, changed: bool | None) -> None:
-        app: KistApp = self.app  # type: ignore[assignment]
         if changed:
-            self._on_library_changed(app.library_path)
+            self._on_library_changed(self.app.library_path)
 
     def action_focus_search(self) -> None:
         self.query_one("#search", Input).focus()

--- a/src/kist/tui/screens/browse.py
+++ b/src/kist/tui/screens/browse.py
@@ -175,7 +175,7 @@ class BrowseScreen(Screen):
             self.app.push_screen(
                 DetailModal(part),
                 callback=self._on_detail_closed,
-            )  # type: ignore[arg-type]
+            )
 
     def _on_detail_closed(self, changed: bool | None) -> None:
         app: KistApp = self.app  # type: ignore[assignment]

--- a/src/kist/tui/screens/browse.py
+++ b/src/kist/tui/screens/browse.py
@@ -1,0 +1,31 @@
+"""Browse screen -- library overview with category sidebar and parts table."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Label
+
+from kist import __version__
+from kist.tui.widgets.header import KistHeader
+
+
+class BrowseScreen(Screen):
+    """Main screen showing the parts library."""
+
+    TITLE = "Kist"
+    SUB_TITLE = f"v{__version__}"
+
+    BINDINGS = [
+        Binding("q", "app.quit", "Quit"),
+        Binding("slash", "focus_search", "Search"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        yield KistHeader(icon="\N{PACKAGE}", page_title="Browse")
+        yield Label("Browse screen placeholder", id="placeholder")
+        yield Footer()
+
+    def action_focus_search(self) -> None:
+        pass

--- a/src/kist/tui/screens/browse.py
+++ b/src/kist/tui/screens/browse.py
@@ -71,6 +71,7 @@ class BrowseScreen(Screen):
 
     def on_mount(self) -> None:
         self.watch(self.app, "library_path", self._on_library_changed)
+        self.watch(self.app, "parts_version", self._on_parts_changed)
 
     def _on_library_changed(self, path: Path | None) -> None:
         """React to the app discovering (or losing) a library."""
@@ -172,13 +173,11 @@ class BrowseScreen(Screen):
         ipn = Ipn(str(event.row_key.value))
         part = next((p for p in self._all_parts if p.ipn == ipn), None)
         if part:
-            self.app.push_screen(
-                DetailModal(part),
-                callback=self._on_detail_closed,
-            )
+            self.app.push_screen(DetailModal(part))
 
-    def _on_detail_closed(self, changed: bool | None) -> None:
-        if changed:
+    def _on_parts_changed(self, version: int) -> None:
+        """Reload parts when the app signals a mutation."""
+        if self.app.library_path:
             self._on_library_changed(self.app.library_path)
 
     def action_focus_search(self) -> None:

--- a/src/kist/tui/screens/detail.py
+++ b/src/kist/tui/screens/detail.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Footer
+from textual.widgets import Button, Footer, Static
 
+from kist.core.config import load_library_config
+from kist.core.database import PartsDatabase
 from kist.models.part import Part
+from kist.tui.save import ValidationNotice, build_part_from_form
 from kist.tui.widgets.part_form import PartForm
+
+if TYPE_CHECKING:
+    from kist.tui.app import KistApp
 
 
 class DetailModal(ModalScreen[bool]):
@@ -23,12 +31,15 @@ class DetailModal(ModalScreen[bool]):
     BINDINGS = [
         Binding("escape", "close", "Close"),
         Binding("e", "toggle_edit", "Edit"),
+        Binding("d", "delete", "Delete"),
+        Binding("ctrl+s", "save", "Save"),
     ]
 
     def __init__(self, part: Part) -> None:
         super().__init__()
         self._part = part
         self._changed = False
+        self._form_snapshot: dict = {}
 
     def compose(self) -> ComposeResult:
         with Vertical(id="detail-container"):
@@ -40,11 +51,146 @@ class DetailModal(ModalScreen[bool]):
         self.call_after_refresh(self._load_part)
 
     def _load_part(self) -> None:
-        self.query_one("#detail-form", PartForm).load_part(self._part)
+        form = self.query_one("#detail-form", PartForm)
+        form.load_part(self._part)
+        self._form_snapshot = form.to_dict()
+        # Reset focus so nothing inside the readonly form is focused
+        self.set_focus(None)
+
+    def _form_dirty(self) -> bool:
+        """Check if form values differ from the loaded snapshot."""
+        form = self.query_one("#detail-form", PartForm)
+        return form.to_dict() != self._form_snapshot
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        """Show edit/delete in readonly mode, save in edit mode."""
+        form = self.query_one("#detail-form", PartForm)
+        editable = form.mode == "editable"
+        if action == "save":
+            return editable
+        if action in ("toggle_edit", "delete"):
+            return not editable
+        return True
+
+    # -- Edit ---
 
     def action_toggle_edit(self) -> None:
         form = self.query_one("#detail-form", PartForm)
         form.mode = "editable" if form.mode == "readonly" else "readonly"
+        self.refresh_bindings()
+
+    def action_save(self) -> None:
+        form = self.query_one("#detail-form", PartForm)
+        if form.mode != "editable":
+            return
+
+        app: KistApp = self.app  # type: ignore[assignment]
+        library_path = app.library_path
+        if not library_path:
+            self.notify("No library found", severity="error")
+            return
+
+        config = load_library_config(library_path)
+        d = form.to_dict()
+
+        try:
+            new_part = build_part_from_form(d, config.categories, config.separator)
+        except ValidationNotice as exc:
+            self.notify(str(exc), severity="error")
+            return
+        except Exception as exc:
+            msg = str(exc).replace("[", "\\[")
+            self.notify(f"Invalid part data: {msg}", severity="error")
+            return
+
+        db = PartsDatabase(library_path / "parts.json")
+        db.load()
+
+        # Remove old, add new (IPN may change since name changed)
+        assert self._part.ipn is not None
+        db.remove(self._part.ipn)
+        db.add(new_part)
+
+        self._part = new_part
+        self._changed = True
+        self._form_snapshot = form.to_dict()
+        self.query_one("#detail-container").border_title = new_part.name
+        form.mode = "readonly"
+        self.refresh_bindings()
+        self.notify(f"Saved: {new_part.name}")
+
+    # -- Delete ---
+
+    def action_delete(self) -> None:
+        self.app.push_screen(
+            ConfirmModal(f"Delete {self._part.name}?"),
+            callback=self._on_delete_confirmed,
+        )  # type: ignore[arg-type]
+
+    def _on_delete_confirmed(self, confirmed: bool | None) -> None:
+        if not confirmed:
+            return
+
+        app: KistApp = self.app  # type: ignore[assignment]
+        library_path = app.library_path
+        if not library_path:
+            return
+
+        db = PartsDatabase(library_path / "parts.json")
+        db.load()
+        assert self._part.ipn is not None
+        db.remove(self._part.ipn)
+        self.dismiss(True)
+
+    # -- Close ---
 
     def action_close(self) -> None:
+        form = self.query_one("#detail-form", PartForm)
+        if form.mode == "editable":
+            if self._form_dirty():
+                self.app.push_screen(
+                    ConfirmModal("Discard unsaved changes?"),
+                    callback=self._on_discard_confirmed,
+                )  # type: ignore[arg-type]
+            else:
+                self._switch_to_readonly()
+            return
         self.dismiss(self._changed)
+
+    def _switch_to_readonly(self) -> None:
+        """Revert form to readonly, restoring the snapshot values."""
+        form = self.query_one("#detail-form", PartForm)
+        form.clear()
+        form.load_part(self._part)
+        form.mode = "readonly"
+        self._form_snapshot = form.to_dict()
+        self.refresh_bindings()
+
+    def _on_discard_confirmed(self, confirmed: bool | None) -> None:
+        if confirmed:
+            self._switch_to_readonly()
+
+
+class ConfirmModal(ModalScreen[bool]):
+    """Simple yes/no confirmation dialog."""
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, message: str) -> None:
+        super().__init__()
+        self._message = message
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="confirm-container"):
+            yield Static(self._message, id="confirm-message")
+            with Horizontal(id="confirm-buttons"):
+                yield Button("Cancel", id="confirm-cancel", variant="default")
+                yield Button("Confirm", id="confirm-ok", variant="error")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "confirm-ok")
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)

--- a/src/kist/tui/screens/detail.py
+++ b/src/kist/tui/screens/detail.py
@@ -1,0 +1,50 @@
+"""Detail modal -- view, edit, and delete a part from the browse screen."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Footer
+
+from kist.models.part import Part
+from kist.tui.widgets.part_form import PartForm
+
+
+class DetailModal(ModalScreen[bool]):
+    """
+    Modal showing full part details in PartForm readonly mode.
+
+    Returns True on dismiss if the underlying data changed (edit/delete),
+    so the browse screen knows to refresh.
+    """
+
+    BINDINGS = [
+        Binding("escape", "close", "Close"),
+        Binding("e", "toggle_edit", "Edit"),
+    ]
+
+    def __init__(self, part: Part) -> None:
+        super().__init__()
+        self._part = part
+        self._changed = False
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="detail-container"):
+            yield PartForm(mode="readonly", id="detail-form")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.query_one("#detail-container").border_title = self._part.name
+        self.call_after_refresh(self._load_part)
+
+    def _load_part(self) -> None:
+        self.query_one("#detail-form", PartForm).load_part(self._part)
+
+    def action_toggle_edit(self) -> None:
+        form = self.query_one("#detail-form", PartForm)
+        form.mode = "editable" if form.mode == "readonly" else "readonly"
+
+    def action_close(self) -> None:
+        self.dismiss(self._changed)

--- a/src/kist/tui/screens/detail.py
+++ b/src/kist/tui/screens/detail.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from textual import getters
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
@@ -13,14 +12,14 @@ from textual.widgets import Button, Footer, Static
 from kist.core.config import load_library_config
 from kist.core.database import PartsDatabase
 from kist.models.part import Part
+from kist.tui.app import KistApp
 from kist.tui.save import ValidationNotice, build_part_from_form
 from kist.tui.widgets.part_form import PartForm
 
-if TYPE_CHECKING:
-    from kist.tui.app import KistApp
-
 
 class DetailModal(ModalScreen[bool]):
+    app = getters.app(KistApp)
+
     """
     Modal showing full part details in PartForm readonly mode.
 
@@ -84,8 +83,7 @@ class DetailModal(ModalScreen[bool]):
         if form.mode != "editable":
             return
 
-        app: KistApp = self.app  # type: ignore[assignment]
-        library_path = app.library_path
+        library_path = self.app.library_path
         if not library_path:
             self.notify("No library found", severity="error")
             return
@@ -131,8 +129,7 @@ class DetailModal(ModalScreen[bool]):
         if not confirmed:
             return
 
-        app: KistApp = self.app  # type: ignore[assignment]
-        library_path = app.library_path
+        library_path = self.app.library_path
         if not library_path:
             return
 

--- a/src/kist/tui/screens/detail.py
+++ b/src/kist/tui/screens/detail.py
@@ -45,6 +45,9 @@ class DetailModal(ModalScreen):
 
     def _load_part(self) -> None:
         form = self.query_one("#detail-form", PartForm)
+        config = self.app.library_config
+        if config:
+            form.set_categories(config.categories)
         form.load_part(self._part)
         self._form_snapshot = form.to_dict()
         # Reset focus so nothing inside the readonly form is focused

--- a/src/kist/tui/screens/detail.py
+++ b/src/kist/tui/screens/detail.py
@@ -9,23 +9,18 @@ from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Footer, Static
 
-from kist.core.config import load_library_config
-from kist.core.database import PartsDatabase
 from kist.models.part import Part
 from kist.tui.app import KistApp
 from kist.tui.save import ValidationNotice, build_part_from_form
 from kist.tui.widgets.part_form import PartForm
 
 
-class DetailModal(ModalScreen[bool]):
-    app = getters.app(KistApp)
-
+class DetailModal(ModalScreen):
     """
     Modal showing full part details in PartForm readonly mode.
-
-    Returns True on dismiss if the underlying data changed (edit/delete),
-    so the browse screen knows to refresh.
     """
+
+    app = getters.app(KistApp)
 
     BINDINGS = [
         Binding("escape", "close", "Close"),
@@ -37,7 +32,6 @@ class DetailModal(ModalScreen[bool]):
     def __init__(self, part: Part) -> None:
         super().__init__()
         self._part = part
-        self._changed = False
         self._form_snapshot: dict = {}
 
     def compose(self) -> ComposeResult:
@@ -83,12 +77,11 @@ class DetailModal(ModalScreen[bool]):
         if form.mode != "editable":
             return
 
-        library_path = self.app.library_path
-        if not library_path:
+        config = self.app.library_config
+        if not config:
             self.notify("No library found", severity="error")
             return
 
-        config = load_library_config(library_path)
         d = form.to_dict()
 
         try:
@@ -101,16 +94,10 @@ class DetailModal(ModalScreen[bool]):
             self.notify(f"Invalid part data: {msg}", severity="error")
             return
 
-        db = PartsDatabase(library_path / "parts.json")
-        db.load()
-
-        # Remove old, add new (IPN may change since name changed)
         assert self._part.ipn is not None
-        db.remove(self._part.ipn)
-        db.add(new_part)
+        self.app.save_part(new_part, replacing=self._part.ipn)
 
         self._part = new_part
-        self._changed = True
         self._form_snapshot = form.to_dict()
         self.query_one("#detail-container").border_title = new_part.name
         form.mode = "readonly"
@@ -129,15 +116,9 @@ class DetailModal(ModalScreen[bool]):
         if not confirmed:
             return
 
-        library_path = self.app.library_path
-        if not library_path:
-            return
-
-        db = PartsDatabase(library_path / "parts.json")
-        db.load()
         assert self._part.ipn is not None
-        db.remove(self._part.ipn)
-        self.dismiss(True)
+        self.app.delete_part(self._part.ipn)
+        self.dismiss()
 
     # -- Close ---
 
@@ -152,7 +133,7 @@ class DetailModal(ModalScreen[bool]):
             else:
                 self._switch_to_readonly()
             return
-        self.dismiss(self._changed)
+        self.dismiss()
 
     def _switch_to_readonly(self) -> None:
         """Revert form to readonly, restoring the snapshot values."""

--- a/src/kist/tui/screens/detail.py
+++ b/src/kist/tui/screens/detail.py
@@ -125,7 +125,7 @@ class DetailModal(ModalScreen[bool]):
         self.app.push_screen(
             ConfirmModal(f"Delete {self._part.name}?"),
             callback=self._on_delete_confirmed,
-        )  # type: ignore[arg-type]
+        )
 
     def _on_delete_confirmed(self, confirmed: bool | None) -> None:
         if not confirmed:
@@ -151,7 +151,7 @@ class DetailModal(ModalScreen[bool]):
                 self.app.push_screen(
                     ConfirmModal("Discard unsaved changes?"),
                     callback=self._on_discard_confirmed,
-                )  # type: ignore[arg-type]
+                )
             else:
                 self._switch_to_readonly()
             return

--- a/src/kist/tui/themes.py
+++ b/src/kist/tui/themes.py
@@ -2,8 +2,8 @@
 
 from textual.theme import Theme
 
-KIST_DARK = Theme(
-    name="kist-dark",
+NULL_THEME = Theme(
+    name="null",
     primary="#55aaff",
     secondary="#555555",
     warning="#cdcd55",

--- a/src/kist/tui/themes.py
+++ b/src/kist/tui/themes.py
@@ -1,0 +1,18 @@
+"""Custom themes for the kist TUI."""
+
+from textual.theme import Theme
+
+KIST_DARK = Theme(
+    name="kist-dark",
+    primary="#55aaff",
+    secondary="#555555",
+    warning="#cdcd55",
+    error="#cc5555",
+    success="#53ae71",
+    accent="#cc55cc",
+    foreground="#b3b3b3",
+    background="#000000",
+    surface="#0a0a0a",
+    panel="#0a0a0a",
+    dark=True,
+)

--- a/src/kist/tui/widgets/__init__.py
+++ b/src/kist/tui/widgets/__init__.py
@@ -1,0 +1,1 @@
+"""TUI widgets."""

--- a/src/kist/tui/widgets/category_list.py
+++ b/src/kist/tui/widgets/category_list.py
@@ -1,0 +1,45 @@
+"""Category sidebar -- OptionList with part counts."""
+
+from __future__ import annotations
+
+from textual.binding import Binding
+from textual.message import Message
+from textual.widgets import OptionList
+from textual.widgets.option_list import Option
+
+
+class CategoryList(OptionList):
+    """Category sidebar with part counts."""
+
+    BINDINGS = [
+        Binding("j", "cursor_down", "Down", show=False),
+        Binding("k", "cursor_up", "Up", show=False),
+    ]
+
+    class Selected(Message):
+        """Posted when a category is selected."""
+
+        def __init__(self, category: str | None) -> None:
+            super().__init__()
+            self.category = category
+
+    def populate(self, categories: dict[str, int]) -> None:
+        """
+        Rebuild the option list from category codes and counts.
+
+        *categories* maps category code to part count. An "All" entry
+        is prepended with the total. Zero-count categories are skipped.
+        """
+        self.clear_options()
+        total = sum(categories.values())
+        self.add_option(Option(f"All  ({total})", id="__all__"))
+        for code in sorted(categories):
+            count = categories[code]
+            if count == 0:
+                continue
+            self.add_option(Option(f"{code}  ({count})", id=code))
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        option_id = event.option.id
+        category = None if option_id == "__all__" else option_id
+        self.post_message(self.Selected(category))

--- a/src/kist/tui/widgets/header.py
+++ b/src/kist/tui/widgets/header.py
@@ -1,0 +1,76 @@
+"""Custom header with library path display."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from textual.app import ComposeResult
+from textual.widgets import Static
+from textual.widgets._header import Header, HeaderTitle
+
+
+class HeaderPageTitle(Static):
+    """Displays icon + page title on the left of the header."""
+
+    DEFAULT_CSS = """
+    HeaderPageTitle {
+        dock: left;
+        padding: 0 1;
+        width: auto;
+        content-align: left middle;
+    }
+    """
+
+    async def on_click(self) -> None:
+        await self.run_action("app.command_palette")
+
+
+class HeaderLibraryPath(Static):
+    """Displays the active library path on the right side of the header."""
+
+    DEFAULT_CSS = """
+    HeaderLibraryPath {
+        dock: right;
+        padding: 0 1;
+        width: auto;
+        max-width: 40;
+        text-opacity: 60%;
+        content-align: right middle;
+    }
+    """
+
+    def on_mount(self) -> None:
+        self.watch(self.app, "library_path", self._update_path)
+
+    def _update_path(self, path: Path | None) -> None:
+        if path is None:
+            self.update("No library")
+            return
+        try:
+            display = "~" / path.relative_to(Path.home())
+        except ValueError:
+            display = path
+        self.update(str(display))
+
+
+class KistHeader(Header):
+    """Kist header -- icon and page title left, app title center, library path right."""
+
+    def __init__(
+        self,
+        *,
+        page_title: str = "",
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+        icon: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes, icon=icon)
+        self._page_title = page_title
+
+    def compose(self) -> ComposeResult:
+        icon = self.icon or ""
+        label = f"{icon} {self._page_title}" if self._page_title else icon
+        yield HeaderPageTitle(label)
+        yield HeaderTitle()
+        yield HeaderLibraryPath()

--- a/src/kist/tui/widgets/part_form.py
+++ b/src/kist/tui/widgets/part_form.py
@@ -24,6 +24,7 @@ from kist.models.part import (
     SemiJellybeanPart,
     Tier,
 )
+from kist.providers.models import DigiKeyProduct
 
 # -- Select option lists ---
 
@@ -52,6 +53,29 @@ def _subcategory_options(category: str) -> list[tuple[str, str]]:
     return [
         (f"{code} ({name})", code) for code, name in cat_def.subcategory_names.items()
     ]
+
+
+# -- Provider helpers ---
+
+_MOUNTING_MAP: dict[str, str] = {
+    "surface mount": Mounting.SMD,
+    "through hole": Mounting.THT,
+}
+
+_JELLYBEAN_CATEGORIES = frozenset({"RES", "CAP", "IND", "FUSE", "XTAL"})
+_SEMI_JELLYBEAN_CATEGORIES = frozenset({"DIO", "TRAN"})
+
+# DigiKey parameters already captured as top-level DigiKeyProduct fields
+_PROVIDER_SKIP_PARAMS = frozenset({"Package / Case", "Mounting Type"})
+
+
+def _detect_tier(category: str | None) -> str:
+    """Auto-detect part tier from category code."""
+    if category in _JELLYBEAN_CATEGORIES:
+        return Tier.JELLYBEAN
+    if category in _SEMI_JELLYBEAN_CATEGORIES:
+        return Tier.SEMI_JELLYBEAN
+    return Tier.PROPRIETARY
 
 
 # -- PartForm ---
@@ -511,6 +535,95 @@ class PartForm(Static):
             self.query_one("#datasheet-ro", Label).update(ds_str)
 
         self.query_one("#notes", TextArea).text = part.notes or ""
+
+    def load_from_provider(self, product: DigiKeyProduct) -> None:
+        """
+        Populate form fields from a provider response.
+
+        Auto-detects tier based on category and fills editable fields.
+        Does not construct a Part -- the form IS the editing step.
+        """
+        # Auto-detect tier
+        tier = _detect_tier(product.category)
+        self.query_one("#tier", Select).value = tier
+        self._apply_tier_visibility(tier)
+
+        # Category
+        if product.category:
+            self.query_one("#category", Select).value = product.category
+            self._update_subcategories(product.category)
+
+        # Identity
+        self.query_one("#mpn", Input).value = product.mpn
+        self.query_one("#manufacturer", Input).value = product.manufacturer
+
+        # Physical
+        if product.package:
+            self.query_one("#package", Input).value = product.package
+        if product.mounting:
+            mounting = _MOUNTING_MAP.get(product.mounting.lower())
+            if mounting:
+                self.query_one("#mounting", Select).value = mounting
+
+        # Description
+        self.query_one("#description", Input).value = product.description
+
+        # Specs from parameters (skip fields captured at top level)
+        for key, value in product.parameters.items():
+            if key not in _PROVIDER_SKIP_PARAMS:
+                self._add_spec_to_table(key, value)
+
+        # Supplier: DigiKey
+        dk_url = product.digikey_url or ""
+        self._add_supplier_to_table("DigiKey", product.digikey_pn, dk_url)
+
+        # Datasheet -- DigiKey sometimes returns protocol-relative URLs
+        if product.datasheet_url:
+            ds_url = product.datasheet_url
+            if ds_url.startswith("//"):
+                ds_url = "https:" + ds_url
+            self.query_one("#datasheet", Input).value = ds_url
+
+    def clear(self) -> None:
+        """Reset all form fields to empty/default state."""
+        # Selects
+        for sel_id in ("tier", "category", "subcategory", "mounting"):
+            self.query_one(f"#{sel_id}", Select).value = Select.BLANK
+
+        # Text inputs
+        for inp_id in (
+            "mpn",
+            "manufacturer",
+            "base-pn",
+            "package",
+            "description",
+            "tags",
+            "symbol",
+            "footprint",
+            "keywords",
+            "datasheet",
+            "supplier-name",
+            "supplier-sku",
+            "supplier-url",
+            "spec-key",
+            "spec-value",
+        ):
+            self.query_one(f"#{inp_id}", Input).value = ""
+
+        # Notes
+        self.query_one("#notes", TextArea).text = ""
+
+        # Generated name label
+        self.query_one("#part-name-ro", Label).update("")
+
+        # Tables
+        self.query_one("#specs-table", DataTable).clear()
+        self._update_specs_empty()
+        self.query_one("#suppliers-table", DataTable).clear()
+        self._update_suppliers_empty()
+
+        # Reset tier visibility -- show all fields until tier selected
+        self._apply_tier_visibility(None)
 
     def to_dict(self) -> dict:
         """Extract current form values as a flat dict."""

--- a/src/kist/tui/widgets/part_form.py
+++ b/src/kist/tui/widgets/part_form.py
@@ -24,7 +24,7 @@ from kist.models.part import (
     SemiJellybeanPart,
     Tier,
 )
-from kist.providers.models import DigiKeyProduct
+from kist.providers.models import ProviderProduct
 
 # -- Select option lists ---
 
@@ -57,16 +57,14 @@ def _subcategory_options(category: str) -> list[tuple[str, str]]:
 
 # -- Provider helpers ---
 
-_MOUNTING_MAP: dict[str, str] = {
-    "surface mount": Mounting.SMD,
-    "through hole": Mounting.THT,
+# Normalised mounting values from provider layer --> Mounting enum
+_MOUNTING_LOOKUP: dict[str, str] = {
+    "smd": Mounting.SMD,
+    "tht": Mounting.THT,
 }
 
 _JELLYBEAN_CATEGORIES = frozenset({"RES", "CAP", "IND", "FUSE", "XTAL"})
 _SEMI_JELLYBEAN_CATEGORIES = frozenset({"DIO", "TRAN"})
-
-# DigiKey parameters already captured as top-level DigiKeyProduct fields
-_PROVIDER_SKIP_PARAMS = frozenset({"Package / Case", "Mounting Type"})
 
 
 def _detect_tier(category: str | None) -> str:
@@ -536,7 +534,7 @@ class PartForm(Static):
 
         self.query_one("#notes", TextArea).text = part.notes or ""
 
-    def load_from_provider(self, product: DigiKeyProduct) -> None:
+    def load_from_provider(self, product: ProviderProduct) -> None:
         """
         Populate form fields from a provider response.
 
@@ -561,28 +559,26 @@ class PartForm(Static):
         if product.package:
             self.query_one("#package", Input).value = product.package
         if product.mounting:
-            mounting = _MOUNTING_MAP.get(product.mounting.lower())
-            if mounting:
-                self.query_one("#mounting", Select).value = mounting
+            mounting_enum = _MOUNTING_LOOKUP.get(product.mounting)
+            if mounting_enum:
+                self.query_one("#mounting", Select).value = mounting_enum
 
         # Description
         self.query_one("#description", Input).value = product.description
 
-        # Specs from parameters (skip fields captured at top level)
+        # Specs -- package/mounting already excluded by provider layer
         for key, value in product.parameters.items():
-            if key not in _PROVIDER_SKIP_PARAMS:
-                self._add_spec_to_table(key, value)
+            self._add_spec_to_table(key, value)
 
-        # Supplier: DigiKey
-        dk_url = product.digikey_url or ""
-        self._add_supplier_to_table("DigiKey", product.digikey_pn, dk_url)
+        # Supplier
+        sup_url = product.supplier_url or ""
+        self._add_supplier_to_table(
+            product.supplier_name, product.supplier_sku, sup_url
+        )
 
-        # Datasheet -- DigiKey sometimes returns protocol-relative URLs
+        # Datasheet -- already normalised by provider layer
         if product.datasheet_url:
-            ds_url = product.datasheet_url
-            if ds_url.startswith("//"):
-                ds_url = "https:" + ds_url
-            self.query_one("#datasheet", Input).value = ds_url
+            self.query_one("#datasheet", Input).value = product.datasheet_url
 
     def clear(self) -> None:
         """Reset all form fields to empty/default state."""

--- a/src/kist/tui/widgets/part_form.py
+++ b/src/kist/tui/widgets/part_form.py
@@ -17,6 +17,7 @@ from textual.widgets import (
 )
 
 from kist.core.categories import WELL_KNOWN_CATEGORIES
+from kist.models.config import CategoryDef
 from kist.models.part import (
     Mounting,
     Part,
@@ -43,16 +44,6 @@ MOUNTING_OPTIONS: list[tuple[str, str]] = [
 CATEGORY_OPTIONS: list[tuple[str, str]] = [
     (f"{code} ({cat.name})", code) for code, cat in WELL_KNOWN_CATEGORIES.items()
 ]
-
-
-def _subcategory_options(category: str) -> list[tuple[str, str]]:
-    """Build subcategory select options for a given category code."""
-    cat_def = WELL_KNOWN_CATEGORIES.get(category)
-    if cat_def is None or not cat_def.subcategory_names:
-        return []
-    return [
-        (f"{code} ({name})", code) for code, name in cat_def.subcategory_names.items()
-    ]
 
 
 # -- Provider helpers ---
@@ -91,12 +82,14 @@ class PartForm(Static):
         self,
         mode: Literal["editable", "readonly"] = "editable",
         *,
+        categories: dict[str, CategoryDef] | None = None,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
     ) -> None:
         super().__init__(name=name, id=id, classes=classes)
         self._mode: Literal["editable", "readonly"] = mode
+        self._categories = categories or WELL_KNOWN_CATEGORIES
 
     @property
     def mode(self) -> Literal["editable", "readonly"]:
@@ -343,11 +336,23 @@ class PartForm(Static):
 
     # -- Category cascading ---
 
+    def set_categories(self, categories: dict[str, CategoryDef]) -> None:
+        """Update category and subcategory options from library config."""
+        self._categories = categories
+        options = [(f"{code} ({cat.name})", code) for code, cat in categories.items()]
+        self.query_one("#category", Select).set_options(options)
+
     def _update_subcategories(self, category: str) -> None:
         """Update subcategory select options based on category."""
-        options = _subcategory_options(category)
-        sub_select = self.query_one("#subcategory", Select)
-        sub_select.set_options(options)
+        cat_def = self._categories.get(category)
+        if cat_def is None or not cat_def.subcategory_names:
+            options = []
+        else:
+            options = [
+                (f"{code} ({name})", code)
+                for code, name in cat_def.subcategory_names.items()
+            ]
+        self.query_one("#subcategory", Select).set_options(options)
 
     # -- Event handlers ---
 
@@ -469,7 +474,7 @@ class PartForm(Static):
         self.query_one("#tier-ro", Label).update(part.tier.value)
 
         self.query_one("#category", Select).value = part.category
-        cat_def = WELL_KNOWN_CATEGORIES.get(part.category)
+        cat_def = self._categories.get(part.category)
         cat_label = f"{part.category} ({cat_def.name})" if cat_def else part.category
         self.query_one("#category-ro", Label).update(cat_label)
 

--- a/src/kist/tui/widgets/part_form.py
+++ b/src/kist/tui/widgets/part_form.py
@@ -318,10 +318,17 @@ class PartForm(Static):
             self.query_one(f"#{ro_id}").display = not editable
             self.query_one(f"#{rw_id}").display = editable
 
-        self.query_one("#notes", TextArea).disabled = not editable
+        notes = self.query_one("#notes", TextArea)
+        notes.disabled = not editable
+        notes.can_focus = editable
+
         # Action buttons hidden in readonly
         self.query_one("#specs-actions").display = editable
         self.query_one("#suppliers-actions").display = editable
+
+        # DataTables only need focus in editable mode
+        self.query_one("#specs-table", DataTable).can_focus = editable
+        self.query_one("#suppliers-table", DataTable).can_focus = editable
 
     # -- Tier visibility ---
 
@@ -421,7 +428,7 @@ class PartForm(Static):
         empty = table.row_count == 0
         self.query_one("#specs-empty").display = empty
         table.display = not empty
-        table.can_focus = not empty
+        table.can_focus = not empty and self._mode == "editable"
 
     # -- Supplier management ---
 
@@ -451,7 +458,7 @@ class PartForm(Static):
         empty = table.row_count == 0
         self.query_one("#suppliers-empty").display = empty
         table.display = not empty
-        table.can_focus = not empty
+        table.can_focus = not empty and self._mode == "editable"
 
     # -- Data flow ---
 

--- a/src/kist/tui/widgets/part_form.py
+++ b/src/kist/tui/widgets/part_form.py
@@ -1,0 +1,573 @@
+"""PartForm -- single-page composite widget for viewing and editing parts."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import (
+    Button,
+    DataTable,
+    Input,
+    Label,
+    Select,
+    Static,
+    TextArea,
+)
+
+from kist.core.categories import WELL_KNOWN_CATEGORIES
+from kist.models.part import (
+    Mounting,
+    Part,
+    ProprietaryPart,
+    SemiJellybeanPart,
+    Tier,
+)
+
+# -- Select option lists ---
+
+TIER_OPTIONS: list[tuple[str, str]] = [
+    ("Proprietary", Tier.PROPRIETARY),
+    ("Semi-jellybean", Tier.SEMI_JELLYBEAN),
+    ("Jellybean", Tier.JELLYBEAN),
+]
+
+MOUNTING_OPTIONS: list[tuple[str, str]] = [
+    ("SMD", Mounting.SMD),
+    ("THT", Mounting.THT),
+    ("Other", Mounting.OTHER),
+]
+
+CATEGORY_OPTIONS: list[tuple[str, str]] = [
+    (f"{code} ({cat.name})", code) for code, cat in WELL_KNOWN_CATEGORIES.items()
+]
+
+
+def _subcategory_options(category: str) -> list[tuple[str, str]]:
+    """Build subcategory select options for a given category code."""
+    cat_def = WELL_KNOWN_CATEGORIES.get(category)
+    if cat_def is None or not cat_def.subcategory_names:
+        return []
+    return [
+        (f"{code} ({name})", code) for code, name in cat_def.subcategory_names.items()
+    ]
+
+
+# -- PartForm ---
+
+
+class PartForm(Static):
+    """
+    Single-page form for viewing/editing a Part.
+
+    Two modes: "editable" (inputs active) and "readonly" (labels shown).
+    Layout: 2x2 grid -- General + Suppliers top, Specs + KiCad bottom.
+    """
+
+    def __init__(
+        self,
+        mode: Literal["editable", "readonly"] = "editable",
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._mode: Literal["editable", "readonly"] = mode
+
+    @property
+    def mode(self) -> Literal["editable", "readonly"]:
+        return self._mode
+
+    @mode.setter
+    def mode(self, value: Literal["editable", "readonly"]) -> None:
+        self._mode = value
+        if self.is_mounted:
+            self._apply_mode()
+
+    # -- Compose ---
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(id="form-top"):
+            yield from self._compose_general()
+            yield from self._compose_supplier()
+        with Horizontal(id="form-bottom"):
+            yield from self._compose_kicad()
+            yield from self._compose_specs()
+
+    def _compose_general(self) -> ComposeResult:
+        with Vertical(classes="section", id="section-general"):
+            with Horizontal(classes="form-field"):
+                yield Label("Tier", classes="field-label")
+                yield Label("", id="tier-ro", classes="field-value-ro")
+                yield Select(
+                    TIER_OPTIONS, id="tier", classes="field-value", prompt="Select tier"
+                )
+            with Horizontal(classes="form-field"):
+                yield Label("Category", classes="field-label")
+                yield Label("", id="category-ro", classes="field-value-ro")
+                yield Select(
+                    CATEGORY_OPTIONS,
+                    id="category",
+                    classes="field-value",
+                    prompt="Select category",
+                )
+            with Horizontal(classes="form-field"):
+                yield Label("Subcategory", classes="field-label")
+                yield Label("", id="subcategory-ro", classes="field-value-ro")
+                yield Select(
+                    [],
+                    id="subcategory",
+                    classes="field-value",
+                    prompt="Select subcategory",
+                )
+            # MPN (tier-conditional)
+            with Horizontal(classes="form-field", id="field-mpn"):
+                yield Label("MPN", classes="field-label")
+                yield Label("", id="mpn-ro", classes="field-value-ro")
+                yield Input(
+                    id="mpn",
+                    classes="field-value",
+                    placeholder="Manufacturer part number",
+                )
+            # Manufacturer (tier-conditional)
+            with Horizontal(classes="form-field", id="field-manufacturer"):
+                yield Label("Manufacturer", classes="field-label")
+                yield Label("", id="manufacturer-ro", classes="field-value-ro")
+                yield Input(
+                    id="manufacturer", classes="field-value", placeholder="Manufacturer"
+                )
+            # Base PN (tier-conditional: semi-JB only)
+            with Horizontal(classes="form-field", id="field-base-pn"):
+                yield Label("Base PN", classes="field-label")
+                yield Label("", id="base-pn-ro", classes="field-value-ro")
+                yield Input(
+                    id="base-pn",
+                    classes="field-value",
+                    placeholder="Base part number",
+                )
+            with Horizontal(classes="form-field"):
+                yield Label("Package", classes="field-label")
+                yield Label("", id="package-ro", classes="field-value-ro")
+                yield Input(id="package", classes="field-value", placeholder="Package")
+            with Horizontal(classes="form-field"):
+                yield Label("Mounting", classes="field-label")
+                yield Label("", id="mounting-ro", classes="field-value-ro")
+                yield Select(
+                    MOUNTING_OPTIONS,
+                    id="mounting",
+                    classes="field-value",
+                    prompt="Select mounting",
+                )
+            # Name (always read-only)
+            with Horizontal(classes="form-field"):
+                yield Label("Name", classes="field-label")
+                yield Label("", id="part-name-ro", classes="field-value-ro")
+            with Horizontal(classes="form-field"):
+                yield Label("Description", classes="field-label")
+                yield Label("", id="description-ro", classes="field-value-ro")
+                yield Input(
+                    id="description", classes="field-value", placeholder="Description"
+                )
+            with Horizontal(classes="form-field"):
+                yield Label("Tags", classes="field-label")
+                yield Label("", id="tags-ro", classes="field-value-ro")
+                yield Input(
+                    id="tags",
+                    classes="field-value",
+                    placeholder="Comma-separated tags",
+                )
+            with Horizontal(classes="form-field"):
+                yield Label("Datasheet", classes="field-label")
+                yield Label("", id="datasheet-ro", classes="field-value-ro")
+                yield Input(
+                    id="datasheet",
+                    classes="field-value",
+                    placeholder="Datasheet URL",
+                )
+            yield Static("", classes="spacer")
+            yield Label("Notes", classes="section-header")
+            yield TextArea(id="notes")
+
+    def _compose_supplier(self) -> ComposeResult:
+        with Vertical(classes="section", id="section-supplier"):
+            yield Label("No suppliers", id="suppliers-empty", classes="empty-message")
+            yield DataTable(id="suppliers-table")
+            with Horizontal(classes="form-actions", id="suppliers-actions"):
+                yield Input(
+                    id="supplier-name", placeholder="Supplier", classes="field-value"
+                )
+                yield Input(id="supplier-sku", placeholder="SKU", classes="field-value")
+                yield Input(id="supplier-url", placeholder="URL", classes="field-value")
+                yield Button("Add", id="add-supplier", variant="default", disabled=True)
+
+    def _compose_kicad(self) -> ComposeResult:
+        with Vertical(classes="section", id="section-kicad"):
+            with Horizontal(classes="form-field"):
+                yield Label("Symbol", classes="field-label")
+                yield Label("", id="symbol-ro", classes="field-value-ro")
+                yield Input(
+                    id="symbol", classes="field-value", placeholder="Library:Symbol"
+                )
+            with Horizontal(classes="form-field"):
+                yield Label("Footprint", classes="field-label")
+                yield Label("", id="footprint-ro", classes="field-value-ro")
+                yield Input(
+                    id="footprint",
+                    classes="field-value",
+                    placeholder="Library:Footprint",
+                )
+            with Horizontal(classes="form-field"):
+                yield Label("Keywords", classes="field-label")
+                yield Label("", id="keywords-ro", classes="field-value-ro")
+                yield Input(
+                    id="keywords",
+                    classes="field-value",
+                    placeholder="Space-separated",
+                )
+
+    def _compose_specs(self) -> ComposeResult:
+        with Vertical(classes="section", id="section-specs"):
+            yield Label("No specs", id="specs-empty", classes="empty-message")
+            yield DataTable(id="specs-table")
+            with Horizontal(classes="form-actions", id="specs-actions"):
+                yield Input(id="spec-key", placeholder="Key", classes="field-value")
+                yield Input(id="spec-value", placeholder="Value", classes="field-value")
+                yield Button(
+                    "Add spec", id="add-spec", variant="default", disabled=True
+                )
+
+    # -- Mount ---
+
+    def on_mount(self) -> None:
+        # Section border titles
+        self.query_one("#section-general").border_title = "General"
+        self.query_one("#section-supplier").border_title = "Suppliers"
+        self.query_one("#section-kicad").border_title = "KiCad"
+        self.query_one("#section-specs").border_title = "Specs"
+
+        # Specs table setup
+        specs_table = self.query_one("#specs-table", DataTable)
+        specs_table.add_columns("Key", "Value")
+        specs_table.show_header = False
+        specs_table.cursor_type = "row"
+        specs_table.zebra_stripes = True
+        specs_table.display = False
+        specs_table.can_focus = False
+
+        # Suppliers table setup
+        sup_table = self.query_one("#suppliers-table", DataTable)
+        sup_table.add_columns("Supplier", "SKU", "URL")
+        sup_table.show_header = True
+        sup_table.cursor_type = "row"
+        sup_table.zebra_stripes = True
+        sup_table.display = False
+        sup_table.can_focus = False
+
+        self._apply_mode()
+        # Default tier visibility -- show all fields until a tier is selected
+        self._apply_tier_visibility(None)
+
+    # -- Mode switching ---
+
+    # Widget pairs: (readonly label id, editable widget id)
+    _RW_PAIRS: list[tuple[str, str]] = [
+        ("tier-ro", "tier"),
+        ("category-ro", "category"),
+        ("subcategory-ro", "subcategory"),
+        ("mpn-ro", "mpn"),
+        ("manufacturer-ro", "manufacturer"),
+        ("base-pn-ro", "base-pn"),
+        ("package-ro", "package"),
+        ("mounting-ro", "mounting"),
+        ("description-ro", "description"),
+        ("tags-ro", "tags"),
+        ("symbol-ro", "symbol"),
+        ("footprint-ro", "footprint"),
+        ("keywords-ro", "keywords"),
+        ("datasheet-ro", "datasheet"),
+    ]
+
+    def _apply_mode(self) -> None:
+        """Toggle display on all readonly/editable widget pairs."""
+        editable = self._mode == "editable"
+        for ro_id, rw_id in self._RW_PAIRS:
+            self.query_one(f"#{ro_id}").display = not editable
+            self.query_one(f"#{rw_id}").display = editable
+
+        self.query_one("#notes", TextArea).disabled = not editable
+        # Action buttons hidden in readonly
+        self.query_one("#specs-actions").display = editable
+        self.query_one("#suppliers-actions").display = editable
+
+    # -- Tier visibility ---
+
+    def _apply_tier_visibility(self, tier: str | None) -> None:
+        """Show/hide fields based on the selected tier."""
+        show_mpn = tier in (Tier.PROPRIETARY, Tier.SEMI_JELLYBEAN)
+        show_base_pn = tier == Tier.SEMI_JELLYBEAN
+
+        self.query_one("#field-mpn").display = show_mpn
+        self.query_one("#field-manufacturer").display = show_mpn
+        self.query_one("#field-base-pn").display = show_base_pn
+
+    # -- Category cascading ---
+
+    def _update_subcategories(self, category: str) -> None:
+        """Update subcategory select options based on category."""
+        options = _subcategory_options(category)
+        sub_select = self.query_one("#subcategory", Select)
+        sub_select.set_options(options)
+
+    # -- Event handlers ---
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        if event.select.id == "tier" and event.value != Select.BLANK:
+            self._apply_tier_visibility(str(event.value))
+        elif event.select.id == "category" and event.value != Select.BLANK:
+            self._update_subcategories(str(event.value))
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Enable Add buttons when required inputs have content."""
+        if event.input.id == "spec-key":
+            self.query_one("#add-spec", Button).disabled = not event.value.strip()
+        elif event.input.id == "supplier-name":
+            has_name = bool(event.value.strip())
+            has_sku = bool(self.query_one("#supplier-sku", Input).value.strip())
+            self.query_one("#add-supplier", Button).disabled = not (
+                has_name and has_sku
+            )
+        elif event.input.id == "supplier-sku":
+            has_name = bool(self.query_one("#supplier-name", Input).value.strip())
+            has_sku = bool(event.value.strip())
+            self.query_one("#add-supplier", Button).disabled = not (
+                has_name and has_sku
+            )
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Tab through input fields, submit on last."""
+        if event.input.id == "spec-key" and event.value.strip():
+            self.query_one("#spec-value", Input).focus()
+        elif event.input.id == "spec-value":
+            if self.query_one("#spec-key", Input).value.strip():
+                self._submit_spec()
+        elif event.input.id == "supplier-name" and event.value.strip():
+            self.query_one("#supplier-sku", Input).focus()
+        elif event.input.id == "supplier-sku" and event.value.strip():
+            self.query_one("#supplier-url", Input).focus()
+        elif event.input.id == "supplier-url":
+            if self.query_one("#supplier-name", Input).value.strip():
+                self._submit_supplier()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "add-spec":
+            self._submit_spec()
+        elif event.button.id == "add-supplier":
+            self._submit_supplier()
+
+    # -- Spec management ---
+
+    def _submit_spec(self) -> None:
+        """Add spec from inputs to table, clear inputs, refocus key."""
+        key_input = self.query_one("#spec-key", Input)
+        value_input = self.query_one("#spec-value", Input)
+        key = key_input.value.strip()
+        value = value_input.value.strip()
+        if not key:
+            return
+        self._add_spec_to_table(key, value)
+        key_input.value = ""
+        value_input.value = ""
+        key_input.focus()
+
+    def _add_spec_to_table(self, key: str, value: str) -> None:
+        table = self.query_one("#specs-table", DataTable)
+        table.add_row(key, value)
+        self._update_specs_empty()
+
+    def _delete_spec_row(self) -> None:
+        """Remove the currently selected spec row (backspace from table)."""
+        table = self.query_one("#specs-table", DataTable)
+        if table.row_count > 0:
+            row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
+            table.remove_row(row_key)
+            self._update_specs_empty()
+
+    def _update_specs_empty(self) -> None:
+        table = self.query_one("#specs-table", DataTable)
+        empty = table.row_count == 0
+        self.query_one("#specs-empty").display = empty
+        table.display = not empty
+        table.can_focus = not empty
+
+    # -- Supplier management ---
+
+    def _submit_supplier(self) -> None:
+        """Add supplier from inputs to table, clear inputs, refocus name."""
+        name_input = self.query_one("#supplier-name", Input)
+        sku_input = self.query_one("#supplier-sku", Input)
+        url_input = self.query_one("#supplier-url", Input)
+        name = name_input.value.strip()
+        sku = sku_input.value.strip()
+        url = url_input.value.strip()
+        if not name or not sku:
+            return
+        self._add_supplier_to_table(name, sku, url)
+        name_input.value = ""
+        sku_input.value = ""
+        url_input.value = ""
+        name_input.focus()
+
+    def _add_supplier_to_table(self, name: str, sku: str, url: str) -> None:
+        table = self.query_one("#suppliers-table", DataTable)
+        table.add_row(name, sku, url)
+        self._update_suppliers_empty()
+
+    def _update_suppliers_empty(self) -> None:
+        table = self.query_one("#suppliers-table", DataTable)
+        empty = table.row_count == 0
+        self.query_one("#suppliers-empty").display = empty
+        table.display = not empty
+        table.can_focus = not empty
+
+    # -- Data flow ---
+
+    def load_part(self, part: Part) -> None:
+        """Populate all form fields from a Part model."""
+        # Identity
+        self.query_one("#tier", Select).value = part.tier
+        self.query_one("#tier-ro", Label).update(part.tier.value)
+
+        self.query_one("#category", Select).value = part.category
+        cat_def = WELL_KNOWN_CATEGORIES.get(part.category)
+        cat_label = f"{part.category} ({cat_def.name})" if cat_def else part.category
+        self.query_one("#category-ro", Label).update(cat_label)
+
+        self._update_subcategories(part.category)
+        if part.subcategory:
+            self.query_one("#subcategory", Select).value = part.subcategory
+            sub_name = (
+                cat_def.subcategory_names.get(part.subcategory, "") if cat_def else ""
+            )
+            sub_label = (
+                f"{part.subcategory} ({sub_name})" if sub_name else part.subcategory
+            )
+            self.query_one("#subcategory-ro", Label).update(sub_label)
+
+        if isinstance(part, (ProprietaryPart, SemiJellybeanPart)):
+            self.query_one("#mpn", Input).value = part.mpn
+            self.query_one("#mpn-ro", Label).update(part.mpn)
+            self.query_one("#manufacturer", Input).value = part.manufacturer
+            self.query_one("#manufacturer-ro", Label).update(part.manufacturer)
+
+        if isinstance(part, SemiJellybeanPart):
+            self.query_one("#base-pn", Input).value = part.base_pn
+            self.query_one("#base-pn-ro", Label).update(part.base_pn)
+
+        self.query_one("#package", Input).value = part.package or ""
+        self.query_one("#package-ro", Label).update(part.package or "")
+
+        if part.mounting:
+            self.query_one("#mounting", Select).value = part.mounting
+            self.query_one("#mounting-ro", Label).update(part.mounting.value)
+
+        self.query_one("#part-name-ro", Label).update(part.name)
+
+        self.query_one("#description", Input).value = part.description
+        self.query_one("#description-ro", Label).update(part.description)
+
+        tags_str = ", ".join(part.tags)
+        self.query_one("#tags", Input).value = tags_str
+        self.query_one("#tags-ro", Label).update(tags_str)
+
+        # Tier visibility
+        self._apply_tier_visibility(part.tier)
+
+        # Specs
+        if part.specifications:
+            for key, val in part.specifications.items():
+                self._add_spec_to_table(key, val)
+
+        # Suppliers
+        for sup_name, info in part.suppliers.items():
+            url_str = str(info.url) if info.url else ""
+            self._add_supplier_to_table(sup_name, info.sku, url_str)
+
+        # KiCad
+        self.query_one("#symbol", Input).value = part.symbol
+        self.query_one("#symbol-ro", Label).update(part.symbol)
+        self.query_one("#footprint", Input).value = part.footprint
+        self.query_one("#footprint-ro", Label).update(part.footprint)
+
+        keywords_str = " ".join(part.keywords)
+        self.query_one("#keywords", Input).value = keywords_str
+        self.query_one("#keywords-ro", Label).update(keywords_str)
+
+        # Notes
+        if part.datasheet:
+            ds_str = str(part.datasheet)
+            self.query_one("#datasheet", Input).value = ds_str
+            self.query_one("#datasheet-ro", Label).update(ds_str)
+
+        self.query_one("#notes", TextArea).text = part.notes or ""
+
+    def to_dict(self) -> dict:
+        """Extract current form values as a flat dict."""
+        result: dict = {}
+
+        # Identity
+        tier_val = self.query_one("#tier", Select).value
+        result["tier"] = tier_val if tier_val != Select.BLANK else None
+
+        cat_val = self.query_one("#category", Select).value
+        result["category"] = cat_val if cat_val != Select.BLANK else None
+
+        sub_val = self.query_one("#subcategory", Select).value
+        result["subcategory"] = sub_val if sub_val != Select.BLANK else None
+
+        result["mpn"] = self.query_one("#mpn", Input).value
+        result["manufacturer"] = self.query_one("#manufacturer", Input).value
+        result["base_pn"] = self.query_one("#base-pn", Input).value
+        result["package"] = self.query_one("#package", Input).value
+
+        mounting_val = self.query_one("#mounting", Select).value
+        result["mounting"] = mounting_val if mounting_val != Select.BLANK else None
+
+        result["description"] = self.query_one("#description", Input).value
+
+        tags_raw = self.query_one("#tags", Input).value
+        result["tags"] = [t.strip() for t in tags_raw.split(",") if t.strip()]
+
+        # Specs
+        specs: dict[str, str] = {}
+        specs_table = self.query_one("#specs-table", DataTable)
+        for row_key in specs_table.rows:
+            row_data = specs_table.get_row(row_key)
+            k = str(row_data[0]).strip()
+            v = str(row_data[1]).strip()
+            if k:
+                specs[k] = v
+        result["specifications"] = specs if specs else None
+
+        # Suppliers
+        suppliers: dict = {}
+        sup_table = self.query_one("#suppliers-table", DataTable)
+        for row_key in sup_table.rows:
+            row_data = sup_table.get_row(row_key)
+            sup_name = str(row_data[0]).strip()
+            sku = str(row_data[1]).strip()
+            url = str(row_data[2]).strip()
+            if sup_name and sku:
+                suppliers[sup_name] = {"sku": sku, "url": url or None}
+        result["suppliers"] = suppliers
+
+        # KiCad
+        result["symbol"] = self.query_one("#symbol", Input).value
+        result["footprint"] = self.query_one("#footprint", Input).value
+        result["keywords"] = self.query_one("#keywords", Input).value.split()
+        # Notes
+        result["datasheet"] = self.query_one("#datasheet", Input).value or None
+        result["notes"] = self.query_one("#notes", TextArea).text or None
+
+        return result

--- a/src/kist/tui/widgets/parts_table.py
+++ b/src/kist/tui/widgets/parts_table.py
@@ -24,15 +24,14 @@ class PartsTable(DataTable):
     Uses ``part.ipn`` as the row key for later detail-modal lookup.
     """
 
-    cursor_type = "row"
-    zebra_stripes = True
-
     BINDINGS = [
         Binding("j", "cursor_down", "Down", show=False),
         Binding("k", "cursor_up", "Up", show=False),
     ]
 
     def on_mount(self) -> None:
+        self.cursor_type = "row"
+        self.zebra_stripes = True
         self.add_columns("Name", "Value", "Package", "Tier", "Description")
 
     def populate(self, parts: list[Part]) -> None:

--- a/src/kist/tui/widgets/parts_table.py
+++ b/src/kist/tui/widgets/parts_table.py
@@ -1,0 +1,52 @@
+"""Parts table -- DataTable configured for displaying Part objects."""
+
+from __future__ import annotations
+
+from textual.binding import Binding
+from textual.widgets import DataTable
+
+from kist.models.part import Part, Tier
+
+TIER_ABBREV: dict[Tier, str] = {
+    Tier.JELLYBEAN: "JB",
+    Tier.SEMI_JELLYBEAN: "SJ",
+    Tier.PROPRIETARY: "PR",
+}
+
+MAX_DESC_LEN = 40
+
+
+class PartsTable(DataTable):
+    """
+    DataTable subclass pre-configured for part display.
+
+    Columns: Name, Value, Package, Tier, Description.
+    Uses ``part.ipn`` as the row key for later detail-modal lookup.
+    """
+
+    cursor_type = "row"
+    zebra_stripes = True
+
+    BINDINGS = [
+        Binding("j", "cursor_down", "Down", show=False),
+        Binding("k", "cursor_up", "Up", show=False),
+    ]
+
+    def on_mount(self) -> None:
+        self.add_columns("Name", "Value", "Package", "Tier", "Description")
+
+    def populate(self, parts: list[Part]) -> None:
+        """Clear and repopulate with the given parts."""
+        self.clear()
+        for part in parts:
+            desc = part.description
+            if len(desc) > MAX_DESC_LEN:
+                desc = desc[: MAX_DESC_LEN - 3] + "..."
+            self.add_row(
+                part.name,
+                part.value,
+                part.package or "",
+                TIER_ABBREV.get(Tier(part.tier), part.tier),
+                desc,
+                key=part.ipn,
+            )

--- a/tests/core/test_check.py
+++ b/tests/core/test_check.py
@@ -1,0 +1,77 @@
+"""Tests for library health checks."""
+
+import copy
+
+from kist.core.categories import WELL_KNOWN_CATEGORIES
+from kist.core.check import check_library
+from kist.core.database import PartsDatabase, create_empty
+from kist.models.config import LibraryConfig
+
+
+def _make_db(tmp_path, parts):
+    """Create a loaded PartsDatabase with the given parts."""
+    path = tmp_path / "parts.json"
+    create_empty(path)
+    db = PartsDatabase(path)
+    db.load()
+    for part in parts:
+        db.add(part)
+    return db
+
+
+def test_clean_library_returns_empty(tmp_path, jellybean_part):
+    db = _make_db(tmp_path, [jellybean_part])
+    config = LibraryConfig(categories=dict(WELL_KNOWN_CATEGORIES))
+    issues = check_library(db, config)
+    assert issues == []
+
+
+def test_empty_library_returns_empty(tmp_path):
+    db = _make_db(tmp_path, [])
+    config = LibraryConfig(categories=dict(WELL_KNOWN_CATEGORIES))
+    issues = check_library(db, config)
+    assert issues == []
+
+
+def test_name_drift_detected(tmp_path, jellybean_part):
+    jellybean_part.name = "WRONG-NAME"
+    db = _make_db(tmp_path, [jellybean_part])
+    config = LibraryConfig(categories=dict(WELL_KNOWN_CATEGORIES))
+
+    issues = check_library(db, config)
+
+    assert len(issues) == 1
+    assert issues[0].kind == "name_drift"
+    assert "WRONG-NAME" in issues[0].message
+    assert issues[0].parts == ["WRONG-NAME"]
+
+
+def test_duplicate_identity_detected(tmp_path, jellybean_part):
+    part_a = jellybean_part
+    part_b = copy.deepcopy(jellybean_part)
+    part_b.name = "RES-10K-1PCT-0603-COPY"
+
+    db = _make_db(tmp_path, [part_a, part_b])
+    config = LibraryConfig(categories=dict(WELL_KNOWN_CATEGORIES))
+
+    issues = check_library(db, config)
+
+    dup_issues = [i for i in issues if i.kind == "duplicate_identity"]
+    assert len(dup_issues) == 1
+    assert len(dup_issues[0].parts) == 2
+
+
+def test_both_issues_reported(tmp_path, jellybean_part):
+    """A part with a wrong name that also collides with another."""
+    part_a = jellybean_part
+    part_b = copy.deepcopy(jellybean_part)
+    part_b.name = "WRONG-NAME"
+
+    db = _make_db(tmp_path, [part_a, part_b])
+    config = LibraryConfig(categories=dict(WELL_KNOWN_CATEGORIES))
+
+    issues = check_library(db, config)
+
+    kinds = {i.kind for i in issues}
+    assert "name_drift" in kinds
+    assert "duplicate_identity" in kinds

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -212,18 +212,16 @@ def test_provider_mapping_extends_defaults(tmp_path, monkeypatch):
     assert mapping.parameters["Resistance"] == "resistance"
 
 
-def test_provider_mapping_replaces_list_fields(tmp_path, monkeypatch):
-    """List fields in TOML replace the defaults entirely."""
+def test_provider_mapping_replaces_scalar_fields(tmp_path, monkeypatch):
+    """Scalar fields in TOML replace the defaults entirely."""
     config_dir = tmp_path / "cfg"
     config_dir.mkdir()
     monkeypatch.setenv("KIST_CONFIG_DIR", str(config_dir))
     providers_dir = config_dir / "providers"
     providers_dir.mkdir()
-    (providers_dir / "digikey.toml").write_text(
-        'ignore_parameters = ["Power (Watts)"]\n'
-    )
+    (providers_dir / "digikey.toml").write_text('supplier_name = "DK Custom"\n')
     mapping = load_provider_mapping("digikey")
-    assert mapping.ignore_parameters == ["Power (Watts)"]
+    assert mapping.supplier_name == "DK Custom"
 
 
 def test_provider_mapping_invalid_toml_raises(tmp_path, monkeypatch):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -52,7 +52,7 @@ def test_load_global_config_invalid_toml(tmp_path, monkeypatch):
 
 def test_global_config_theme_default():
     cfg = GlobalConfig()
-    assert cfg.theme == "kist-dark"
+    assert cfg.theme == "null"
 
 
 # --- save_global_config ---

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -6,6 +6,7 @@ from kist.core.config import (
     load_global_config,
     load_library_config,
     load_project_ref,
+    load_provider_mapping,
     resolve_init_config,
     save_library_config,
     save_project_ref,
@@ -164,3 +165,78 @@ def test_load_project_ref_invalid_raises(tmp_path):
     path.write_text("bad [[[")
     with pytest.raises(ConfigError):
         load_project_ref(path)
+
+
+# --- load_provider_mapping ---
+
+
+def test_provider_mapping_no_toml_returns_defaults():
+    """No config file returns the provider's built-in defaults."""
+    mapping = load_provider_mapping("digikey")
+    assert mapping.supplier_name == "DigiKey"
+    assert "Resistors" in mapping.categories
+    assert "Resistance" in mapping.parameters
+    assert mapping.parameters["Package / Case"] == "package"
+    assert mapping.parameters["Mounting Type"] == "mounting"
+
+
+def test_provider_mapping_merges_overrides(tmp_path, monkeypatch):
+    """User TOML entries overlay defaults; unspecified defaults are kept."""
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(config_dir))
+    providers_dir = config_dir / "providers"
+    providers_dir.mkdir()
+    (providers_dir / "digikey.toml").write_text(
+        '[categories]\n"My Custom Category" = "IC"\n'
+    )
+    mapping = load_provider_mapping("digikey")
+    # User override present
+    assert mapping.categories["My Custom Category"] == "IC"
+    # Built-in defaults preserved
+    assert mapping.categories["Resistors"] == "RES"
+
+
+def test_provider_mapping_extends_defaults(tmp_path, monkeypatch):
+    """New entries in TOML are added alongside existing defaults."""
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(config_dir))
+    providers_dir = config_dir / "providers"
+    providers_dir.mkdir()
+    (providers_dir / "digikey.toml").write_text(
+        '[parameters]\n"New Param" = "new_param"\n'
+    )
+    mapping = load_provider_mapping("digikey")
+    assert mapping.parameters["New Param"] == "new_param"
+    assert mapping.parameters["Resistance"] == "resistance"
+
+
+def test_provider_mapping_replaces_list_fields(tmp_path, monkeypatch):
+    """List fields in TOML replace the defaults entirely."""
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(config_dir))
+    providers_dir = config_dir / "providers"
+    providers_dir.mkdir()
+    (providers_dir / "digikey.toml").write_text(
+        'ignore_parameters = ["Power (Watts)"]\n'
+    )
+    mapping = load_provider_mapping("digikey")
+    assert mapping.ignore_parameters == ["Power (Watts)"]
+
+
+def test_provider_mapping_invalid_toml_raises(tmp_path, monkeypatch):
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(config_dir))
+    providers_dir = config_dir / "providers"
+    providers_dir.mkdir()
+    (providers_dir / "digikey.toml").write_text("bad [[[")
+    with pytest.raises(ConfigError):
+        load_provider_mapping("digikey")
+
+
+def test_provider_mapping_unknown_provider_raises():
+    with pytest.raises(ConfigError, match="Unknown provider"):
+        load_provider_mapping("nonexistent")

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -8,11 +8,12 @@ from kist.core.config import (
     load_project_ref,
     load_provider_mapping,
     resolve_init_config,
+    save_global_config,
     save_library_config,
     save_project_ref,
 )
 from kist.errors import ConfigError
-from kist.models import DEFAULT_SUPPLIERS, LibraryConfig, ProjectRef
+from kist.models import DEFAULT_SUPPLIERS, GlobalConfig, LibraryConfig, ProjectRef
 
 
 @pytest.fixture(autouse=True)
@@ -47,6 +48,31 @@ def test_load_global_config_invalid_toml(tmp_path, monkeypatch):
     (config_dir / "config.toml").write_text("not valid toml [[[")
     with pytest.raises(ConfigError):
         load_global_config()
+
+
+def test_global_config_theme_default():
+    cfg = GlobalConfig()
+    assert cfg.theme == "kist-dark"
+
+
+# --- save_global_config ---
+
+
+def test_save_global_config_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(tmp_path / "gc"))
+    cfg = GlobalConfig(theme="nord")
+    save_global_config(cfg)
+    loaded = load_global_config()
+    assert loaded.theme == "nord"
+    # Other fields preserved
+    assert loaded.symbols_dir == "symbols"
+
+
+def test_save_global_config_creates_dir(tmp_path, monkeypatch):
+    config_dir = tmp_path / "new-dir"
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(config_dir))
+    save_global_config(GlobalConfig())
+    assert (config_dir / "config.toml").exists()
 
 
 # --- resolve_init_config ---

--- a/tests/core/test_database.py
+++ b/tests/core/test_database.py
@@ -104,6 +104,33 @@ def test_resolve_missing_returns_none(db: PartsDatabase):
     assert db.resolve("DOES-NOT-EXIST") is None
 
 
+# -- ipn on parts ------------------------------------------------------------
+
+
+def test_ipn_set_on_load(db: PartsDatabase, proprietary_part: ProprietaryPart):
+    """Parts carry their own IPN after load."""
+    ipn = db.add(proprietary_part)
+
+    db2 = PartsDatabase(db.path)
+    db2.load()
+    part = db2.get(ipn)
+    assert part is not None
+    assert part.ipn == ipn
+
+
+def test_ipn_set_on_add(db: PartsDatabase, proprietary_part: ProprietaryPart):
+    """add() sets ipn on the part object."""
+    ipn = db.add(proprietary_part)
+    assert proprietary_part.ipn == ipn
+
+
+def test_ipn_excluded_from_serialization(proprietary_part: ProprietaryPart):
+    """ipn is excluded from model_dump so it doesn't duplicate the dict key."""
+    proprietary_part.ipn = Ipn("test-id")
+    data = proprietary_part.model_dump(mode="json")
+    assert "ipn" not in data
+
+
 # -- list_parts --------------------------------------------------------------
 
 

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -1,7 +1,10 @@
 """Tests for library operations: init, link, and discovery."""
 
+import uuid
+
 import pytest
 
+from kist.core.config import load_library_config
 from kist.core.library import find_library, init_library, link_library
 from kist.errors import LibraryExistsError, LibraryNotFoundError
 
@@ -22,6 +25,13 @@ def test_init_creates_structure(tmp_path):
     assert (root / "footprints").is_dir()
     assert (root / "3dmodels").is_dir()
     assert (root / "blocks").is_dir()
+
+
+def test_init_generates_library_id(tmp_path):
+    root = init_library(tmp_path / "lib")
+    config = load_library_config(root)
+    assert config.library_id
+    uuid.UUID(config.library_id)  # raises ValueError if not valid
 
 
 def test_init_respects_overrides(tmp_path):
@@ -68,7 +78,23 @@ def test_link_creates_ref_and_symlink(tmp_path):
     assert ref_path.exists()
     content = ref_path.read_text()
     assert "library_path" in content
+    assert "library_id" in content
     assert (project / "lib").is_symlink()
+
+
+def test_link_stores_library_id(tmp_path):
+    lib = tmp_path / "lib"
+    init_library(lib)
+    lib_config = load_library_config(lib)
+    project = tmp_path / "project"
+    project.mkdir()
+
+    link_library(project, lib)
+
+    from kist.core.config import load_project_ref
+
+    ref = load_project_ref(project / "kist.toml")
+    assert ref.library_id == lib_config.library_id
 
 
 def test_link_skips_existing_lib_dir(tmp_path):
@@ -110,7 +136,9 @@ def test_link_rejects_already_linked(tmp_path):
 def test_find_from_library_root(tmp_path):
     lib = tmp_path / "lib"
     init_library(lib)
-    assert find_library(lib) == lib.resolve()
+    result = find_library(lib)
+    assert result.library_root == lib.resolve()
+    assert result.project_dir is None
 
 
 def test_find_from_subdirectory(tmp_path):
@@ -118,7 +146,7 @@ def test_find_from_subdirectory(tmp_path):
     init_library(lib)
     subdir = lib / "symbols" / "deep"
     subdir.mkdir(parents=True)
-    assert find_library(subdir) == lib.resolve()
+    assert find_library(subdir).library_root == lib.resolve()
 
 
 def test_find_via_project_ref(tmp_path):
@@ -127,7 +155,9 @@ def test_find_via_project_ref(tmp_path):
     project = tmp_path / "project"
     project.mkdir()
     link_library(project, lib)
-    assert find_library(project) == lib.resolve()
+    result = find_library(project)
+    assert result.library_root == lib.resolve()
+    assert result.project_dir == project.resolve()
 
 
 def test_find_via_nested_subdir_to_project_ref(tmp_path):
@@ -138,7 +168,9 @@ def test_find_via_nested_subdir_to_project_ref(tmp_path):
     link_library(project, lib)
     subdir = project / "boards" / "rev-a"
     subdir.mkdir(parents=True)
-    assert find_library(subdir) == lib.resolve()
+    result = find_library(subdir)
+    assert result.library_root == lib.resolve()
+    assert result.project_dir == project.resolve()
 
 
 def test_find_not_found(tmp_path):
@@ -160,11 +192,51 @@ def test_find_prefers_kist_marker_over_ref(tmp_path):
     init_library(lib)
     # Also drop a kist.toml pointing elsewhere
     (lib / "kist.toml").write_text('version = 1\nlibrary_path = "../other"\n')
-    assert find_library(lib) == lib.resolve()
+    assert find_library(lib).library_root == lib.resolve()
 
 
 def test_find_uses_cwd_default(tmp_path, monkeypatch):
     lib = tmp_path / "lib"
     init_library(lib)
     monkeypatch.chdir(lib)
-    assert find_library() == lib.resolve()
+    assert find_library().library_root == lib.resolve()
+
+
+# --- project_dir discovery from library root ---
+
+
+def test_find_discovers_project_from_library(tmp_path):
+    """When inside the library, check parent for kist.toml."""
+    project = tmp_path / "project"
+    project.mkdir()
+    lib = project / "lib"
+    init_library(lib)
+    link_library(project, lib)
+
+    result = find_library(lib)
+    assert result.library_root == lib.resolve()
+    assert result.project_dir == project.resolve()
+
+
+def test_find_no_project_when_parent_has_no_ref(tmp_path):
+    """Library root with no kist.toml in parent returns no project_dir."""
+    lib = tmp_path / "lib"
+    init_library(lib)
+    result = find_library(lib)
+    assert result.project_dir is None
+
+
+def test_find_no_project_when_parent_ref_points_elsewhere(tmp_path):
+    """kist.toml in parent that points to a different library is ignored."""
+    project = tmp_path / "project"
+    project.mkdir()
+    lib = project / "lib"
+    init_library(lib)
+    # kist.toml points to a different library
+    other_lib = tmp_path / "other-lib"
+    init_library(other_lib)
+    link_library(project, other_lib)
+
+    result = find_library(lib)
+    assert result.library_root == lib.resolve()
+    assert result.project_dir is None

--- a/tests/core/test_sync.py
+++ b/tests/core/test_sync.py
@@ -6,7 +6,7 @@ import pytest
 
 from kist.core.categories import WELL_KNOWN_CATEGORIES
 from kist.core.database import PartsDatabase, create_empty
-from kist.core.sync import sync_symbols
+from kist.core.sync import SYM_LIB_TABLE, sync_sym_lib_table, sync_symbols
 from kist.kicad.mapping import library_filename
 from kist.kicad.symbols import SymbolLibrary
 from kist.models import (
@@ -225,3 +225,89 @@ def test_creates_symbols_dir_if_missing(tmp_path):
 
     path = root / "symbols" / _res_filename()
     assert path.exists()
+
+
+def test_sync_symbols_returns_written_files(library):
+    root, db, config = library
+    res = _make_resistor("10kΩ", "1%", "0603")
+    cap = _make_capacitor("100nF", "50V", "0402")
+    db.add(res)
+    db.add(cap)
+
+    written = sync_symbols(root, db, config)
+    assert len(written) == 2
+    assert all(p.suffix == ".kicad_sym" for p in written)
+
+
+# --- sync_sym_lib_table ---
+
+
+def test_sync_sym_lib_table_creates_file(library):
+    root, db, config = library
+    db.add(_make_resistor("10kΩ", "1%", "0603"))
+    symbol_files = sync_symbols(root, db, config)
+
+    project_dir = root.parent
+    sync_sym_lib_table(project_dir, symbol_files, config)
+
+    table_path = project_dir / SYM_LIB_TABLE
+    assert table_path.exists()
+    content = table_path.read_text()
+    assert "00k-Resistors" in content
+    assert "${KIPRJMOD}/lib/symbols/" in content
+
+
+def test_sync_sym_lib_table_updates_existing(library):
+    root, db, config = library
+    project_dir = root.parent
+
+    # Write an existing table with a non-kist entry
+    existing = (
+        "(sym_lib_table\n"
+        "  (version 7)\n"
+        '  (lib (name "power")(type "KiCad")'
+        '(uri "${KICAD8_SYMBOL_DIR}/power.kicad_sym")'
+        '(options "")(descr ""))\n'
+        ")\n"
+    )
+    (project_dir / SYM_LIB_TABLE).write_text(existing)
+
+    db.add(_make_resistor("10kΩ", "1%", "0603"))
+    symbol_files = sync_symbols(root, db, config)
+    sync_sym_lib_table(project_dir, symbol_files, config)
+
+    content = (project_dir / SYM_LIB_TABLE).read_text()
+    # Non-kist entry preserved
+    assert "power" in content
+    # Kist entry added
+    assert "00k-Resistors" in content
+
+
+def test_sync_sym_lib_table_empty_db(library):
+    root, db, config = library
+    symbol_files = sync_symbols(root, db, config)
+
+    project_dir = root.parent
+    sync_sym_lib_table(project_dir, symbol_files, config)
+
+    table_path = project_dir / SYM_LIB_TABLE
+    assert table_path.exists()
+    content = table_path.read_text()
+    assert "sym_lib_table" in content
+    # No lib entries
+    assert "00k-" not in content
+
+
+def test_sync_sym_lib_table_idempotent(library):
+    root, db, config = library
+    db.add(_make_resistor("10kΩ", "1%", "0603"))
+    symbol_files = sync_symbols(root, db, config)
+
+    project_dir = root.parent
+    sync_sym_lib_table(project_dir, symbol_files, config)
+    first = (project_dir / SYM_LIB_TABLE).read_text()
+
+    sync_sym_lib_table(project_dir, symbol_files, config)
+    second = (project_dir / SYM_LIB_TABLE).read_text()
+
+    assert first == second

--- a/tests/kicad/test_lib_table.py
+++ b/tests/kicad/test_lib_table.py
@@ -1,0 +1,141 @@
+"""Tests for sym-lib-table generation and update."""
+
+from pathlib import Path
+
+from kist.kicad.lib_table import generate_sym_lib_table, update_sym_lib_table
+from kist.sexpr import find_all, parse_one
+
+
+def _parse_table(content: str) -> list:
+    """Parse lib table content, asserting it's a list."""
+    tree = parse_one(content)
+    assert isinstance(tree, list)
+    return tree
+
+
+def _lib_names(content: str) -> list[str]:
+    """Extract library names from a lib table string."""
+    tree = _parse_table(content)
+    names = []
+    for lib in find_all(tree, "lib"):
+        for child in lib[1:]:
+            if isinstance(child, list) and child and child[0] == "name":
+                names.append(str(child[1]))
+    return names
+
+
+def _lib_uris(content: str) -> list[str]:
+    """Extract library URIs from a lib table string."""
+    tree = _parse_table(content)
+    uris = []
+    for lib in find_all(tree, "lib"):
+        for child in lib[1:]:
+            if isinstance(child, list) and child and child[0] == "uri":
+                uris.append(str(child[1]))
+    return uris
+
+
+# --- generate_sym_lib_table ---
+
+
+def test_generate_empty_produces_valid_table():
+    content = generate_sym_lib_table([], "symbols", "00k", "-")
+    tree = _parse_table(content)
+    assert tree[0] == "sym_lib_table"
+    assert find_all(tree, "lib") == []
+
+
+def test_generate_single_file():
+    files = [Path("symbols/00k-Resistors.kicad_sym")]
+    content = generate_sym_lib_table(files, "symbols", "00k", "-")
+
+    names = _lib_names(content)
+    assert names == ["00k-Resistors"]
+
+    uris = _lib_uris(content)
+    assert uris == ["${KIPRJMOD}/lib/symbols/00k-Resistors.kicad_sym"]
+
+
+def test_generate_multiple_files_sorted():
+    files = [
+        Path("symbols/00k-ICs.kicad_sym"),
+        Path("symbols/00k-Capacitors.kicad_sym"),
+        Path("symbols/00k-Resistors.kicad_sym"),
+    ]
+    content = generate_sym_lib_table(files, "symbols", "00k", "-")
+
+    names = _lib_names(content)
+    assert names == ["00k-Capacitors", "00k-ICs", "00k-Resistors"]
+
+
+def test_generate_custom_prefix_and_dir():
+    files = [Path("sym/01k-Diodes.kicad_sym")]
+    content = generate_sym_lib_table(files, "sym", "01k", "-")
+
+    uris = _lib_uris(content)
+    assert uris == ["${KIPRJMOD}/lib/sym/01k-Diodes.kicad_sym"]
+
+
+def test_generate_roundtrip():
+    """Generated content can be parsed back."""
+    files = [
+        Path("symbols/00k-Resistors.kicad_sym"),
+        Path("symbols/00k-Capacitors.kicad_sym"),
+    ]
+    content = generate_sym_lib_table(files, "symbols", "00k", "-")
+    tree = _parse_table(content)
+    assert tree[0] == "sym_lib_table"
+    assert len(find_all(tree, "lib")) == 2
+
+
+# --- update_sym_lib_table ---
+
+
+EXISTING_TABLE = """\
+(sym_lib_table
+  (version 7)
+  (lib (name "power")(type "KiCad")(uri "${KICAD8_SYMBOL_DIR}/power.kicad_sym")(options "")(descr ""))
+  (lib (name "00k-Resistors")(type "KiCad")(uri "${KIPRJMOD}/lib/symbols/00k-Resistors.kicad_sym")(options "")(descr ""))
+)
+"""
+
+
+def test_update_replaces_kist_entries():
+    new_files = [
+        Path("symbols/00k-Capacitors.kicad_sym"),
+        Path("symbols/00k-Resistors.kicad_sym"),
+    ]
+    content = update_sym_lib_table(EXISTING_TABLE, new_files, "symbols", "00k", "-")
+    names = _lib_names(content)
+
+    # Non-kist entry preserved
+    assert "power" in names
+    # Old kist entry replaced, new one added
+    assert "00k-Resistors" in names
+    assert "00k-Capacitors" in names
+
+
+def test_update_preserves_non_kist_entries():
+    content = update_sym_lib_table(EXISTING_TABLE, [], "symbols", "00k", "-")
+    names = _lib_names(content)
+    assert names == ["power"]
+
+
+def test_update_kist_entries_appended_after_non_kist():
+    new_files = [Path("symbols/00k-Diodes.kicad_sym")]
+    content = update_sym_lib_table(EXISTING_TABLE, new_files, "symbols", "00k", "-")
+    names = _lib_names(content)
+    # power should still be first, kist entries after
+    assert names[0] == "power"
+    assert "00k-Diodes" in names
+
+
+def test_update_different_prefix_leaves_entries_alone():
+    """Entries with a different prefix are not touched."""
+    new_files = [Path("symbols/01k-Resistors.kicad_sym")]
+    content = update_sym_lib_table(EXISTING_TABLE, new_files, "symbols", "01k", "-")
+    names = _lib_names(content)
+    # 00k-Resistors is NOT kist-managed under prefix 01k, so it stays
+    assert "00k-Resistors" in names
+    assert "01k-Resistors" in names
+    assert "power" in names

--- a/tests/providers/test_digikey.py
+++ b/tests/providers/test_digikey.py
@@ -87,6 +87,16 @@ SAMPLE_RESPONSE = {
                 "ValueText": "0.1W, 1/10W",
             },
             {
+                "ParameterId": 252,
+                "ParameterText": "Composition",
+                "ValueText": "Thick Film",
+            },
+            {
+                "ParameterId": 9999,
+                "ParameterText": "Number of Terminations",
+                "ValueText": "2",
+            },
+            {
                 "ParameterId": 16,
                 "ParameterText": "Package / Case",
                 "ValueText": "0603 (1608 Metric)",
@@ -164,10 +174,17 @@ def test_map_parameters_renamed():
     assert result.parameters["tolerance"] == "\u00b11%"
 
 
-def test_map_unknown_parameters_preserved():
-    """Parameters not in PARAMETER_MAP keep their original name."""
+def test_map_known_parameters_renamed():
+    """Mapped parameters get their normalised target name."""
     result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
-    assert result.parameters["Power (Watts)"] == "0.1W, 1/10W"
+    assert result.parameters["power_rating"] == "0.1W, 1/10W"
+    assert result.parameters["composition"] == "Thick Film"
+
+
+def test_map_ignored_parameters_dropped():
+    """Parameters in the ignore list are dropped entirely."""
+    result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
+    assert "Number of Terminations" not in result.parameters
 
 
 def test_map_no_variations_keeps_input_pn():

--- a/tests/providers/test_digikey.py
+++ b/tests/providers/test_digikey.py
@@ -7,8 +7,10 @@ from kist.providers.digikey import (
     CATEGORY_MAP,
     PARAMETER_MAP,
     _map_product,
+    default_mapping,
     parse_digikey_url,
 )
+from kist.providers.models import ProviderMappingConfig
 
 # -- parse_digikey_url -------------------------------------------------------
 
@@ -46,6 +48,8 @@ def test_parse_empty_path_raises():
 
 
 # -- _map_product ------------------------------------------------------------
+
+_DEFAULT = default_mapping()
 
 # Minimal API response structure matching DigiKey v4 ProductDetails
 SAMPLE_RESPONSE = {
@@ -107,57 +111,62 @@ SAMPLE_RESPONSE = {
 
 
 def test_map_basic_fields():
-    result = _map_product(SAMPLE_RESPONSE, "726835")
+    result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
     assert result.mpn == "RC0603FR-0710KL"
     assert result.manufacturer == "Yageo"
     assert result.description == "RES 10K OHM 1% 1/10W 0603"
     assert "10 kOhms" in result.detailed_description
 
 
-def test_map_digikey_pn_from_variation():
-    result = _map_product(SAMPLE_RESPONSE, "726835")
-    assert result.digikey_pn == "311-10.0KHRCT-ND"
+def test_map_supplier_sku_from_variation():
+    result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
+    assert result.supplier_sku == "311-10.0KHRCT-ND"
+
+
+def test_map_supplier_name():
+    result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
+    assert result.supplier_name == "DigiKey"
 
 
 def test_map_urls():
-    result = _map_product(SAMPLE_RESPONSE, "726835")
-    assert result.digikey_url is not None
-    assert "digikey.com" in result.digikey_url
+    result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
+    assert result.supplier_url is not None
+    assert "digikey.com" in result.supplier_url
     assert result.datasheet_url is not None
     assert "yageo.com" in result.datasheet_url
 
 
 def test_map_pricing_and_stock():
-    result = _map_product(SAMPLE_RESPONSE, "726835")
+    result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
     assert result.unit_price == 0.10
     assert result.quantity_available == 28890000
 
 
 def test_map_category():
-    result = _map_product(SAMPLE_RESPONSE, "726835")
+    result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
     assert result.category == "RES"
 
 
 def test_map_package_extracted():
-    result = _map_product(SAMPLE_RESPONSE, "726835")
+    result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
     assert result.package == "0603 (1608 Metric)"
 
 
-def test_map_mounting_extracted():
-    result = _map_product(SAMPLE_RESPONSE, "726835")
-    assert result.mounting == "Surface Mount"
+def test_map_mounting_normalised():
+    result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
+    assert result.mounting == "smd"
 
 
 def test_map_parameters_renamed():
     """Known parameters should be renamed to kist spec names."""
-    result = _map_product(SAMPLE_RESPONSE, "726835")
+    result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
     assert result.parameters["resistance"] == "10 kOhms"
     assert result.parameters["tolerance"] == "\u00b11%"
 
 
 def test_map_unknown_parameters_preserved():
     """Parameters not in PARAMETER_MAP keep their original name."""
-    result = _map_product(SAMPLE_RESPONSE, "726835")
+    result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
     assert result.parameters["Power (Watts)"] == "0.1W, 1/10W"
 
 
@@ -169,8 +178,8 @@ def test_map_no_variations_keeps_input_pn():
             "ProductVariations": [],
         }
     }
-    result = _map_product(data, "726835")
-    assert result.digikey_pn == "726835"
+    result = _map_product(data, "726835", _DEFAULT)
+    assert result.supplier_sku == "726835"
 
 
 def test_map_unknown_category_returns_none():
@@ -183,7 +192,7 @@ def test_map_unknown_category_returns_none():
             },
         }
     }
-    result = _map_product(data, "726835")
+    result = _map_product(data, "726835", _DEFAULT)
     assert result.category is None
 
 
@@ -199,7 +208,7 @@ def test_map_missing_optional_fields():
             },
         }
     }
-    result = _map_product(data, "TEST-123")
+    result = _map_product(data, "TEST-123", _DEFAULT)
     assert result.mpn == "TEST-123"
     assert result.unit_price is None
     assert result.quantity_available is None
@@ -207,6 +216,65 @@ def test_map_missing_optional_fields():
     assert result.mounting is None
     assert result.parameters == {}
     assert result.category is None
+
+
+def test_map_extracted_params_excluded():
+    """Package and mounting are routed to top-level fields, not parameters."""
+    result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
+    assert "package" not in result.parameters
+    assert "mounting" not in result.parameters
+    # Raw names should also be absent (they were normalised first)
+    assert "Package / Case" not in result.parameters
+    assert "Mounting Type" not in result.parameters
+
+
+def test_map_ignored_params_excluded():
+    """Parameters in ignore_parameters are dropped entirely."""
+    custom = ProviderMappingConfig(
+        supplier_name="DigiKey",
+        categories=dict(CATEGORY_MAP),
+        parameters=dict(PARAMETER_MAP),
+        ignore_parameters=["resistance"],
+        mounting={"Surface Mount": "smd"},
+    )
+    result = _map_product(SAMPLE_RESPONSE, "726835", custom)
+    assert "resistance" not in result.parameters
+
+
+def test_map_custom_category_mapping():
+    """Custom mapping overrides change how categories are resolved."""
+    custom = ProviderMappingConfig(
+        supplier_name="DigiKey",
+        categories={"Resistors": "CUSTOM"},
+        parameters=dict(PARAMETER_MAP),
+        mounting={"Surface Mount": "smd"},
+    )
+    result = _map_product(SAMPLE_RESPONSE, "726835", custom)
+    assert result.category == "CUSTOM"
+
+
+def test_map_unknown_mounting_returns_none():
+    """Mounting values not in the mapping produce None."""
+    custom = ProviderMappingConfig(
+        supplier_name="DigiKey",
+        categories=dict(CATEGORY_MAP),
+        parameters=dict(PARAMETER_MAP),
+        mounting={},  # empty -- no normalisation
+    )
+    result = _map_product(SAMPLE_RESPONSE, "726835", custom)
+    assert result.mounting is None
+
+
+def test_map_protocol_relative_datasheet():
+    """Protocol-relative datasheet URLs get https: prefix."""
+    data = {
+        "Product": {
+            **SAMPLE_RESPONSE["Product"],
+            "DatasheetUrl": "//www.yageo.com/datasheet.pdf",
+        }
+    }
+    result = _map_product(data, "726835", _DEFAULT)
+    assert result.datasheet_url == "https://www.yageo.com/datasheet.pdf"
 
 
 # -- Mapping dicts -----------------------------------------------------------

--- a/tests/providers/test_digikey.py
+++ b/tests/providers/test_digikey.py
@@ -181,8 +181,8 @@ def test_map_known_parameters_renamed():
     assert result.parameters["composition"] == "Thick Film"
 
 
-def test_map_ignored_parameters_dropped():
-    """Parameters in the ignore list are dropped entirely."""
+def test_map_unmapped_parameters_dropped():
+    """Parameters not in the map are dropped (whitelist approach)."""
     result = _map_product(SAMPLE_RESPONSE, "726835", _DEFAULT)
     assert "Number of Terminations" not in result.parameters
 
@@ -245,13 +245,13 @@ def test_map_extracted_params_excluded():
     assert "Mounting Type" not in result.parameters
 
 
-def test_map_ignored_params_excluded():
-    """Parameters in ignore_parameters are dropped entirely."""
+def test_map_removing_param_from_map_drops_it():
+    """Removing a parameter from the map causes it to be dropped."""
+    trimmed = {k: v for k, v in PARAMETER_MAP.items() if v != "resistance"}
     custom = ProviderMappingConfig(
         supplier_name="DigiKey",
         categories=dict(CATEGORY_MAP),
-        parameters=dict(PARAMETER_MAP),
-        ignore_parameters=["resistance"],
+        parameters=trimmed,
         mounting={"Surface Mount": "smd"},
     )
     result = _map_product(SAMPLE_RESPONSE, "726835", custom)

--- a/tests/providers/test_dispatch.py
+++ b/tests/providers/test_dispatch.py
@@ -1,0 +1,131 @@
+"""Tests for provider dispatch -- detect_provider and fetch_product."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kist.errors import ProviderError
+from kist.providers import detect_provider, fetch_product
+from kist.providers.models import ProviderProduct
+
+# -- detect_provider ---------------------------------------------------------
+
+
+def test_detect_digikey_url():
+    url = "https://www.digikey.com/en/products/detail/yageo/RC0603FR-0710KL/726835"
+    provider, identifier = detect_provider(url)
+    assert provider == "digikey"
+    assert identifier == "RC0603FR-0710KL"
+
+
+def test_detect_digikey_au_url():
+    url = (
+        "https://www.digikey.com.au/en/products/detail/nordic/NPM1300-QEAA-R7/19722501"
+    )
+    provider, identifier = detect_provider(url)
+    assert provider == "digikey"
+    assert identifier == "NPM1300-QEAA-R7"
+
+
+def test_detect_bare_mpn_defaults_to_digikey():
+    provider, identifier = detect_provider("RC0603FR-0710KL")
+    assert provider == "digikey"
+    assert identifier == "RC0603FR-0710KL"
+
+
+def test_detect_bare_mpn_strips_whitespace():
+    provider, identifier = detect_provider("  RC0603FR-0710KL  ")
+    assert provider == "digikey"
+    assert identifier == "RC0603FR-0710KL"
+
+
+def test_detect_unknown_url_raises():
+    with pytest.raises(ProviderError, match="Unrecognised supplier URL"):
+        detect_provider("https://www.example.com/some/product")
+
+
+# -- fetch_product -----------------------------------------------------------
+
+
+def _mock_provider_product() -> ProviderProduct:
+    return ProviderProduct(
+        mpn="RC0603FR-0710KL",
+        manufacturer="Yageo",
+        description="10k resistor",
+        detailed_description="",
+        supplier_name="DigiKey",
+        supplier_sku="311-10.0KHRCT-ND",
+        category="RES",
+        parameters={"resistance": "10 kOhms"},
+    )
+
+
+@patch("kist.providers.DigiKeyClient")
+@patch("kist.core.config.load_global_config")
+@patch("kist.core.config.load_provider_mapping")
+def test_fetch_product_digikey_url(
+    mock_mapping, mock_config, mock_client_cls, monkeypatch
+):
+    """fetch_product dispatches to DigiKey for DigiKey URLs."""
+    monkeypatch.delenv("KIST_DIGIKEY_CLIENT_ID", raising=False)
+    monkeypatch.delenv("KIST_DIGIKEY_CLIENT_SECRET", raising=False)
+
+    mock_mapping.return_value = MagicMock()
+    mock_cfg = MagicMock()
+    mock_cfg.providers.digikey.client_id = "test-id"
+    mock_cfg.providers.digikey.client_secret = "test-secret"
+    mock_config.return_value = mock_cfg
+
+    expected = _mock_provider_product()
+    mock_client_cls.return_value.fetch_product.return_value = expected
+
+    result = fetch_product(
+        "https://www.digikey.com/en/products/detail/yageo/RC0603FR-0710KL/726835"
+    )
+
+    assert result == expected
+    mock_client_cls.assert_called_once_with("test-id", "test-secret")
+    mock_client_cls.return_value.fetch_product.assert_called_once()
+
+
+@patch("kist.providers.DigiKeyClient")
+@patch("kist.core.config.load_global_config")
+@patch("kist.core.config.load_provider_mapping")
+def test_fetch_product_bare_mpn(
+    mock_mapping, mock_config, mock_client_cls, monkeypatch
+):
+    """fetch_product dispatches bare MPNs to the default provider."""
+    monkeypatch.delenv("KIST_DIGIKEY_CLIENT_ID", raising=False)
+    monkeypatch.delenv("KIST_DIGIKEY_CLIENT_SECRET", raising=False)
+
+    mock_mapping.return_value = MagicMock()
+    mock_cfg = MagicMock()
+    mock_cfg.providers.digikey.client_id = "test-id"
+    mock_cfg.providers.digikey.client_secret = "test-secret"
+    mock_config.return_value = mock_cfg
+
+    expected = _mock_provider_product()
+    mock_client_cls.return_value.fetch_product.return_value = expected
+
+    result = fetch_product("RC0603FR-0710KL")
+
+    assert result == expected
+
+
+@patch("kist.core.config.load_global_config")
+@patch("kist.core.config.load_provider_mapping")
+def test_fetch_product_missing_credentials(mock_mapping, mock_config, monkeypatch):
+    """fetch_product raises ProviderError when credentials are missing."""
+    monkeypatch.delenv("KIST_DIGIKEY_CLIENT_ID", raising=False)
+    monkeypatch.delenv("KIST_DIGIKEY_CLIENT_SECRET", raising=False)
+
+    mock_mapping.return_value = MagicMock()
+    mock_cfg = MagicMock()
+    mock_cfg.providers.digikey.client_id = None
+    mock_cfg.providers.digikey.client_secret = None
+    mock_config.return_value = mock_cfg
+
+    with pytest.raises(ProviderError, match="credentials not configured"):
+        fetch_product("RC0603FR-0710KL")

--- a/tests/tui/test_add_screen.py
+++ b/tests/tui/test_add_screen.py
@@ -12,7 +12,7 @@ from textual.widgets import Input, Select
 from kist.core.database import PartsDatabase
 from kist.core.library import init_library
 from kist.models.part import Mounting, ProprietaryPart, Tier
-from kist.providers.models import DigiKeyProduct
+from kist.providers.models import ProviderProduct
 from kist.tui.screens.add import AddScreen
 from kist.tui.widgets.part_form import PartForm
 
@@ -82,41 +82,44 @@ async def test_url_input_populated_from_arg():
 # -- Provider population ---
 
 
-def _make_ic_product() -> DigiKeyProduct:
-    return DigiKeyProduct(
+def _make_ic_product() -> ProviderProduct:
+    return ProviderProduct(
         mpn="STM32F405RGT6",
         manufacturer="STMicroelectronics",
         description="ARM Cortex-M4 MCU",
         detailed_description="ARM Cortex-M4 MCU, 1MB Flash",
-        digikey_pn="497-STM32F405RGT6-ND",
-        digikey_url="https://www.digikey.com/en/products/detail/stm/STM32F405RGT6/123",
+        supplier_name="DigiKey",
+        supplier_sku="497-STM32F405RGT6-ND",
+        supplier_url="https://www.digikey.com/en/products/detail/stm/STM32F405RGT6/123",
         datasheet_url="https://www.st.com/resource/en/datasheet/stm32f405rg.pdf",
         category="IC",
         package="LQFP-64",
-        mounting="Surface Mount",
+        mounting="smd",
         parameters={"frequency": "168MHz", "flash": "1MB"},
     )
 
 
-def _make_resistor_product() -> DigiKeyProduct:
-    return DigiKeyProduct(
+def _make_resistor_product() -> ProviderProduct:
+    return ProviderProduct(
         mpn="RC0603FR-0710KL",
         manufacturer="Yageo",
         description="10 kOhms 1% 0.1W Chip Resistor",
         detailed_description="",
-        digikey_pn="311-10.0KHRCT-ND",
+        supplier_name="DigiKey",
+        supplier_sku="311-10.0KHRCT-ND",
         category="RES",
         parameters={"resistance": "10 kOhms", "tolerance": "1%"},
     )
 
 
-def _make_diode_product() -> DigiKeyProduct:
-    return DigiKeyProduct(
+def _make_diode_product() -> ProviderProduct:
+    return ProviderProduct(
         mpn="1N4148W-7-F",
         manufacturer="Diodes Incorporated",
         description="Diode Standard 100V 300mA",
         detailed_description="",
-        digikey_pn="1N4148W-FDICT-ND",
+        supplier_name="DigiKey",
+        supplier_sku="1N4148W-FDICT-ND",
         category="DIO",
         parameters={},
     )
@@ -149,7 +152,7 @@ async def test_load_from_provider_adds_supplier(app):
         form.load_from_provider(product)
 
         d = form.to_dict()
-        assert "DigiKey" in d["suppliers"]
+        assert product.supplier_name in d["suppliers"]
         assert d["suppliers"]["DigiKey"]["sku"] == "497-STM32F405RGT6-ND"
 
 

--- a/tests/tui/test_add_screen.py
+++ b/tests/tui/test_add_screen.py
@@ -1,0 +1,348 @@
+"""AddScreen tests -- form population, validation, and save flow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from textual.app import App
+from textual.reactive import reactive
+from textual.widgets import Input, Select
+
+from kist.core.database import PartsDatabase
+from kist.core.library import init_library
+from kist.models.part import Mounting, ProprietaryPart, Tier
+from kist.providers.models import DigiKeyProduct
+from kist.tui.screens.add import AddScreen
+from kist.tui.widgets.part_form import PartForm
+
+
+class AddScreenApp(App):
+    """Minimal app for testing AddScreen in isolation."""
+
+    CSS = ""
+    library_path: reactive[Path | None] = reactive(None)
+
+    def __init__(
+        self,
+        library_path: Path | None = None,
+        url_or_mpn: str | None = None,
+    ) -> None:
+        super().__init__()
+        self._library_path = library_path
+        self._url_or_mpn = url_or_mpn
+
+    def get_default_screen(self) -> AddScreen:
+        return AddScreen(url_or_mpn=self._url_or_mpn)
+
+    def on_mount(self) -> None:
+        self.library_path = self._library_path
+
+
+@pytest.fixture
+def app():
+    return AddScreenApp()
+
+
+@pytest.fixture
+def library_path(tmp_path):
+    """Create a temporary kist library and return its path."""
+    return init_library(tmp_path / "lib")
+
+
+@pytest.fixture
+def app_with_library(library_path):
+    return AddScreenApp(library_path=library_path)
+
+
+# -- Screen mount ---
+
+
+async def test_add_screen_has_part_form(app):
+    async with app.run_test():
+        form = app.query_one("#part-form", PartForm)
+        assert form is not None
+        assert form.mode == "editable"
+
+
+async def test_add_screen_has_url_input(app):
+    async with app.run_test():
+        url_input = app.query_one("#url-input", Input)
+        assert url_input is not None
+
+
+async def test_url_input_populated_from_arg():
+    """CLI argument pre-fills the URL input."""
+    test_app = AddScreenApp(url_or_mpn="STM32F405RGT6")
+    async with test_app.run_test():
+        url_input = test_app.query_one("#url-input", Input)
+        assert url_input.value == "STM32F405RGT6"
+
+
+# -- Provider population ---
+
+
+def _make_ic_product() -> DigiKeyProduct:
+    return DigiKeyProduct(
+        mpn="STM32F405RGT6",
+        manufacturer="STMicroelectronics",
+        description="ARM Cortex-M4 MCU",
+        detailed_description="ARM Cortex-M4 MCU, 1MB Flash",
+        digikey_pn="497-STM32F405RGT6-ND",
+        digikey_url="https://www.digikey.com/en/products/detail/stm/STM32F405RGT6/123",
+        datasheet_url="https://www.st.com/resource/en/datasheet/stm32f405rg.pdf",
+        category="IC",
+        package="LQFP-64",
+        mounting="Surface Mount",
+        parameters={"frequency": "168MHz", "flash": "1MB"},
+    )
+
+
+def _make_resistor_product() -> DigiKeyProduct:
+    return DigiKeyProduct(
+        mpn="RC0603FR-0710KL",
+        manufacturer="Yageo",
+        description="10 kOhms 1% 0.1W Chip Resistor",
+        detailed_description="",
+        digikey_pn="311-10.0KHRCT-ND",
+        category="RES",
+        parameters={"resistance": "10 kOhms", "tolerance": "1%"},
+    )
+
+
+def _make_diode_product() -> DigiKeyProduct:
+    return DigiKeyProduct(
+        mpn="1N4148W-7-F",
+        manufacturer="Diodes Incorporated",
+        description="Diode Standard 100V 300mA",
+        detailed_description="",
+        digikey_pn="1N4148W-FDICT-ND",
+        category="DIO",
+        parameters={},
+    )
+
+
+async def test_load_from_provider_populates_form(app):
+    product = _make_ic_product()
+
+    async with app.run_test():
+        form = app.query_one("#part-form", PartForm)
+        form.load_from_provider(product)
+
+        assert form.query_one("#mpn", Input).value == "STM32F405RGT6"
+        assert form.query_one("#manufacturer", Input).value == "STMicroelectronics"
+        assert form.query_one("#description", Input).value == "ARM Cortex-M4 MCU"
+        assert form.query_one("#package", Input).value == "LQFP-64"
+        assert form.query_one("#mounting", Select).value == Mounting.SMD
+        assert form.query_one("#tier", Select).value == Tier.PROPRIETARY
+        assert form.query_one("#category", Select).value == "IC"
+        assert form.query_one("#datasheet", Input).value == (
+            "https://www.st.com/resource/en/datasheet/stm32f405rg.pdf"
+        )
+
+
+async def test_load_from_provider_adds_supplier(app):
+    product = _make_ic_product()
+
+    async with app.run_test():
+        form = app.query_one("#part-form", PartForm)
+        form.load_from_provider(product)
+
+        d = form.to_dict()
+        assert "DigiKey" in d["suppliers"]
+        assert d["suppliers"]["DigiKey"]["sku"] == "497-STM32F405RGT6-ND"
+
+
+async def test_load_from_provider_adds_specs(app):
+    product = _make_ic_product()
+
+    async with app.run_test():
+        form = app.query_one("#part-form", PartForm)
+        form.load_from_provider(product)
+
+        d = form.to_dict()
+        assert d["specifications"]["frequency"] == "168MHz"
+        assert d["specifications"]["flash"] == "1MB"
+
+
+async def test_load_from_provider_detects_jellybean_tier(app):
+    product = _make_resistor_product()
+
+    async with app.run_test():
+        form = app.query_one("#part-form", PartForm)
+        form.load_from_provider(product)
+
+        assert form.query_one("#tier", Select).value == Tier.JELLYBEAN
+
+
+async def test_load_from_provider_detects_semi_jellybean_tier(app):
+    product = _make_diode_product()
+
+    async with app.run_test():
+        form = app.query_one("#part-form", PartForm)
+        form.load_from_provider(product)
+
+        assert form.query_one("#tier", Select).value == Tier.SEMI_JELLYBEAN
+
+
+# -- Clear ---
+
+
+async def test_clear_resets_form(app):
+    async with app.run_test():
+        form = app.query_one("#part-form", PartForm)
+
+        # Populate some fields
+        form.query_one("#tier", Select).value = Tier.PROPRIETARY
+        form.query_one("#mpn", Input).value = "TEST123"
+        form.query_one("#manufacturer", Input).value = "TestCorp"
+        form.query_one("#package", Input).value = "SO8"
+        form._add_spec_to_table("resistance", "10k")
+
+        form.clear()
+
+        assert form.query_one("#tier", Select).value == Select.BLANK
+        assert form.query_one("#mpn", Input).value == ""
+        assert form.query_one("#manufacturer", Input).value == ""
+        assert form.query_one("#package", Input).value == ""
+        d = form.to_dict()
+        assert d["specifications"] is None
+
+
+# -- Save validation ---
+
+
+async def test_save_requires_tier(app):
+    async with app.run_test():
+        # Form is empty -- save should fail on missing tier
+        app.screen.action_save()
+
+        form = app.query_one("#part-form", PartForm)
+        # Form should NOT be cleared (no successful save)
+        assert form.query_one("#tier", Select).value == Select.BLANK
+
+
+async def test_save_requires_category(app):
+    async with app.run_test():
+        form = app.query_one("#part-form", PartForm)
+        form.query_one("#tier", Select).value = Tier.PROPRIETARY
+
+        app.screen.action_save()
+
+        # Category still blank -- save didn't succeed
+        assert form.query_one("#category", Select).value == Select.BLANK
+
+
+async def test_save_requires_library(app):
+    """Save fails gracefully when no library is discovered."""
+    async with app.run_test():
+        form = app.query_one("#part-form", PartForm)
+        form.query_one("#tier", Select).value = Tier.PROPRIETARY
+        form.query_one("#category", Select).value = "IC"
+        form.query_one("#mpn", Input).value = "TEST"
+        form.query_one("#manufacturer", Input).value = "Corp"
+
+        app.screen.action_save()
+
+        # Form not cleared -- save failed because no library
+        assert form.query_one("#mpn", Input).value == "TEST"
+
+
+async def test_save_requires_mpn_for_proprietary(app_with_library):
+    async with app_with_library.run_test():
+        form = app_with_library.query_one("#part-form", PartForm)
+        form.query_one("#tier", Select).value = Tier.PROPRIETARY
+        form.query_one("#category", Select).value = "IC"
+        # MPN left empty
+
+        app_with_library.screen.action_save()
+
+        # Form not cleared -- save failed
+        assert form.query_one("#tier", Select).value == Tier.PROPRIETARY
+
+
+# -- Save flow ---
+
+
+async def test_save_proprietary_part(app_with_library, library_path):
+    async with app_with_library.run_test():
+        form = app_with_library.query_one("#part-form", PartForm)
+
+        form.query_one("#tier", Select).value = Tier.PROPRIETARY
+        form.query_one("#category", Select).value = "IC"
+        form.query_one("#mpn", Input).value = "STM32F405RGT6"
+        form.query_one("#manufacturer", Input).value = "STMicroelectronics"
+        form.query_one("#package", Input).value = "LQFP-64"
+
+        app_with_library.screen.action_save()
+
+        # Part saved to database
+        db = PartsDatabase(library_path / "parts.json")
+        db.load()
+        parts = db.list_parts()
+        assert len(parts) == 1
+        part = parts[0]
+        assert isinstance(part, ProprietaryPart)
+        assert part.mpn == "STM32F405RGT6"
+        assert "IC" in part.name
+        assert "STM32F405RGT6" in part.name
+
+        # Form cleared after successful save
+        assert form.query_one("#tier", Select).value == Select.BLANK
+        assert form.query_one("#mpn", Input).value == ""
+
+
+async def test_save_jellybean_part(app_with_library, library_path):
+    async with app_with_library.run_test():
+        form = app_with_library.query_one("#part-form", PartForm)
+
+        form.query_one("#tier", Select).value = Tier.JELLYBEAN
+        form.query_one("#category", Select).value = "RES"
+        form.query_one("#package", Input).value = "0603"
+        form.query_one("#mounting", Select).value = Mounting.SMD
+        form._add_spec_to_table("resistance", "10k")
+        form._add_spec_to_table("tolerance", "1%")
+
+        app_with_library.screen.action_save()
+
+        db = PartsDatabase(library_path / "parts.json")
+        db.load()
+        parts = db.list_parts()
+        assert len(parts) == 1
+        assert parts[0].tier == Tier.JELLYBEAN
+        assert "RES" in parts[0].name
+        assert parts[0].reference == "R"
+
+        # Form cleared
+        assert form.query_one("#tier", Select).value == Select.BLANK
+
+
+async def test_save_duplicate_shows_error(app_with_library, library_path):
+    """Saving the same part twice shows a duplicate error."""
+    async with app_with_library.run_test():
+        form = app_with_library.query_one("#part-form", PartForm)
+
+        # Save first part
+        form.query_one("#tier", Select).value = Tier.PROPRIETARY
+        form.query_one("#category", Select).value = "IC"
+        form.query_one("#mpn", Input).value = "LM358"
+        form.query_one("#manufacturer", Input).value = "TI"
+        app_with_library.screen.action_save()
+
+        # Form should be cleared after first save
+        assert form.query_one("#mpn", Input).value == ""
+
+        # Try to save same part again
+        form.query_one("#tier", Select).value = Tier.PROPRIETARY
+        form.query_one("#category", Select).value = "IC"
+        form.query_one("#mpn", Input).value = "LM358"
+        form.query_one("#manufacturer", Input).value = "TI"
+        app_with_library.screen.action_save()
+
+        # Form NOT cleared -- duplicate error
+        assert form.query_one("#mpn", Input).value == "LM358"
+
+        # Only one part in database
+        db = PartsDatabase(library_path / "parts.json")
+        db.load()
+        assert len(db.list_parts()) == 1

--- a/tests/tui/test_add_screen.py
+++ b/tests/tui/test_add_screen.py
@@ -5,23 +5,23 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from textual.app import App
-from textual.reactive import reactive
 from textual.widgets import Input, Select
 
+from kist.core.config import load_library_config
 from kist.core.database import PartsDatabase
 from kist.core.library import init_library
 from kist.models.part import Mounting, ProprietaryPart, Tier
 from kist.providers.models import ProviderProduct
+from kist.tui.app import KistApp
 from kist.tui.screens.add import AddScreen
 from kist.tui.widgets.part_form import PartForm
 
 
-class AddScreenApp(App):
+class AddScreenApp(KistApp):
     """Minimal app for testing AddScreen in isolation."""
 
+    CSS_PATH = None
     CSS = ""
-    library_path: reactive[Path | None] = reactive(None)
 
     def __init__(
         self,
@@ -29,14 +29,16 @@ class AddScreenApp(App):
         url_or_mpn: str | None = None,
     ) -> None:
         super().__init__()
-        self._library_path = library_path
-        self._url_or_mpn = url_or_mpn
+        self._test_library_path = library_path
+        self._url_or_mpn_arg = url_or_mpn
 
     def get_default_screen(self) -> AddScreen:
-        return AddScreen(url_or_mpn=self._url_or_mpn)
+        return AddScreen(url_or_mpn=self._url_or_mpn_arg)
 
-    def on_mount(self) -> None:
-        self.library_path = self._library_path
+    def _discover_library(self) -> None:
+        if self._test_library_path:
+            self.library_path = self._test_library_path
+            self.library_config = load_library_config(self._test_library_path)
 
 
 @pytest.fixture

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -58,9 +58,9 @@ async def test_quit_from_browse(app):
         assert app._exit
 
 
-async def test_kist_dark_theme_registered(app):
+async def test_null_theme_registered(app):
     async with app.run_test():
-        assert "kist-dark" in app.available_themes
+        assert "null" in app.available_themes
 
 
 async def test_library_path_none_outside_library(app, tmp_path, monkeypatch):

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -2,9 +2,16 @@
 
 import pytest
 
+from kist.core.config import save_global_config
+from kist.models.config import GlobalConfig
 from kist.tui.app import KistApp
 from kist.tui.screens.add import AddScreen
 from kist.tui.screens.browse import BrowseScreen
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(tmp_path / "config"))
 
 
 @pytest.fixture
@@ -67,3 +74,44 @@ async def test_add_part_in_system_commands(app):
         commands = list(app.get_system_commands(app.screen))
         titles = [c.title for c in commands]
         assert "Add part" in titles
+
+
+async def test_settings_always_in_system_commands(app):
+    async with app.run_test():
+        commands = list(app.get_system_commands(app.screen))
+        titles = [c.title for c in commands]
+        assert "Settings" in titles
+
+
+async def test_library_commands_hidden_without_library(app, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    async with app.run_test():
+        assert app.library_path is None
+        commands = list(app.get_system_commands(app.screen))
+        titles = [c.title for c in commands]
+        assert "Sync to KiCad" not in titles
+        assert "Check library" not in titles
+        assert "Manage categories" not in titles
+
+
+async def test_library_commands_present_with_library(tmp_path, monkeypatch):
+    from kist.core.library import init_library
+
+    init_library(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    app = KistApp()
+    async with app.run_test():
+        assert app.library_path is not None
+        commands = list(app.get_system_commands(app.screen))
+        titles = [c.title for c in commands]
+        assert "Sync to KiCad" in titles
+        assert "Check library" in titles
+        assert "Manage categories" in titles
+
+
+async def test_saved_theme_applied_on_startup(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(tmp_path / "cfg"))
+    save_global_config(GlobalConfig(theme="nord"))
+    app = KistApp()
+    async with app.run_test():
+        assert app.theme == "nord"

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -1,0 +1,69 @@
+"""TUI app shell tests -- Phase 1 smoke tests."""
+
+import pytest
+
+from kist.tui.app import KistApp
+from kist.tui.screens.add import AddScreen
+from kist.tui.screens.browse import BrowseScreen
+
+
+@pytest.fixture
+def app():
+    return KistApp()
+
+
+async def test_default_screen_is_browse(app):
+    async with app.run_test():
+        assert isinstance(app.screen, BrowseScreen)
+
+
+async def test_header_shows_title(app):
+    async with app.run_test():
+        header_title = app.query_one("HeaderTitle")
+        content = header_title.render()
+        assert "Kist" in str(content)
+
+
+async def test_add_screen_pushed_on_start():
+    app = KistApp(start_screen="add")
+    async with app.run_test():
+        assert isinstance(app.screen, AddScreen)
+
+
+async def test_add_screen_shows_url():
+    app = KistApp(start_screen="add", url_or_mpn="https://example.com")
+    async with app.run_test():
+        label = app.screen.query_one("#placeholder")
+        assert "https://example.com" in str(label.render())
+
+
+async def test_escape_pops_add_screen():
+    app = KistApp(start_screen="add")
+    async with app.run_test() as pilot:
+        assert isinstance(app.screen, AddScreen)
+        await pilot.press("escape")
+        assert isinstance(app.screen, BrowseScreen)
+
+
+async def test_quit_from_browse(app):
+    async with app.run_test() as pilot:
+        await pilot.press("q")
+        assert app._exit
+
+
+async def test_kist_dark_theme_registered(app):
+    async with app.run_test():
+        assert "kist-dark" in app.available_themes
+
+
+async def test_library_path_none_outside_library(app, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    async with app.run_test():
+        assert app.library_path is None
+
+
+async def test_add_part_in_system_commands(app):
+    async with app.run_test():
+        commands = list(app.get_system_commands(app.screen))
+        titles = [c.title for c in commands]
+        assert "Add part" in titles

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -30,11 +30,11 @@ async def test_add_screen_pushed_on_start():
         assert isinstance(app.screen, AddScreen)
 
 
-async def test_add_screen_shows_url():
+async def test_add_screen_has_part_form():
     app = KistApp(start_screen="add", url_or_mpn="https://example.com")
     async with app.run_test():
-        label = app.screen.query_one("#placeholder")
-        assert "https://example.com" in str(label.render())
+        form = app.screen.query_one("#part-form")
+        assert form is not None
 
 
 async def test_escape_pops_add_screen():

--- a/tests/tui/test_category_modal.py
+++ b/tests/tui/test_category_modal.py
@@ -1,16 +1,17 @@
 """CategoryFormModal and CategoryManagerModal tests."""
 
 import pytest
-from textual.app import App
 from textual.widgets import DataTable, Input, Select
 
 from kist.core.config import load_library_config, save_library_config
 from kist.core.database import create_empty
 from kist.models.config import CategoryDef, LibraryConfig
+from kist.tui.app import KistApp
 from kist.tui.modals.categories import CategoryFormModal, CategoryManagerModal
 
 
-class ModalApp(App):
+class ModalApp(KistApp):
+    CSS_PATH = None
     CSS = ""
 
 

--- a/tests/tui/test_category_modal.py
+++ b/tests/tui/test_category_modal.py
@@ -14,6 +14,15 @@ class ModalApp(KistApp):
     CSS_PATH = None
     CSS = ""
 
+    def __init__(self, library_path=None):
+        super().__init__()
+        self._test_library_path = library_path
+
+    def _discover_library(self):
+        if self._test_library_path:
+            self.library_path = self._test_library_path
+            self.library_config = load_library_config(self._test_library_path)
+
 
 # -- CategoryFormModal ---
 
@@ -116,7 +125,7 @@ def library_path(tmp_path):
 
 
 async def test_manager_loads_categories(library_path):
-    app = ModalApp()
+    app = ModalApp(library_path)
     async with app.run_test():
         await app.push_screen(CategoryManagerModal(library_path))
         table = app.screen.query_one("#catmgr-table", DataTable)
@@ -125,7 +134,7 @@ async def test_manager_loads_categories(library_path):
 
 async def test_manager_add_category(library_path):
     """Add via the form modal persists to config."""
-    app = ModalApp()
+    app = ModalApp(library_path)
     async with app.run_test() as pilot:
         await app.push_screen(CategoryManagerModal(library_path))
         await pilot.press("a")
@@ -146,7 +155,7 @@ async def test_manager_add_category(library_path):
 
 async def test_manager_edit_category(library_path):
     """Edit updates the category in config."""
-    app = ModalApp()
+    app = ModalApp(library_path)
     async with app.run_test() as pilot:
         await app.push_screen(CategoryManagerModal(library_path))
         # Select first row (RES) and edit
@@ -162,7 +171,7 @@ async def test_manager_edit_category(library_path):
 
 async def test_manager_delete_category(library_path):
     """Delete removes category from config."""
-    app = ModalApp()
+    app = ModalApp(library_path)
     async with app.run_test() as pilot:
         await app.push_screen(CategoryManagerModal(library_path))
         await pilot.press("d")

--- a/tests/tui/test_category_modal.py
+++ b/tests/tui/test_category_modal.py
@@ -1,0 +1,81 @@
+"""CategoryFormModal tests -- create mode, edit mode, cancel."""
+
+from textual.app import App
+from textual.widgets import Input, Select
+
+from kist.models.config import CategoryDef
+from kist.tui.modals.categories import CategoryFormModal
+
+
+class ModalApp(App):
+    CSS = ""
+
+
+async def test_create_mode_empty_form():
+    app = ModalApp()
+    async with app.run_test():
+        await app.push_screen(CategoryFormModal())
+        code = app.screen.query_one("#cat-code", Input)
+        assert code.value == ""
+        assert not code.disabled
+
+
+async def test_edit_mode_populates_fields():
+    cat = CategoryDef(
+        name="Resistors",
+        refdes="R",
+        key_specs=["resistance", "tolerance"],
+        value_field="resistance",
+        symbol_template="resistor",
+        subcategory_names={"TF": "Thick Film", "MF": "Metal Film"},
+    )
+    app = ModalApp()
+    async with app.run_test():
+        await app.push_screen(CategoryFormModal(edit=("RES", cat)))
+        assert app.screen.query_one("#cat-code", Input).value == "RES"
+        assert app.screen.query_one("#cat-code", Input).disabled
+        assert app.screen.query_one("#cat-name", Input).value == "Resistors"
+        assert app.screen.query_one("#cat-refdes", Input).value == "R"
+        assert (
+            app.screen.query_one("#cat-keyspecs", Input).value
+            == "resistance, tolerance"
+        )
+        assert app.screen.query_one("#cat-valuefield", Input).value == "resistance"
+        assert app.screen.query_one("#cat-template", Select).value == "resistor"
+
+
+async def test_cancel_returns_none():
+    results: list = []
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        app.push_screen(CategoryFormModal(), callback=results.append)
+        await pilot.pause()
+        await pilot.press("escape")
+        assert results == [None]
+
+
+async def test_save_returns_category():
+    results: list = []
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        app.push_screen(CategoryFormModal(), callback=results.append)
+        await pilot.pause()
+        app.screen.query_one("#cat-code", Input).value = "OPTO"
+        app.screen.query_one("#cat-name", Input).value = "Optocouplers"
+        app.screen.query_one("#cat-refdes", Input).value = "U"
+        await pilot.press("ctrl+s")
+        assert len(results) == 1
+        code, cat_def = results[0]
+        assert code == "OPTO"
+        assert cat_def.name == "Optocouplers"
+        assert cat_def.refdes == "U"
+
+
+async def test_save_validates_required_fields():
+    """Save with empty required fields shows error, doesn't dismiss."""
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(CategoryFormModal())
+        await pilot.press("ctrl+s")
+        # Modal should still be open
+        assert isinstance(app.screen, CategoryFormModal)

--- a/tests/tui/test_category_modal.py
+++ b/tests/tui/test_category_modal.py
@@ -1,14 +1,20 @@
-"""CategoryFormModal tests -- create mode, edit mode, cancel."""
+"""CategoryFormModal and CategoryManagerModal tests."""
 
+import pytest
 from textual.app import App
-from textual.widgets import Input, Select
+from textual.widgets import DataTable, Input, Select
 
-from kist.models.config import CategoryDef
-from kist.tui.modals.categories import CategoryFormModal
+from kist.core.config import load_library_config, save_library_config
+from kist.core.database import create_empty
+from kist.models.config import CategoryDef, LibraryConfig
+from kist.tui.modals.categories import CategoryFormModal, CategoryManagerModal
 
 
 class ModalApp(App):
     CSS = ""
+
+
+# -- CategoryFormModal ---
 
 
 async def test_create_mode_empty_form():
@@ -79,3 +85,91 @@ async def test_save_validates_required_fields():
         await pilot.press("ctrl+s")
         # Modal should still be open
         assert isinstance(app.screen, CategoryFormModal)
+
+
+# -- CategoryManagerModal ---
+
+
+@pytest.fixture
+def library_path(tmp_path):
+    """Create a minimal library with two categories."""
+    config = LibraryConfig(
+        categories={
+            "RES": CategoryDef(
+                name="Resistors",
+                refdes="R",
+                key_specs=["resistance", "tolerance"],
+                symbol_template="resistor",
+            ),
+            "CAP": CategoryDef(
+                name="Capacitors",
+                refdes="C",
+                key_specs=["capacitance", "voltage_rating"],
+                symbol_template="capacitor",
+            ),
+        }
+    )
+    save_library_config(tmp_path, config)
+    create_empty(tmp_path / "parts.json")
+    return tmp_path
+
+
+async def test_manager_loads_categories(library_path):
+    app = ModalApp()
+    async with app.run_test():
+        await app.push_screen(CategoryManagerModal(library_path))
+        table = app.screen.query_one("#catmgr-table", DataTable)
+        assert table.row_count == 2
+
+
+async def test_manager_add_category(library_path):
+    """Add via the form modal persists to config."""
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(CategoryManagerModal(library_path))
+        await pilot.press("a")
+        await pilot.pause()
+        # Fill the form
+        app.screen.query_one("#cat-code", Input).value = "DIO"
+        app.screen.query_one("#cat-name", Input).value = "Diodes"
+        app.screen.query_one("#cat-refdes", Input).value = "D"
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        # Table updated
+        table = app.screen.query_one("#catmgr-table", DataTable)
+        assert table.row_count == 3
+        # Config persisted
+        config = load_library_config(library_path)
+        assert "DIO" in config.categories
+
+
+async def test_manager_edit_category(library_path):
+    """Edit updates the category in config."""
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(CategoryManagerModal(library_path))
+        # Select first row (RES) and edit
+        await pilot.press("e")
+        await pilot.pause()
+        # Change name
+        app.screen.query_one("#cat-name", Input).value = "Resistors (Updated)"
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        config = load_library_config(library_path)
+        assert config.categories["RES"].name == "Resistors (Updated)"
+
+
+async def test_manager_delete_category(library_path):
+    """Delete removes category from config."""
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(CategoryManagerModal(library_path))
+        await pilot.press("d")
+        await pilot.pause()
+        # Confirm deletion
+        await pilot.press("tab")
+        await pilot.press("enter")
+        await pilot.pause()
+        config = load_library_config(library_path)
+        # One category removed
+        assert len(config.categories) == 1

--- a/tests/tui/test_check_modal.py
+++ b/tests/tui/test_check_modal.py
@@ -1,0 +1,82 @@
+"""LibraryCheckModal tests -- display issues and empty state."""
+
+from textual.app import App
+from textual.widgets import Label, Static
+
+from kist.core.check import CheckIssue
+from kist.tui.modals.check import LibraryCheckModal
+
+
+class ModalApp(App):
+    """Minimal app for testing modals."""
+
+    CSS = ""
+
+
+async def test_check_modal_shows_issue_count():
+    issues = [
+        CheckIssue(
+            kind="name_drift",
+            message='"WRONG" should be "RIGHT"',
+            parts=["WRONG"],
+        ),
+        CheckIssue(
+            kind="duplicate_identity",
+            message="A and B share (RES, 10K)",
+            parts=["A", "B"],
+        ),
+    ]
+    app = ModalApp()
+    async with app.run_test():
+        await app.push_screen(LibraryCheckModal(issues))
+        header = app.screen.query_one("#check-header", Label)
+        assert "2 issues found" in str(header.content)
+
+
+async def test_check_modal_shows_all_clean():
+    app = ModalApp()
+    async with app.run_test():
+        await app.push_screen(LibraryCheckModal([]))
+        header = app.screen.query_one("#check-header", Label)
+        assert "All clean" in str(header.content)
+
+
+async def test_check_modal_shows_issue_details():
+    issues = [
+        CheckIssue(
+            kind="name_drift",
+            message='"OLD" should be "NEW"',
+            parts=["OLD"],
+        ),
+    ]
+    app = ModalApp()
+    async with app.run_test():
+        await app.push_screen(LibraryCheckModal(issues))
+        kind_labels = app.screen.query(".check-kind")
+        assert len(kind_labels) == 1
+        kind_label = kind_labels.first(Label)
+        assert "Name drift" in str(kind_label.content)
+        detail_labels = app.screen.query(".check-detail")
+        detail = detail_labels.first(Static)
+        assert '"OLD" should be "NEW"' in str(detail.content)
+
+
+async def test_check_modal_escape_closes():
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(LibraryCheckModal([]))
+        assert isinstance(app.screen, LibraryCheckModal)
+        await pilot.press("escape")
+        assert not isinstance(app.screen, LibraryCheckModal)
+
+
+async def test_check_modal_singular_issue():
+    """Single issue uses singular 'issue' not 'issues'."""
+    issues = [
+        CheckIssue(kind="name_drift", message="test", parts=["X"]),
+    ]
+    app = ModalApp()
+    async with app.run_test():
+        await app.push_screen(LibraryCheckModal(issues))
+        header = app.screen.query_one("#check-header", Label)
+        assert "1 issue found" in str(header.content)

--- a/tests/tui/test_detail_modal.py
+++ b/tests/tui/test_detail_modal.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from textual.app import App
-from textual.reactive import reactive
 from textual.widgets import Input, Label
 
+from kist.core.config import load_library_config
 from kist.core.database import PartsDatabase
 from kist.core.library import init_library
 from kist.models.part import Mounting, ProprietaryPart, Tier
+from kist.tui.app import KistApp
 from kist.tui.screens.browse import BrowseScreen
 from kist.tui.screens.detail import ConfirmModal, DetailModal
 from kist.tui.widgets.part_form import PartForm
@@ -35,21 +35,23 @@ def _make_proprietary_part() -> ProprietaryPart:
     )
 
 
-class BrowseApp(App):
+class BrowseApp(KistApp):
     """Minimal app for testing browse + detail modal integration."""
 
+    CSS_PATH = None
     CSS = ""
-    library_path: reactive[Path | None] = reactive(None)
 
     def __init__(self, library_path: Path | None = None) -> None:
         super().__init__()
-        self._library_path = library_path
+        self._test_library_path = library_path
 
     def get_default_screen(self) -> BrowseScreen:
         return BrowseScreen()
 
-    def on_mount(self) -> None:
-        self.library_path = self._library_path
+    def _discover_library(self) -> None:
+        if self._test_library_path:
+            self.library_path = self._test_library_path
+            self.library_config = load_library_config(self._test_library_path)
 
 
 @pytest.fixture

--- a/tests/tui/test_detail_modal.py
+++ b/tests/tui/test_detail_modal.py
@@ -1,0 +1,175 @@
+"""DetailModal tests -- open, display, edit, delete, and browse integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from textual.app import App
+from textual.reactive import reactive
+from textual.widgets import Label
+
+from kist.core.database import PartsDatabase
+from kist.core.library import init_library
+from kist.models.part import Mounting, ProprietaryPart, Tier
+from kist.tui.screens.browse import BrowseScreen
+from kist.tui.screens.detail import DetailModal
+from kist.tui.widgets.part_form import PartForm
+
+
+def _make_proprietary_part() -> ProprietaryPart:
+    return ProprietaryPart(
+        name="IC-STM32F405RGT6-LQFP64",
+        tier=Tier.PROPRIETARY,
+        description="ARM Cortex-M4 MCU",
+        category="IC",
+        package="LQFP-64",
+        mounting=Mounting.SMD,
+        mpn="STM32F405RGT6",
+        manufacturer="STMicroelectronics",
+        symbol="MCU_ST:STM32F405RGTx",
+        footprint="Package_QFP:LQFP-64",
+        value="STM32F405RGT6",
+        reference="U",
+        tags=["arm", "cortex-m4"],
+    )
+
+
+class BrowseApp(App):
+    """Minimal app for testing browse + detail modal integration."""
+
+    CSS = ""
+    library_path: reactive[Path | None] = reactive(None)
+
+    def __init__(self, library_path: Path | None = None) -> None:
+        super().__init__()
+        self._library_path = library_path
+
+    def get_default_screen(self) -> BrowseScreen:
+        return BrowseScreen()
+
+    def on_mount(self) -> None:
+        self.library_path = self._library_path
+
+
+@pytest.fixture
+def library_path(tmp_path):
+    """Create a temporary kist library with one part."""
+    lib = init_library(tmp_path / "lib")
+    db = PartsDatabase(lib / "parts.json")
+    db.load()
+    part = _make_proprietary_part()
+    db.add(part)
+    return lib
+
+
+@pytest.fixture
+def browse_app(library_path):
+    return BrowseApp(library_path=library_path)
+
+
+# -- Modal open/close ---
+
+
+async def test_detail_modal_opens_with_part_data():
+    """DetailModal shows part data in a readonly PartForm."""
+    part = _make_proprietary_part()
+    app = BrowseApp()
+
+    async with app.run_test() as pilot:
+        await app.push_screen(DetailModal(part))
+        await pilot.pause()
+
+        form = app.screen.query_one("#detail-form", PartForm)
+        assert form.mode == "readonly"
+        assert form.query_one("#mpn-ro", Label).content == "STM32F405RGT6"
+        assert form.query_one("#manufacturer-ro", Label).content == "STMicroelectronics"
+
+
+async def test_detail_modal_border_title():
+    """Modal container shows part name in border title."""
+    part = _make_proprietary_part()
+    app = BrowseApp()
+
+    async with app.run_test() as pilot:
+        await app.push_screen(DetailModal(part))
+        await pilot.pause()
+
+        container = app.screen.query_one("#detail-container")
+        assert container.border_title == "IC-STM32F405RGT6-LQFP64"
+
+
+async def test_escape_dismisses_modal():
+    """Escape closes the detail modal."""
+    part = _make_proprietary_part()
+    app = BrowseApp()
+
+    async with app.run_test() as pilot:
+        await app.push_screen(DetailModal(part))
+        await pilot.pause()
+
+        assert isinstance(app.screen, DetailModal)
+        await pilot.press("escape")
+        assert not isinstance(app.screen, DetailModal)
+
+
+async def test_escape_returns_false_when_unchanged():
+    """Dismiss without changes returns False."""
+    part = _make_proprietary_part()
+    result = None
+
+    def on_dismiss(value: bool | None) -> None:
+        nonlocal result
+        result = value
+
+    app = BrowseApp()
+
+    async with app.run_test() as pilot:
+        await app.push_screen(DetailModal(part), callback=on_dismiss)
+        await pilot.pause()
+        await pilot.press("escape")
+
+        assert result is False
+
+
+# -- Edit toggle ---
+
+
+async def test_edit_toggle():
+    """Pressing 'e' toggles between readonly and editable mode."""
+    part = _make_proprietary_part()
+    app = BrowseApp()
+
+    async with app.run_test() as pilot:
+        await app.push_screen(DetailModal(part))
+        await pilot.pause()
+
+        form = app.screen.query_one("#detail-form", PartForm)
+        assert form.mode == "readonly"
+
+        await pilot.press("e")
+        assert form.mode == "editable"
+
+        await pilot.press("e")
+        assert form.mode == "readonly"
+
+
+# -- Browse integration ---
+
+
+async def test_browse_row_select_opens_detail(browse_app):
+    """Selecting a row in the browse table opens the detail modal."""
+    async with browse_app.run_test() as pilot:
+        # Table should have one row from the fixture
+        table = browse_app.query_one("#parts-table")
+        assert table.row_count == 1
+
+        # Focus and select
+        table.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(browse_app.screen, DetailModal)
+        form = browse_app.screen.query_one("#detail-form", PartForm)
+        assert form.query_one("#mpn-ro", Label).content == "STM32F405RGT6"

--- a/tests/tui/test_detail_modal.py
+++ b/tests/tui/test_detail_modal.py
@@ -7,13 +7,13 @@ from pathlib import Path
 import pytest
 from textual.app import App
 from textual.reactive import reactive
-from textual.widgets import Label
+from textual.widgets import Input, Label
 
 from kist.core.database import PartsDatabase
 from kist.core.library import init_library
 from kist.models.part import Mounting, ProprietaryPart, Tier
 from kist.tui.screens.browse import BrowseScreen
-from kist.tui.screens.detail import DetailModal
+from kist.tui.screens.detail import ConfirmModal, DetailModal
 from kist.tui.widgets.part_form import PartForm
 
 
@@ -135,8 +135,8 @@ async def test_escape_returns_false_when_unchanged():
 # -- Edit toggle ---
 
 
-async def test_edit_toggle():
-    """Pressing 'e' toggles between readonly and editable mode."""
+async def test_e_enters_edit_mode():
+    """Pressing 'e' in readonly mode switches to editable."""
     part = _make_proprietary_part()
     app = BrowseApp()
 
@@ -150,7 +150,208 @@ async def test_edit_toggle():
         await pilot.press("e")
         assert form.mode == "editable"
 
+
+async def test_escape_exits_edit_mode():
+    """Pressing escape in edit mode with no changes returns to readonly."""
+    part = _make_proprietary_part()
+    app = BrowseApp()
+
+    async with app.run_test() as pilot:
+        await app.push_screen(DetailModal(part))
+        await pilot.pause()
+
         await pilot.press("e")
+        form = app.screen.query_one("#detail-form", PartForm)
+        assert form.mode == "editable"
+
+        await pilot.press("escape")
+        assert form.mode == "readonly"
+        # Still on detail modal, not dismissed
+        assert isinstance(app.screen, DetailModal)
+
+
+# -- Edit save ---
+
+
+def _persisted_part(library_path: Path) -> ProprietaryPart:
+    """Load the part from the database so it has an IPN assigned."""
+    db = PartsDatabase(library_path / "parts.json")
+    db.load()
+    parts = db.list_parts()
+    assert len(parts) == 1
+    return parts[0]  # type: ignore[return-value]
+
+
+async def test_edit_save_persists_changes(browse_app, library_path):
+    """Editing and saving updates the part in the database."""
+    part = _persisted_part(library_path)
+
+    async with browse_app.run_test() as pilot:
+        await browse_app.push_screen(DetailModal(part))
+        await pilot.pause()
+
+        # Switch to edit mode
+        await pilot.press("e")
+        form = browse_app.screen.query_one("#detail-form", PartForm)
+        assert form.mode == "editable"
+
+        # Change the description
+        desc_input = form.query_one("#description", Input)
+        desc_input.value = "Updated MCU description"
+
+        # Save
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+
+        # Should switch back to readonly
+        assert form.mode == "readonly"
+
+        # Verify in database
+        db = PartsDatabase(library_path / "parts.json")
+        db.load()
+        parts = db.list_parts()
+        assert len(parts) == 1
+        assert parts[0].description == "Updated MCU description"
+
+
+async def test_save_ignored_in_readonly_mode(browse_app, library_path):
+    """ctrl+s does nothing when not in edit mode."""
+    part = _persisted_part(library_path)
+
+    async with browse_app.run_test() as pilot:
+        await browse_app.push_screen(DetailModal(part))
+        await pilot.pause()
+
+        form = browse_app.screen.query_one("#detail-form", PartForm)
+        assert form.mode == "readonly"
+
+        # Save should be a no-op
+        await pilot.press("ctrl+s")
+        assert form.mode == "readonly"
+
+
+# -- Delete ---
+
+
+async def test_delete_removes_part(browse_app, library_path):
+    """Deleting a part removes it from the database and dismisses the modal."""
+    part = _persisted_part(library_path)
+
+    async with browse_app.run_test() as pilot:
+        await browse_app.push_screen(DetailModal(part))
+        await pilot.pause()
+
+        # Press d to open confirm modal
+        await pilot.press("d")
+        await pilot.pause()
+        assert isinstance(browse_app.screen, ConfirmModal)
+
+        # Click confirm
+        await pilot.click("#confirm-ok")
+        await pilot.pause()
+
+        # Modal should be dismissed
+        assert not isinstance(browse_app.screen, DetailModal)
+
+        # Part removed from database
+        db = PartsDatabase(library_path / "parts.json")
+        db.load()
+        assert len(db.list_parts()) == 0
+
+
+async def test_delete_cancel_keeps_part(browse_app, library_path):
+    """Cancelling the delete confirmation leaves the part intact."""
+    part = _persisted_part(library_path)
+
+    async with browse_app.run_test() as pilot:
+        await browse_app.push_screen(DetailModal(part))
+        await pilot.pause()
+
+        await pilot.press("d")
+        await pilot.pause()
+        assert isinstance(browse_app.screen, ConfirmModal)
+
+        # Cancel
+        await pilot.press("escape")
+        await pilot.pause()
+
+        # Back to detail modal, part still exists
+        assert isinstance(browse_app.screen, DetailModal)
+        db = PartsDatabase(library_path / "parts.json")
+        db.load()
+        assert len(db.list_parts()) == 1
+
+
+# -- Unsaved changes prompt ---
+
+
+async def test_escape_in_edit_mode_with_no_changes_goes_readonly(
+    browse_app, library_path
+):
+    """Escape in edit mode returns to readonly if form is unchanged."""
+    part = _persisted_part(library_path)
+
+    async with browse_app.run_test() as pilot:
+        await browse_app.push_screen(DetailModal(part))
+        await pilot.pause()
+
+        await pilot.press("e")
+        form = browse_app.screen.query_one("#detail-form", PartForm)
+        assert form.mode == "editable"
+
+        await pilot.press("escape")
+        assert form.mode == "readonly"
+        assert isinstance(browse_app.screen, DetailModal)
+
+
+async def test_escape_in_edit_mode_with_changes_prompts(browse_app, library_path):
+    """Escape in edit mode shows confirm dialog when form has changes."""
+    part = _persisted_part(library_path)
+
+    async with browse_app.run_test() as pilot:
+        await browse_app.push_screen(DetailModal(part))
+        await pilot.pause()
+
+        await pilot.press("e")
+        form = browse_app.screen.query_one("#detail-form", PartForm)
+        form.query_one("#description", Input).value = "Changed description"
+
+        # Escape should show confirm dialog
+        await pilot.press("escape")
+        await pilot.pause()
+        assert isinstance(browse_app.screen, ConfirmModal)
+
+        # Cancel keeps us in edit mode
+        await pilot.press("escape")
+        await pilot.pause()
+        assert isinstance(browse_app.screen, DetailModal)
+        assert form.mode == "editable"
+
+
+async def test_escape_with_changes_confirm_reverts_to_readonly(
+    browse_app, library_path
+):
+    """Confirming discard returns to readonly mode with original data."""
+    part = _persisted_part(library_path)
+
+    async with browse_app.run_test() as pilot:
+        await browse_app.push_screen(DetailModal(part))
+        await pilot.pause()
+
+        await pilot.press("e")
+        form = browse_app.screen.query_one("#detail-form", PartForm)
+        form.query_one("#description", Input).value = "Changed description"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert isinstance(browse_app.screen, ConfirmModal)
+
+        # Confirm discard
+        await pilot.click("#confirm-ok")
+        await pilot.pause()
+
+        # Back to readonly in the detail modal, not dismissed
+        assert isinstance(browse_app.screen, DetailModal)
         assert form.mode == "readonly"
 
 
@@ -173,3 +374,28 @@ async def test_browse_row_select_opens_detail(browse_app):
         assert isinstance(browse_app.screen, DetailModal)
         form = browse_app.screen.query_one("#detail-form", PartForm)
         assert form.query_one("#mpn-ro", Label).content == "STM32F405RGT6"
+
+
+async def test_browse_refreshes_after_delete(browse_app, library_path):
+    """Browse table refreshes after a part is deleted in the detail modal."""
+    async with browse_app.run_test() as pilot:
+        table = browse_app.query_one("#parts-table")
+        assert table.row_count == 1
+
+        # Open detail modal
+        table.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(browse_app.screen, DetailModal)
+
+        # Delete the part
+        await pilot.press("d")
+        await pilot.pause()
+        await pilot.click("#confirm-ok")
+        await pilot.pause()
+
+        # Back on browse screen, table hidden and empty state shown
+        assert isinstance(browse_app.screen, BrowseScreen)
+        assert table.display is False
+        assert browse_app.query_one("#empty-state").display is True

--- a/tests/tui/test_detail_modal.py
+++ b/tests/tui/test_detail_modal.py
@@ -115,23 +115,17 @@ async def test_escape_dismisses_modal():
         assert not isinstance(app.screen, DetailModal)
 
 
-async def test_escape_returns_false_when_unchanged():
-    """Dismiss without changes returns False."""
+async def test_escape_dismisses_without_callback():
+    """Dismiss without changes closes the modal (no callback needed)."""
     part = _make_proprietary_part()
-    result = None
-
-    def on_dismiss(value: bool | None) -> None:
-        nonlocal result
-        result = value
-
     app = BrowseApp()
 
     async with app.run_test() as pilot:
-        await app.push_screen(DetailModal(part), callback=on_dismiss)
+        await app.push_screen(DetailModal(part))
         await pilot.pause()
         await pilot.press("escape")
 
-        assert result is False
+        assert not isinstance(app.screen, DetailModal)
 
 
 # -- Edit toggle ---

--- a/tests/tui/test_part_form.py
+++ b/tests/tui/test_part_form.py
@@ -1,0 +1,187 @@
+"""PartForm widget tests -- mode switching, tier visibility, data flow."""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Input, Label, Select
+
+from kist.models.part import (
+    Mounting,
+    ProprietaryPart,
+    SupplierInfo,
+    Tier,
+)
+from kist.tui.widgets.part_form import PartForm
+
+
+class PartFormApp(App):
+    """Minimal app for testing PartForm in isolation."""
+
+    CSS = ""
+
+    def __init__(self, mode="editable"):
+        super().__init__()
+        self._mode = mode
+
+    def compose(self) -> ComposeResult:
+        yield PartForm(mode=self._mode, id="form")
+
+
+@pytest.fixture
+def editable_app():
+    return PartFormApp(mode="editable")
+
+
+@pytest.fixture
+def readonly_app():
+    return PartFormApp(mode="readonly")
+
+
+# -- Mode tests ---
+
+
+async def test_editable_mode_shows_inputs(editable_app):
+    async with editable_app.run_test():
+        form = editable_app.query_one("#form", PartForm)
+        # Editable widget visible
+        assert form.query_one("#tier", Select).display is True
+        # Readonly label hidden
+        assert form.query_one("#tier-ro", Label).display is False
+        # Input visible
+        assert form.query_one("#description", Input).display is True
+        assert form.query_one("#description-ro", Label).display is False
+
+
+async def test_readonly_mode_shows_labels(readonly_app):
+    async with readonly_app.run_test():
+        form = readonly_app.query_one("#form", PartForm)
+        # Readonly label visible
+        assert form.query_one("#tier-ro", Label).display is True
+        # Editable widget hidden
+        assert form.query_one("#tier", Select).display is False
+        assert form.query_one("#description-ro", Label).display is True
+        assert form.query_one("#description", Input).display is False
+
+
+async def test_mode_toggle(editable_app):
+    async with editable_app.run_test():
+        form = editable_app.query_one("#form", PartForm)
+        assert form.mode == "editable"
+        assert form.query_one("#tier", Select).display is True
+
+        form.mode = "readonly"
+        assert form.query_one("#tier", Select).display is False
+        assert form.query_one("#tier-ro", Label).display is True
+
+        form.mode = "editable"
+        assert form.query_one("#tier", Select).display is True
+        assert form.query_one("#tier-ro", Label).display is False
+
+
+# -- Tier visibility tests ---
+
+
+async def test_jellybean_hides_mpn_manufacturer_basepn(editable_app):
+    async with editable_app.run_test():
+        form = editable_app.query_one("#form", PartForm)
+        form._apply_tier_visibility(Tier.JELLYBEAN)
+
+        assert form.query_one("#field-mpn").display is False
+        assert form.query_one("#field-manufacturer").display is False
+        assert form.query_one("#field-base-pn").display is False
+
+
+async def test_semi_jellybean_shows_all_conditional_fields(editable_app):
+    async with editable_app.run_test():
+        form = editable_app.query_one("#form", PartForm)
+        form._apply_tier_visibility(Tier.SEMI_JELLYBEAN)
+
+        assert form.query_one("#field-mpn").display is True
+        assert form.query_one("#field-manufacturer").display is True
+        assert form.query_one("#field-base-pn").display is True
+
+
+async def test_proprietary_shows_mpn_hides_basepn(editable_app):
+    async with editable_app.run_test():
+        form = editable_app.query_one("#form", PartForm)
+        form._apply_tier_visibility(Tier.PROPRIETARY)
+
+        assert form.query_one("#field-mpn").display is True
+        assert form.query_one("#field-manufacturer").display is True
+        assert form.query_one("#field-base-pn").display is False
+
+
+# -- Category cascading ---
+
+
+async def test_category_cascading_populates_subcategories(editable_app):
+    async with editable_app.run_test():
+        form = editable_app.query_one("#form", PartForm)
+        form._update_subcategories("CAP")
+
+        sub_select = form.query_one("#subcategory", Select)
+        # _options is a list of (label, value) tuples
+        option_values = [opt[1] for opt in sub_select._options]
+        assert "CER" in option_values
+        assert "ELEC" in option_values
+        assert "TANT" in option_values
+        assert "FILM" in option_values
+
+
+async def test_category_without_subcategories_clears_options(editable_app):
+    async with editable_app.run_test():
+        form = editable_app.query_one("#form", PartForm)
+        form._update_subcategories("CAP")
+        form._update_subcategories("IC")
+
+        sub_select = form.query_one("#subcategory", Select)
+        # Filter out the BLANK sentinel that Select always includes
+        option_values = [
+            opt[1] for opt in sub_select._options if opt[1] != Select.BLANK
+        ]
+        assert option_values == []
+
+
+# -- load_part / to_dict roundtrip ---
+
+
+async def test_load_part_to_dict_roundtrip(editable_app):
+    part = ProprietaryPart(
+        tier=Tier.PROPRIETARY,
+        name="IC-STM32F405RGT6-LQFP64",
+        description="ARM Cortex-M4 MCU",
+        category="IC",
+        mpn="STM32F405RGT6",
+        manufacturer="STMicroelectronics",
+        package="LQFP64",
+        mounting=Mounting.SMD,
+        tags=["mcu", "arm"],
+        symbol="00k-ICs:IC-STM32F405",
+        footprint="Package_QFP:LQFP-64",
+        value="STM32F405RGT6",
+        reference="U",
+        keywords=["arm", "cortex"],
+        specifications={"frequency": "168MHz", "flash": "1MB"},
+        suppliers={"DigiKey": SupplierInfo(sku="497-STM32F405RGT6-ND")},
+        exclude_from_bom=False,
+        exclude_from_board=False,
+    )
+
+    async with editable_app.run_test():
+        form = editable_app.query_one("#form", PartForm)
+        form.load_part(part)
+        d = form.to_dict()
+
+        assert d["tier"] == Tier.PROPRIETARY
+        assert d["category"] == "IC"
+        assert d["mpn"] == "STM32F405RGT6"
+        assert d["manufacturer"] == "STMicroelectronics"
+        assert d["package"] == "LQFP64"
+        assert d["mounting"] == Mounting.SMD
+        assert d["description"] == "ARM Cortex-M4 MCU"
+        assert d["tags"] == ["mcu", "arm"]
+        assert d["specifications"] == {"frequency": "168MHz", "flash": "1MB"}
+        assert "DigiKey" in d["suppliers"]
+        assert d["suppliers"]["DigiKey"]["sku"] == "497-STM32F405RGT6-ND"
+        assert d["symbol"] == "00k-ICs:IC-STM32F405"
+        assert d["footprint"] == "Package_QFP:LQFP-64"
+        assert d["keywords"] == ["arm", "cortex"]

--- a/tests/tui/test_settings_modal.py
+++ b/tests/tui/test_settings_modal.py
@@ -1,0 +1,84 @@
+"""SettingsModal tests -- theme persistence, library fields."""
+
+import pytest
+from textual.app import App
+from textual.widgets import Input, Select
+
+from kist.core.config import (
+    load_global_config,
+    load_library_config,
+    save_library_config,
+)
+from kist.models.config import LibraryConfig
+from kist.tui.modals.settings import SettingsModal
+from kist.tui.themes import KIST_DARK
+
+
+class SettingsApp(App):
+    CSS = ""
+
+    def on_mount(self) -> None:
+        self.register_theme(KIST_DARK)
+        self.theme = "kist-dark"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("KIST_CONFIG_DIR", str(tmp_path / "config"))
+
+
+@pytest.fixture
+def library_path(tmp_path):
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    save_library_config(lib, LibraryConfig(library_prefix="00k", suppliers=["digikey"]))
+    return lib
+
+
+async def test_theme_change_persists(library_path):
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(SettingsModal(library_path))
+        app.screen.query_one("#setting-theme", Select).value = "nord"
+        await pilot.pause()
+        # Live preview applied
+        assert app.theme == "nord"
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        cfg = load_global_config()
+        assert cfg.theme == "nord"
+
+
+async def test_cancel_reverts_theme():
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(SettingsModal())
+        app.screen.query_one("#setting-theme", Select).value = "dracula"
+        await pilot.pause()
+        assert app.theme == "dracula"
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.theme == "kist-dark"
+
+
+async def test_library_fields_save(library_path):
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(SettingsModal(library_path))
+        app.screen.query_one("#setting-prefix", Input).value = "xyz"
+        app.screen.query_one("#setting-suppliers", Input).value = "mouser, lcsc"
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        cfg = load_library_config(library_path)
+        assert cfg.library_prefix == "xyz"
+        assert cfg.suppliers == ["mouser", "lcsc"]
+
+
+async def test_no_library_hides_library_sections():
+    app = SettingsApp()
+    async with app.run_test():
+        await app.push_screen(SettingsModal(library_path=None))
+        results = app.screen.query("#section-library")
+        assert len(results) == 0
+        results = app.screen.query("#section-directories")
+        assert len(results) == 0

--- a/tests/tui/test_settings_modal.py
+++ b/tests/tui/test_settings_modal.py
@@ -1,7 +1,6 @@
 """SettingsModal tests -- theme persistence, library fields."""
 
 import pytest
-from textual.app import App
 from textual.widgets import Input, Select
 
 from kist.core.config import (
@@ -10,16 +9,13 @@ from kist.core.config import (
     save_library_config,
 )
 from kist.models.config import LibraryConfig
+from kist.tui.app import KistApp
 from kist.tui.modals.settings import SettingsModal
-from kist.tui.themes import NULL_THEME
 
 
-class SettingsApp(App):
+class SettingsApp(KistApp):
+    CSS_PATH = None
     CSS = ""
-
-    def on_mount(self) -> None:
-        self.register_theme(NULL_THEME)
-        self.theme = "null"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/tui/test_settings_modal.py
+++ b/tests/tui/test_settings_modal.py
@@ -17,6 +17,15 @@ class SettingsApp(KistApp):
     CSS_PATH = None
     CSS = ""
 
+    def __init__(self, library_path=None):
+        super().__init__()
+        self._test_library_path = library_path
+
+    def _discover_library(self):
+        if self._test_library_path:
+            self.library_path = self._test_library_path
+            self.library_config = load_library_config(self._test_library_path)
+
 
 @pytest.fixture(autouse=True)
 def _isolate_config(monkeypatch, tmp_path):
@@ -32,7 +41,7 @@ def library_path(tmp_path):
 
 
 async def test_theme_change_persists(library_path):
-    app = SettingsApp()
+    app = SettingsApp(library_path)
     async with app.run_test() as pilot:
         await app.push_screen(SettingsModal(library_path))
         app.screen.query_one("#setting-theme", Select).value = "nord"
@@ -58,7 +67,7 @@ async def test_cancel_reverts_theme():
 
 
 async def test_library_fields_save(library_path):
-    app = SettingsApp()
+    app = SettingsApp(library_path)
     async with app.run_test() as pilot:
         await app.push_screen(SettingsModal(library_path))
         app.screen.query_one("#setting-prefix", Input).value = "xyz"

--- a/tests/tui/test_settings_modal.py
+++ b/tests/tui/test_settings_modal.py
@@ -11,15 +11,15 @@ from kist.core.config import (
 )
 from kist.models.config import LibraryConfig
 from kist.tui.modals.settings import SettingsModal
-from kist.tui.themes import KIST_DARK
+from kist.tui.themes import NULL_THEME
 
 
 class SettingsApp(App):
     CSS = ""
 
     def on_mount(self) -> None:
-        self.register_theme(KIST_DARK)
-        self.theme = "kist-dark"
+        self.register_theme(NULL_THEME)
+        self.theme = "null"
 
 
 @pytest.fixture(autouse=True)
@@ -58,7 +58,7 @@ async def test_cancel_reverts_theme():
         assert app.theme == "dracula"
         await pilot.press("escape")
         await pilot.pause()
-        assert app.theme == "kist-dark"
+        assert app.theme == "null"
 
 
 async def test_library_fields_save(library_path):


### PR DESCRIPTION
## Summary

Adds the Textual TUI foundation -- app class, custom header, screen stubs,
theme, CSS, and CLI wiring. `kist` now launches a TUI instead of printing
a placeholder message. `kist add [url]` opens the add screen directly.

## Changes

- `kist.tui` package: `KistApp`, `BrowseScreen`, `AddScreen`, `KistHeader`,
  `kist-dark` theme, base TCSS
- `KistHeader` subclasses Textual's `Header`, replacing the clock with a
  `HeaderLibraryPath` widget that watches `app.library_path`
- `KistApp.get_default_screen()` returns `BrowseScreen`; `AddScreen` is
  pushed on top when `start_screen="add"`
- `kist-dark` theme derived from null.lua / wez-theme terminal palette,
  registered and applied in `on_mount`
- `format_title` override uses ` -- ` separator (project style)
- `get_system_commands` adds "Add part" to the command palette
- CLI: `main()` and `add()` now launch the TUI with deferred imports
- 9 Textual pilot tests covering screen lifecycle, navigation, and commands

## Test plan

- `pytest tests/tui/` -- 9 tests pass (screen composition, escape/quit
  navigation, URL passthrough, theme registration, library discovery,
  system commands)
- Full suite `pytest tests/` passes
- Manual: `kist`, `kist add`, `kist add <url>`, escape, quit, command
  palette, `kist --version`, `kist search` all verified

## Notes

- Screens are stubs with placeholder labels -- fleshed out in follow-up work.