### PR TITLE
Add KiCad library indexing and search selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,6 @@ minversion = "9.0"
 addopts = "-ra -q --strict-markers"
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "slow: marks tests as slow (skip with '-m \"not slow\"')",
+]

--- a/src/kist/kicad/discovery.py
+++ b/src/kist/kicad/discovery.py
@@ -8,14 +8,18 @@ and resolves ``${KICAD9_FOOTPRINT_DIR}`` style variables to real paths.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
+import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import platformdirs
 
 from kist.sexpr import find_all, parse_one
+
+log = logging.getLogger(__name__)
 
 # -- Data types ---
 
@@ -62,12 +66,59 @@ def _major(version: str) -> int:
     return int(version.split(".")[0])
 
 
+_NIX_EXPORT_RE = re.compile(
+    r"^export\s+(KICAD\d+_\w+_DIR)=\$\{[^-]+-'([^']+)'\}",
+)
+
+
+def _nix_kicad_variables() -> dict[str, Path]:
+    """
+    Extract KiCad variable defaults from a Nix wrapper script.
+
+    On NixOS / nix-managed installs, the ``kicad`` binary is a bash
+    wrapper that sets ``KICAD9_FOOTPRINT_DIR`` etc. with Nix store
+    paths as defaults.  Returns those paths, or an empty dict if
+    KiCad is not a Nix wrapper.
+    """
+    kicad_bin = shutil.which("kicad")
+    if kicad_bin is None:
+        return {}
+
+    bin_path = Path(kicad_bin)
+    resolved = bin_path.resolve()
+    if "/nix/store/" not in str(bin_path) and "/nix/store/" not in str(resolved):
+        return {}
+
+    # It's a Nix binary -- read the wrapper script for variable defaults
+    try:
+        wrapper_text = Path(kicad_bin).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+
+    variables: dict[str, Path] = {}
+    for line in wrapper_text.splitlines():
+        m = _NIX_EXPORT_RE.match(line.strip())
+        if m:
+            var_name, nix_path = m.group(1), m.group(2)
+            p = Path(nix_path)
+            if p.is_dir():
+                variables[var_name] = p
+
+    if variables:
+        log.debug("Discovered Nix KiCad variables: %s", list(variables.keys()))
+
+    return variables
+
+
 def _build_variables(version: str, data_dir: Path) -> dict[str, Path]:
     """
     Build the KiCad variable map for a given version.
 
-    Checks environment variable overrides first, then falls back to
-    the conventional data directory layout.
+    Resolution order for each variable:
+    1. Environment variable override (user explicitly set it)
+    2. Conventional data directory (``~/.local/share/kicad/9.0/...``)
+    3. Nix wrapper defaults (if the conventional path doesn't exist
+       and KiCad is installed via Nix)
     """
     major = _major(version)
     mapping: dict[str, Path] = {}
@@ -85,6 +136,23 @@ def _build_variables(version: str, data_dir: Path) -> dict[str, Path]:
             mapping[var_name] = Path(env_val)
         else:
             mapping[var_name] = default_path
+
+    # If key directories are missing or empty, check for Nix wrapper overrides.
+    # KiCad may create empty dirs at ~/.local/share/kicad/9.0/footprints/
+    # while the actual libraries live in the Nix store.
+    def _dir_has_content(p: Path) -> bool:
+        return p.is_dir() and any(p.iterdir())
+
+    needs_nix = any(
+        not _dir_has_content(mapping[v])
+        for v in (f"KICAD{major}_FOOTPRINT_DIR", f"KICAD{major}_SYMBOL_DIR")
+        if v in mapping
+    )
+    if needs_nix:
+        nix_vars = _nix_kicad_variables()
+        for var_name, nix_path in nix_vars.items():
+            if var_name in mapping and not _dir_has_content(mapping[var_name]):
+                mapping[var_name] = nix_path
 
     return mapping
 

--- a/src/kist/kicad/discovery.py
+++ b/src/kist/kicad/discovery.py
@@ -1,0 +1,185 @@
+"""
+KiCad installation discovery.
+
+Finds KiCad's config and data directories, parses the global
+``fp-lib-table`` and ``sym-lib-table`` to get library names and URIs,
+and resolves ``${KICAD9_FOOTPRINT_DIR}`` style variables to real paths.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import platformdirs
+
+from kist.sexpr import find_all, parse_one
+
+# -- Data types ---
+
+
+@dataclass
+class LibTableEntry:
+    """A single row from a KiCad lib table (fp-lib-table or sym-lib-table)."""
+
+    name: str
+    uri: str
+    lib_type: str = "KiCad"
+
+
+@dataclass
+class KiCadEnvironment:
+    """Detected KiCad installation paths and variable mappings."""
+
+    version: str  # e.g. "9.0"
+    config_dir: Path  # e.g. ~/.config/kicad/9.0
+    data_dir: Path  # e.g. ~/.local/share/kicad/9.0
+    variables: dict[str, Path] = field(default_factory=dict)
+
+
+# -- Detection ---
+
+_VERSION_RE = re.compile(r"^(\d+\.\d+)$")
+
+
+def _probe_versioned_dirs(base: Path) -> list[str]:
+    """Return version strings found under *base*, sorted descending."""
+    if not base.is_dir():
+        return []
+    versions = []
+    for child in base.iterdir():
+        if child.is_dir() and _VERSION_RE.match(child.name):
+            versions.append(child.name)
+    return sorted(
+        versions, key=lambda v: tuple(int(x) for x in v.split(".")), reverse=True
+    )
+
+
+def _major(version: str) -> int:
+    """Extract major version number: '9.0' -> 9."""
+    return int(version.split(".")[0])
+
+
+def _build_variables(version: str, data_dir: Path) -> dict[str, Path]:
+    """
+    Build the KiCad variable map for a given version.
+
+    Checks environment variable overrides first, then falls back to
+    the conventional data directory layout.
+    """
+    major = _major(version)
+    mapping: dict[str, Path] = {}
+
+    var_defs = {
+        f"KICAD{major}_FOOTPRINT_DIR": data_dir / "footprints",
+        f"KICAD{major}_SYMBOL_DIR": data_dir / "symbols",
+        f"KICAD{major}_3DMODEL_DIR": data_dir / "3dmodels",
+        f"KICAD{major}_TEMPLATE_DIR": data_dir / "template",
+    }
+
+    for var_name, default_path in var_defs.items():
+        env_val = os.environ.get(var_name)
+        if env_val:
+            mapping[var_name] = Path(env_val)
+        else:
+            mapping[var_name] = default_path
+
+    return mapping
+
+
+def detect_kicad() -> KiCadEnvironment | None:
+    """
+    Detect the KiCad installation by probing for versioned config dirs.
+
+    Returns the environment for the highest version found, or ``None``
+    if no KiCad config directory exists.
+    """
+    config_base = Path(platformdirs.user_config_dir("kicad"))
+    data_base = Path(platformdirs.user_data_dir("kicad"))
+
+    versions = _probe_versioned_dirs(config_base)
+    if not versions:
+        return None
+
+    version = versions[0]  # highest
+    config_dir = config_base / version
+    data_dir = data_base / version
+    variables = _build_variables(version, data_dir)
+
+    return KiCadEnvironment(
+        version=version,
+        config_dir=config_dir,
+        data_dir=data_dir,
+        variables=variables,
+    )
+
+
+# -- Variable resolution ---
+
+_VAR_RE = re.compile(r"\$\{([^}]+)\}")
+
+
+def resolve_uri(uri: str, env: KiCadEnvironment) -> Path:
+    """
+    Resolve a KiCad URI by substituting ``${VAR}`` references.
+
+    Variables are looked up in *env.variables*.  Unresolved variables
+    are left as-is (the path will likely not exist, which callers can
+    handle).
+    """
+
+    def _replace(match: re.Match) -> str:
+        var_name = match.group(1)
+        resolved = env.variables.get(var_name)
+        if resolved is not None:
+            return str(resolved)
+        # Check environment directly as fallback
+        env_val = os.environ.get(var_name)
+        if env_val is not None:
+            return env_val
+        return match.group(0)
+
+    return Path(_VAR_RE.sub(_replace, uri))
+
+
+# -- Lib table parsing ---
+
+
+def parse_lib_table(path: Path) -> list[LibTableEntry]:
+    """
+    Parse a KiCad ``fp-lib-table`` or ``sym-lib-table`` file.
+
+    Returns a list of :class:`LibTableEntry` with name, URI, and type
+    for each ``(lib ...)`` row.
+    """
+    if not path.is_file():
+        return []
+
+    text = path.read_text(encoding="utf-8")
+    tree = parse_one(text)
+
+    if not isinstance(tree, list) or not tree:
+        return []
+
+    entries: list[LibTableEntry] = []
+    for lib in find_all(tree, "lib"):
+        name = ""
+        uri = ""
+        lib_type = "KiCad"
+        for child in lib[1:]:
+            if not isinstance(child, list) or len(child) < 2:
+                continue
+            tag = child[0]
+            val = str(child[1])
+            if tag == "name":
+                name = val
+            elif tag == "uri":
+                uri = val
+            elif tag == "type":
+                lib_type = val
+        if name:
+            entries.append(LibTableEntry(name=name, uri=uri, lib_type=lib_type))
+
+    return entries

--- a/src/kist/kicad/indexer.py
+++ b/src/kist/kicad/indexer.py
@@ -158,13 +158,19 @@ def _cache_dir() -> Path:
 
 
 def _cache_key(env: KiCadEnvironment) -> str:
-    """Hash the lib-table mtimes to detect changes."""
+    """Hash lib-table mtimes and resolved variable paths to detect changes.
+
+    Including the resolved paths ensures the cache invalidates when
+    variables change (e.g. Nix store path update, env var override).
+    """
     parts: list[str] = []
     for table_name in ("fp-lib-table", "sym-lib-table"):
         table_path = env.config_dir / table_name
         if table_path.is_file():
             mtime = table_path.stat().st_mtime
             parts.append(f"{table_path}:{mtime}")
+    for var_name in sorted(env.variables):
+        parts.append(f"{var_name}={env.variables[var_name]}")
     return hashlib.md5("|".join(parts).encode()).hexdigest()
 
 

--- a/src/kist/kicad/indexer.py
+++ b/src/kist/kicad/indexer.py
@@ -1,0 +1,220 @@
+"""
+Library index builder.
+
+Scans KiCad's installed library directories to build a searchable
+catalog of footprints and symbols.  Footprints are indexed by directory
+listing (fast); symbols are parsed via :class:`SymbolLibrary`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import platformdirs
+
+from kist.kicad.discovery import KiCadEnvironment, parse_lib_table, resolve_uri
+from kist.kicad.symbols import SymbolLibrary
+from kist.models.config import LibraryConfig
+
+log = logging.getLogger(__name__)
+
+# -- Data types ---
+
+
+@dataclass
+class LibraryItem:
+    """A single footprint or symbol from a library."""
+
+    library: str  # e.g. "Resistor_SMD"
+    name: str  # e.g. "R_0603_1608Metric"
+    source: str  # "kicad" | "kist" | "3rdparty"
+
+    @property
+    def reference(self) -> str:
+        """Full KiCad reference string: ``Library:Name``."""
+        return f"{self.library}:{self.name}"
+
+
+@dataclass
+class LibraryIndex:
+    """Combined index of all discovered footprints and symbols."""
+
+    footprints: list[LibraryItem]
+    symbols: list[LibraryItem]
+
+
+# -- Footprint indexing ---
+
+
+def build_footprint_index(
+    env: KiCadEnvironment,
+    kist_root: Path | None = None,
+    config: LibraryConfig | None = None,
+) -> list[LibraryItem]:
+    """
+    Build a footprint index from KiCad's ``fp-lib-table`` and kist's own footprints.
+
+    Footprint indexing is fast -- just list ``.kicad_mod`` files inside
+    each ``.pretty`` directory.  No file parsing needed.
+    """
+    items: list[LibraryItem] = []
+
+    # KiCad global footprint libraries
+    fp_table = env.config_dir / "fp-lib-table"
+    for entry in parse_lib_table(fp_table):
+        lib_path = resolve_uri(entry.uri, env)
+        if lib_path.is_dir():
+            for mod_file in sorted(lib_path.glob("*.kicad_mod")):
+                items.append(
+                    LibraryItem(
+                        library=entry.name,
+                        name=mod_file.stem,
+                        source="kicad",
+                    )
+                )
+
+    # Kist library footprints
+    if kist_root and config:
+        fp_dir = kist_root / config.footprints_dir
+        if fp_dir.is_dir():
+            for pretty_dir in sorted(fp_dir.glob("*.pretty")):
+                lib_name = pretty_dir.stem
+                for mod_file in sorted(pretty_dir.glob("*.kicad_mod")):
+                    items.append(
+                        LibraryItem(
+                            library=lib_name,
+                            name=mod_file.stem,
+                            source="kist",
+                        )
+                    )
+
+    return items
+
+
+# -- Symbol indexing ---
+
+
+def build_symbol_index(
+    env: KiCadEnvironment,
+    kist_root: Path | None = None,
+    config: LibraryConfig | None = None,
+) -> list[LibraryItem]:
+    """
+    Build a symbol index from KiCad's ``sym-lib-table`` and kist's own symbols.
+
+    Parses each ``.kicad_sym`` file using :class:`SymbolLibrary` to
+    extract symbol names.
+    """
+    items: list[LibraryItem] = []
+
+    # KiCad global symbol libraries
+    sym_table = env.config_dir / "sym-lib-table"
+    for entry in parse_lib_table(sym_table):
+        sym_path = resolve_uri(entry.uri, env)
+        if sym_path.is_file():
+            try:
+                lib = SymbolLibrary.load(sym_path)
+                for name in lib.symbols():
+                    items.append(
+                        LibraryItem(
+                            library=entry.name,
+                            name=name,
+                            source="kicad",
+                        )
+                    )
+            except Exception:
+                log.warning("Failed to parse symbol library: %s", sym_path)
+
+    # Kist library symbols
+    if kist_root and config:
+        sym_dir = kist_root / config.symbols_dir
+        if sym_dir.is_dir():
+            for sym_file in sorted(sym_dir.glob("*.kicad_sym")):
+                try:
+                    lib = SymbolLibrary.load(sym_file)
+                    for name in lib.symbols():
+                        items.append(
+                            LibraryItem(
+                                library=sym_file.stem,
+                                name=name,
+                                source="kist",
+                            )
+                        )
+                except Exception:
+                    log.warning("Failed to parse kist symbol library: %s", sym_file)
+
+    return items
+
+
+# -- Caching ---
+
+
+def _cache_dir() -> Path:
+    return Path(platformdirs.user_cache_dir("kist"))
+
+
+def _cache_key(env: KiCadEnvironment) -> str:
+    """Hash the lib-table mtimes to detect changes."""
+    parts: list[str] = []
+    for table_name in ("fp-lib-table", "sym-lib-table"):
+        table_path = env.config_dir / table_name
+        if table_path.is_file():
+            mtime = table_path.stat().st_mtime
+            parts.append(f"{table_path}:{mtime}")
+    return hashlib.md5("|".join(parts).encode()).hexdigest()
+
+
+def _save_cache(index: LibraryIndex, cache_path: Path) -> None:
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "footprints": [asdict(item) for item in index.footprints],
+        "symbols": [asdict(item) for item in index.symbols],
+    }
+    cache_path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _load_cache(cache_path: Path) -> LibraryIndex | None:
+    if not cache_path.is_file():
+        return None
+    try:
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+        return LibraryIndex(
+            footprints=[LibraryItem(**item) for item in data["footprints"]],
+            symbols=[LibraryItem(**item) for item in data["symbols"]],
+        )
+    except Exception:
+        return None
+
+
+def load_or_build_index(
+    env: KiCadEnvironment,
+    kist_root: Path | None = None,
+    config: LibraryConfig | None = None,
+    cache_dir: Path | None = None,
+) -> LibraryIndex:
+    """
+    Load the library index from cache, or build and cache it.
+
+    The cache is keyed on the mtimes of the global lib-table files.
+    """
+    if cache_dir is None:
+        cache_dir = _cache_dir()
+
+    key = _cache_key(env)
+    cache_path = cache_dir / f"library_index_{key}.json"
+
+    cached = _load_cache(cache_path)
+    if cached is not None:
+        return cached
+
+    index = LibraryIndex(
+        footprints=build_footprint_index(env, kist_root, config),
+        symbols=build_symbol_index(env, kist_root, config),
+    )
+
+    _save_cache(index, cache_path)
+    return index

--- a/src/kist/kicad/indexer.py
+++ b/src/kist/kicad/indexer.py
@@ -3,7 +3,8 @@ Library index builder.
 
 Scans KiCad's installed library directories to build a searchable
 catalog of footprints and symbols.  Footprints are indexed by directory
-listing (fast); symbols are parsed via :class:`SymbolLibrary`.
+listing (fast); symbols use a lightweight regex scan to extract
+top-level symbol names without full S-expression parsing.
 """
 
 from __future__ import annotations
@@ -11,16 +12,27 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import platformdirs
 
 from kist.kicad.discovery import KiCadEnvironment, parse_lib_table, resolve_uri
-from kist.kicad.symbols import SymbolLibrary
 from kist.models.config import LibraryConfig
 
 log = logging.getLogger(__name__)
+
+# Top-level symbol names in .kicad_sym files: one tab indent, then (symbol "NAME"
+# This avoids full S-expression parsing (~50x faster for 225 libraries).
+_SYMBOL_NAME_RE = re.compile(r'^\t\(symbol\s+"([^"]+)"', re.MULTILINE)
+
+
+def _scan_symbol_names(path: Path) -> list[str]:
+    """Extract top-level symbol names from a .kicad_sym file via regex."""
+    text = path.read_text(encoding="utf-8")
+    return _SYMBOL_NAME_RE.findall(text)
+
 
 # -- Data types ---
 
@@ -106,8 +118,8 @@ def build_symbol_index(
     """
     Build a symbol index from KiCad's ``sym-lib-table`` and kist's own symbols.
 
-    Parses each ``.kicad_sym`` file using :class:`SymbolLibrary` to
-    extract symbol names.
+    Uses a lightweight regex scan to extract top-level symbol names
+    from ``.kicad_sym`` files without full S-expression parsing.
     """
     items: list[LibraryItem] = []
 
@@ -117,8 +129,7 @@ def build_symbol_index(
         sym_path = resolve_uri(entry.uri, env)
         if sym_path.is_file():
             try:
-                lib = SymbolLibrary.load(sym_path)
-                for name in lib.symbols():
+                for name in _scan_symbol_names(sym_path):
                     items.append(
                         LibraryItem(
                             library=entry.name,
@@ -127,7 +138,7 @@ def build_symbol_index(
                         )
                     )
             except Exception:
-                log.warning("Failed to parse symbol library: %s", sym_path)
+                log.warning("Failed to scan symbol library: %s", sym_path)
 
     # Kist library symbols
     if kist_root and config:
@@ -135,8 +146,7 @@ def build_symbol_index(
         if sym_dir.is_dir():
             for sym_file in sorted(sym_dir.glob("*.kicad_sym")):
                 try:
-                    lib = SymbolLibrary.load(sym_file)
-                    for name in lib.symbols():
+                    for name in _scan_symbol_names(sym_file):
                         items.append(
                             LibraryItem(
                                 library=sym_file.stem,
@@ -145,7 +155,7 @@ def build_symbol_index(
                             )
                         )
                 except Exception:
-                    log.warning("Failed to parse kist symbol library: %s", sym_file)
+                    log.warning("Failed to scan kist symbol library: %s", sym_file)
 
     return items
 

--- a/src/kist/kicad/indexer.py
+++ b/src/kist/kicad/indexer.py
@@ -167,7 +167,40 @@ def _cache_dir() -> Path:
     return Path(platformdirs.user_cache_dir("kist"))
 
 
-def _cache_key(env: KiCadEnvironment) -> str:
+def _iter_kist_fingerprint_parts(
+    kist_root: Path | None,
+    config: LibraryConfig | None,
+) -> list[str]:
+    """Build fingerprint parts for kist-managed symbols/footprints."""
+    if kist_root is None or config is None:
+        return []
+
+    parts: list[str] = []
+    config_path = kist_root / ".kist" / "config.toml"
+    if config_path.is_file():
+        stat = config_path.stat()
+        parts.append(f"{config_path}:{stat.st_mtime_ns}:{stat.st_size}")
+
+    sym_dir = kist_root / config.symbols_dir
+    if sym_dir.is_dir():
+        for sym_file in sorted(sym_dir.glob("*.kicad_sym")):
+            stat = sym_file.stat()
+            parts.append(f"{sym_file}:{stat.st_mtime_ns}:{stat.st_size}")
+
+    fp_dir = kist_root / config.footprints_dir
+    if fp_dir.is_dir():
+        for mod_file in sorted(fp_dir.glob("*.pretty/*.kicad_mod")):
+            stat = mod_file.stat()
+            parts.append(f"{mod_file}:{stat.st_mtime_ns}:{stat.st_size}")
+
+    return parts
+
+
+def _cache_key(
+    env: KiCadEnvironment,
+    kist_root: Path | None = None,
+    config: LibraryConfig | None = None,
+) -> str:
     """Hash lib-table mtimes and resolved variable paths to detect changes.
 
     Including the resolved paths ensures the cache invalidates when
@@ -181,6 +214,7 @@ def _cache_key(env: KiCadEnvironment) -> str:
             parts.append(f"{table_path}:{mtime}")
     for var_name in sorted(env.variables):
         parts.append(f"{var_name}={env.variables[var_name]}")
+    parts.extend(_iter_kist_fingerprint_parts(kist_root, config))
     return hashlib.md5("|".join(parts).encode()).hexdigest()
 
 
@@ -220,7 +254,7 @@ def load_or_build_index(
     if cache_dir is None:
         cache_dir = _cache_dir()
 
-    key = _cache_key(env)
+    key = _cache_key(env, kist_root, config)
     cache_path = cache_dir / f"library_index_{key}.json"
 
     cached = _load_cache(cache_path)

--- a/src/kist/tui/app.py
+++ b/src/kist/tui/app.py
@@ -82,6 +82,7 @@ class KistApp(App):
                 self.push_screen(InitScreen())
 
     def _discover_library(self) -> None:
+        self._library_index = None
         try:
             result = find_library()
             self.library_path = result.library_root
@@ -117,6 +118,7 @@ class KistApp(App):
         assert self.library_path is not None
         _save_library_config(self.library_path, config)
         self.library_config = config
+        self._library_index = None
 
     def get_library_index(self) -> LibraryIndex | None:
         """Return the library index, building it lazily on first access."""
@@ -139,6 +141,7 @@ class KistApp(App):
             symbol_files = sync_symbols(self.library_path, db, self.library_config)
             if self.project_dir:
                 sync_sym_lib_table(self.project_dir, symbol_files, self.library_config)
+        self._library_index = None
         self.parts_version += 1
 
     def format_title(self, title: str, sub_title: str) -> Content:

--- a/src/kist/tui/app.py
+++ b/src/kist/tui/app.py
@@ -18,6 +18,8 @@ from kist.core.database import PartsDatabase
 from kist.core.library import find_library
 from kist.core.sync import sync_sym_lib_table, sync_symbols
 from kist.errors import LibraryNotFoundError
+from kist.kicad.discovery import detect_kicad
+from kist.kicad.indexer import LibraryIndex, load_or_build_index
 from kist.models.config import LibraryConfig
 from kist.models.part import Ipn, Part
 from kist.tui.themes import NULL_THEME
@@ -48,6 +50,7 @@ class KistApp(App):
         self._start_screen = start_screen
         self._url_or_mpn = url_or_mpn
         self._init_path = init_path
+        self._library_index: LibraryIndex | None = None
 
     def get_default_screen(self) -> Screen:
         from kist.tui.screens.browse import BrowseScreen
@@ -114,6 +117,20 @@ class KistApp(App):
         assert self.library_path is not None
         _save_library_config(self.library_path, config)
         self.library_config = config
+
+    def get_library_index(self) -> LibraryIndex | None:
+        """Return the library index, building it lazily on first access."""
+        if self._library_index is not None:
+            return self._library_index
+        env = detect_kicad()
+        if env is None:
+            return None
+        self._library_index = load_or_build_index(
+            env,
+            kist_root=self.library_path,
+            config=self.library_config,
+        )
+        return self._library_index
 
     def _after_mutation(self, db: PartsDatabase) -> None:
         """Post-mutation side effects: sync symbols, lib table, UI refresh."""

--- a/src/kist/tui/app.py
+++ b/src/kist/tui/app.py
@@ -126,12 +126,20 @@ class KistApp(App):
             return self._library_index
         env = detect_kicad()
         if env is None:
+            self.notify("KiCad not found -- cannot browse libraries", severity="warning")
             return None
-        self._library_index = load_or_build_index(
-            env,
-            kist_root=self.library_path,
-            config=self.library_config,
-        )
+        try:
+            self._library_index = load_or_build_index(
+                env,
+                kist_root=self.library_path,
+                config=self.library_config,
+            )
+        except Exception as exc:
+            self.notify(
+                f"Failed to read KiCad library tables: {exc}",
+                severity="warning",
+            )
+            return None
         return self._library_index
 
     def _after_mutation(self, db: PartsDatabase) -> None:

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -573,12 +573,11 @@ LibrarySearchModal {
 }
 
 #libsearch-input {
-    dock: top;
+    height: 1;
     margin: 0 0 1 0;
 }
 
 #libsearch-status {
-    dock: top;
     height: 1;
     text-opacity: 60%;
     padding: 0 1;

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -190,6 +190,20 @@ PartForm.-readonly .section:focus-within {
     hatch: right $surface-lighten-1 70%;
 }
 
+.browse-btn {
+    width: 3;
+    min-width: 3;
+    padding: 0;
+    background: $panel;
+    color: $foreground;
+    text-style: none;
+    border: none;
+    height: 1;
+    &:hover {
+        background: $accent;
+    }
+}
+
 .spacer {
     height: 1;
 }

--- a/src/kist/tui/kist.tcss
+++ b/src/kist/tui/kist.tcss
@@ -531,6 +531,50 @@ ConfirmModal {
     margin: 1 1;
 }
 
+/* -- Library search modal --- */
+
+LibrarySearchModal {
+    align: center middle;
+
+    & Input {
+        padding: 0 1;
+        height: 1;
+        border: none;
+        &:focus {
+            padding-left: 0;
+            border-left: outer $surface-lighten-1;
+        }
+    }
+}
+
+#libsearch-container {
+    width: 90%;
+    max-width: 100;
+    height: 80%;
+    border: round $accent;
+    border-title-color: $foreground;
+    border-title-style: bold;
+    background: $background;
+    padding: 1 2;
+}
+
+#libsearch-input {
+    dock: top;
+    margin: 0 0 1 0;
+}
+
+#libsearch-status {
+    dock: top;
+    height: 1;
+    text-opacity: 60%;
+    padding: 0 1;
+}
+
+#libsearch-table {
+    height: 1fr;
+    width: 1fr;
+}
+
 /* -- Modal overlay -- dimmed background like command palette --- */
 
 ModalScreen {

--- a/src/kist/tui/modals/library_search.py
+++ b/src/kist/tui/modals/library_search.py
@@ -6,9 +6,13 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widgets import DataTable, Footer, Input, Label
 
 from kist.kicad.indexer import LibraryItem
+
+_MAX_ROWS = 200
+_DEBOUNCE_S = 0.15
 
 
 class LibrarySearchModal(ModalScreen[str | None]):
@@ -29,6 +33,7 @@ class LibrarySearchModal(ModalScreen[str | None]):
         self._items = items
         self._title = title
         self._filtered: list[LibraryItem] = list(items)
+        self._debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical(id="libsearch-container") as container:
@@ -48,23 +53,22 @@ class LibrarySearchModal(ModalScreen[str | None]):
 
     def _status_text(self) -> str:
         total = len(self._items)
-        shown = len(self._filtered)
+        matched = len(self._filtered)
         label = self._title.lower()
-        if shown == total:
+        if matched == total:
             return f"{total} {label}"
-        return f"{shown} / {total} {label}"
+        suffix = f" (showing {_MAX_ROWS})" if matched > _MAX_ROWS else ""
+        return f"{matched} / {total} {label}{suffix}"
 
     def _populate_table(self) -> None:
         table = self.query_one("#libsearch-table", DataTable)
         table.clear()
-        for item in self._filtered:
+        for item in self._filtered[:_MAX_ROWS]:
             table.add_row(item.library, item.name, key=item.reference)
         self.query_one("#libsearch-status", Label).update(self._status_text())
 
-    def on_input_changed(self, event: Input.Changed) -> None:
-        if event.input.id != "libsearch-input":
-            return
-        query = event.value.strip().lower()
+    def _run_filter(self) -> None:
+        query = self.query_one("#libsearch-input", Input).value.strip().lower()
         if not query:
             self._filtered = list(self._items)
         else:
@@ -72,6 +76,13 @@ class LibrarySearchModal(ModalScreen[str | None]):
                 item for item in self._items if query in item.reference.lower()
             ]
         self._populate_table()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id != "libsearch-input":
+            return
+        if self._debounce_timer is not None:
+            self._debounce_timer.stop()
+        self._debounce_timer = self.set_timer(_DEBOUNCE_S, self._run_filter)
 
     def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
         if event.data_table.id != "libsearch-table":

--- a/src/kist/tui/modals/library_search.py
+++ b/src/kist/tui/modals/library_search.py
@@ -1,0 +1,83 @@
+"""Library search modal -- fzf-style search for footprints and symbols."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import DataTable, Footer, Input, Label
+
+from kist.kicad.indexer import LibraryItem
+
+
+class LibrarySearchModal(ModalScreen[str | None]):
+    """
+    Search and select a library item (footprint or symbol).
+
+    Presents an input at the top with filtered results below.
+    Substring matching on the full ``Library:Name`` reference.
+    Dismisses with the selected reference string, or ``None`` on cancel.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, items: list[LibraryItem], title: str = "Footprints") -> None:
+        super().__init__()
+        self._items = items
+        self._title = title
+        self._filtered: list[LibraryItem] = list(items)
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="libsearch-container") as container:
+            container.border_title = self._title
+            yield Input(placeholder="Type to search...", id="libsearch-input")
+            yield Label(self._status_text(), id="libsearch-status")
+            yield DataTable(id="libsearch-table")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        table = self.query_one("#libsearch-table", DataTable)
+        table.add_columns("Library", "Name")
+        table.cursor_type = "row"
+        table.zebra_stripes = True
+        self._populate_table()
+        self.query_one("#libsearch-input", Input).focus()
+
+    def _status_text(self) -> str:
+        total = len(self._items)
+        shown = len(self._filtered)
+        label = self._title.lower()
+        if shown == total:
+            return f"{total} {label}"
+        return f"{shown} / {total} {label}"
+
+    def _populate_table(self) -> None:
+        table = self.query_one("#libsearch-table", DataTable)
+        table.clear()
+        for item in self._filtered:
+            table.add_row(item.library, item.name, key=item.reference)
+        self.query_one("#libsearch-status", Label).update(self._status_text())
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id != "libsearch-input":
+            return
+        query = event.value.strip().lower()
+        if not query:
+            self._filtered = list(self._items)
+        else:
+            self._filtered = [
+                item for item in self._items if query in item.reference.lower()
+            ]
+        self._populate_table()
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        if event.data_table.id != "libsearch-table":
+            return
+        ref = str(event.row_key.value)
+        self.dismiss(ref)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)

--- a/src/kist/tui/widgets/part_form.py
+++ b/src/kist/tui/widgets/part_form.py
@@ -494,9 +494,6 @@ class PartForm(Static):
         app: KistApp = self.app  # type: ignore[assignment]
         index: LibraryIndex | None = app.get_library_index()
         if index is None:
-            self.notify(
-                "KiCad not found -- cannot browse libraries", severity="warning"
-            )
             return
 
         if field == "symbol":

--- a/src/kist/tui/widgets/part_form.py
+++ b/src/kist/tui/widgets/part_form.py
@@ -240,6 +240,11 @@ class PartForm(Static):
                 yield Input(
                     id="symbol", classes="field-value", placeholder="Library:Symbol"
                 )
+                yield Button(
+                    "\N{HORIZONTAL ELLIPSIS}",
+                    id="browse-symbol",
+                    classes="browse-btn",
+                )
             with Horizontal(classes="form-field"):
                 yield Label("Footprint", classes="field-label")
                 yield Label("", id="footprint-ro", classes="field-value-ro")
@@ -247,6 +252,11 @@ class PartForm(Static):
                     id="footprint",
                     classes="field-value",
                     placeholder="Library:Footprint",
+                )
+                yield Button(
+                    "\N{HORIZONTAL ELLIPSIS}",
+                    id="browse-footprint",
+                    classes="browse-btn",
                 )
             with Horizontal(classes="form-field"):
                 yield Label("Keywords", classes="field-label")
@@ -334,6 +344,10 @@ class PartForm(Static):
         # Action buttons hidden in readonly
         self.query_one("#specs-actions").display = editable
         self.query_one("#suppliers-actions").display = editable
+
+        # Browse buttons hidden in readonly
+        self.query_one("#browse-symbol", Button).display = editable
+        self.query_one("#browse-footprint", Button).display = editable
 
         # DataTables only need focus in editable mode
         self.query_one("#specs-table", DataTable).can_focus = editable
@@ -464,6 +478,50 @@ class PartForm(Static):
             self._submit_spec()
         elif event.button.id == "add-supplier":
             self._submit_supplier()
+        elif event.button.id == "browse-symbol":
+            self._open_library_search("symbol")
+        elif event.button.id == "browse-footprint":
+            self._open_library_search("footprint")
+
+    # -- Library search ---
+
+    def _open_library_search(self, field: str) -> None:
+        """Push LibrarySearchModal for the given field (symbol or footprint)."""
+        from kist.kicad.indexer import LibraryIndex
+        from kist.tui.app import KistApp
+        from kist.tui.modals.library_search import LibrarySearchModal
+
+        app: KistApp = self.app  # type: ignore[assignment]
+        index: LibraryIndex | None = app.get_library_index()
+        if index is None:
+            self.notify(
+                "KiCad not found -- cannot browse libraries", severity="warning"
+            )
+            return
+
+        if field == "symbol":
+            items = index.symbols
+            title = "Symbols"
+        else:
+            items = index.footprints
+            title = "Footprints"
+
+        if not items:
+            self.notify(
+                f"No {title.lower()} found in library index", severity="warning"
+            )
+            return
+
+        app.push_screen(
+            LibrarySearchModal(items, title=title),
+            callback=lambda ref: self._on_library_search_result(ref, field),
+        )
+
+    def _on_library_search_result(self, ref: str | None, field: str) -> None:
+        """Handle LibrarySearchModal result: populate the Input."""
+        if ref is None:
+            return
+        self.query_one(f"#{field}", Input).value = ref
 
     # -- Spec management ---
 

--- a/tests/kicad/test_discovery.py
+++ b/tests/kicad/test_discovery.py
@@ -9,6 +9,7 @@ import pytest
 from kist.kicad.discovery import (
     KiCadEnvironment,
     LibTableEntry,
+    _nix_kicad_variables,
     detect_kicad,
     parse_lib_table,
     resolve_uri,
@@ -163,6 +164,8 @@ def test_detect_kicad_builds_variables(tmp_path: Path, monkeypatch: pytest.Monke
 
     monkeypatch.setattr("platformdirs.user_config_dir", lambda app: str(config_base))
     monkeypatch.setattr("platformdirs.user_data_dir", lambda app: str(data_base))
+    # Disable Nix detection (test dirs are empty, would trigger fallback)
+    monkeypatch.setattr("shutil.which", lambda cmd: None)
     # Clear any real env vars that might interfere
     monkeypatch.delenv("KICAD9_FOOTPRINT_DIR", raising=False)
     monkeypatch.delenv("KICAD9_SYMBOL_DIR", raising=False)
@@ -181,12 +184,16 @@ def test_detect_kicad_env_var_override(tmp_path: Path, monkeypatch: pytest.Monke
     config_base = tmp_path / "config"
     data_base = tmp_path / "data"
     custom_fp = tmp_path / "custom" / "footprints"
+    custom_fp.mkdir(parents=True)
+    (custom_fp / "dummy.pretty").mkdir()  # non-empty so Nix fallback won't trigger
 
     (config_base / "9.0").mkdir(parents=True)
 
     monkeypatch.setattr("platformdirs.user_config_dir", lambda app: str(config_base))
     monkeypatch.setattr("platformdirs.user_data_dir", lambda app: str(data_base))
     monkeypatch.setenv("KICAD9_FOOTPRINT_DIR", str(custom_fp))
+    # Disable Nix detection for the remaining vars
+    monkeypatch.setattr("shutil.which", lambda cmd: None)
     # Clear others
     monkeypatch.delenv("KICAD9_SYMBOL_DIR", raising=False)
     monkeypatch.delenv("KICAD9_3DMODEL_DIR", raising=False)
@@ -213,3 +220,97 @@ def test_detect_kicad_ignores_non_version_dirs(
     env = detect_kicad()
     assert env is not None
     assert env.version == "8.0"
+
+
+# -- Nix detection ---
+
+
+def test_nix_kicad_variables_parses_wrapper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """_nix_kicad_variables extracts paths from a Nix-style wrapper script."""
+    nix_fp = tmp_path / "nix-fps"
+    nix_sym = tmp_path / "nix-syms"
+    nix_fp.mkdir()
+    nix_sym.mkdir()
+    # Dirs must have content for is_dir() validation in _nix_kicad_variables
+    (nix_fp / "Resistor.pretty").mkdir()
+    (nix_sym / "Device.kicad_sym").touch()
+
+    # Write a Nix-style wrapper at a path under /nix/store/
+    nix_bin = tmp_path / "nix" / "store" / "abc" / "bin" / "kicad"
+    nix_bin.parent.mkdir(parents=True)
+    nix_bin.write_text(
+        f"#!/nix/store/bash/bin/bash -e\n"
+        f"export KICAD9_FOOTPRINT_DIR=${{KICAD9_FOOTPRINT_DIR-'{nix_fp}'}}\n"
+        f"export KICAD9_SYMBOL_DIR=${{KICAD9_SYMBOL_DIR-'{nix_sym}'}}\n"
+    )
+
+    monkeypatch.setattr("shutil.which", lambda cmd: str(nix_bin))
+
+    result = _nix_kicad_variables()
+    assert result["KICAD9_FOOTPRINT_DIR"] == nix_fp
+    assert result["KICAD9_SYMBOL_DIR"] == nix_sym
+
+
+def test_nix_kicad_variables_returns_empty_for_non_nix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Non-Nix kicad binary returns empty dict."""
+    wrapper = tmp_path / "usr" / "bin" / "kicad"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text("#!/bin/bash\nexec /usr/lib/kicad/bin/kicad\n")
+
+    monkeypatch.setattr("shutil.which", lambda cmd: str(wrapper))
+
+    result = _nix_kicad_variables()
+    assert result == {}
+
+
+def test_nix_kicad_variables_returns_empty_when_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """No kicad binary returns empty dict."""
+    monkeypatch.setattr("shutil.which", lambda cmd: None)
+    assert _nix_kicad_variables() == {}
+
+
+def test_nix_fallback_overrides_empty_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When default dirs are empty, Nix paths are used instead."""
+    config_base = tmp_path / "config"
+    data_base = tmp_path / "data"
+    (config_base / "9.0").mkdir(parents=True)
+    # Create empty default dirs (as KiCad does on Nix)
+    (data_base / "9.0" / "footprints").mkdir(parents=True)
+    (data_base / "9.0" / "symbols").mkdir(parents=True)
+
+    nix_fp = tmp_path / "nix-fps"
+    nix_sym = tmp_path / "nix-syms"
+    nix_fp.mkdir()
+    nix_sym.mkdir()
+    # Put content in Nix dirs
+    (nix_fp / "Resistor.pretty").mkdir()
+    (nix_sym / "Device.kicad_sym").touch()
+
+    nix_bin = tmp_path / "nix" / "store" / "abc" / "bin" / "kicad"
+    nix_bin.parent.mkdir(parents=True)
+    nix_bin.write_text(
+        f"#!/nix/store/bash/bin/bash -e\n"
+        f"export KICAD9_FOOTPRINT_DIR=${{KICAD9_FOOTPRINT_DIR-'{nix_fp}'}}\n"
+        f"export KICAD9_SYMBOL_DIR=${{KICAD9_SYMBOL_DIR-'{nix_sym}'}}\n"
+    )
+
+    monkeypatch.setattr("platformdirs.user_config_dir", lambda app: str(config_base))
+    monkeypatch.setattr("platformdirs.user_data_dir", lambda app: str(data_base))
+    monkeypatch.setattr("shutil.which", lambda cmd: str(nix_bin))
+    monkeypatch.delenv("KICAD9_FOOTPRINT_DIR", raising=False)
+    monkeypatch.delenv("KICAD9_SYMBOL_DIR", raising=False)
+    monkeypatch.delenv("KICAD9_3DMODEL_DIR", raising=False)
+    monkeypatch.delenv("KICAD9_TEMPLATE_DIR", raising=False)
+
+    env = detect_kicad()
+    assert env is not None
+    assert env.variables["KICAD9_FOOTPRINT_DIR"] == nix_fp
+    assert env.variables["KICAD9_SYMBOL_DIR"] == nix_sym

--- a/tests/kicad/test_discovery.py
+++ b/tests/kicad/test_discovery.py
@@ -1,0 +1,215 @@
+"""Tests for KiCad installation discovery and lib-table parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kist.kicad.discovery import (
+    KiCadEnvironment,
+    LibTableEntry,
+    detect_kicad,
+    parse_lib_table,
+    resolve_uri,
+)
+
+# -- Fixtures ---
+
+
+@pytest.fixture()
+def kicad_env(tmp_path: Path) -> KiCadEnvironment:
+    """A minimal KiCadEnvironment pointing at tmp_path."""
+    return KiCadEnvironment(
+        version="9.0",
+        config_dir=tmp_path / "config" / "kicad" / "9.0",
+        data_dir=tmp_path / "data" / "kicad" / "9.0",
+        variables={
+            "KICAD9_FOOTPRINT_DIR": tmp_path / "data" / "kicad" / "9.0" / "footprints",
+            "KICAD9_SYMBOL_DIR": tmp_path / "data" / "kicad" / "9.0" / "symbols",
+            "KICAD9_3DMODEL_DIR": tmp_path / "data" / "kicad" / "9.0" / "3dmodels",
+        },
+    )
+
+
+FP_LIB_TABLE = """\
+(fp_lib_table
+  (version 7)
+  (lib (name "Resistor_SMD")(type "KiCad")(uri "${KICAD9_FOOTPRINT_DIR}/Resistor_SMD.pretty")(options "")(descr ""))
+  (lib (name "Capacitor_SMD")(type "KiCad")(uri "${KICAD9_FOOTPRINT_DIR}/Capacitor_SMD.pretty")(options "")(descr ""))
+)
+"""
+
+SYM_LIB_TABLE = """\
+(sym_lib_table
+  (version 7)
+  (lib (name "Device")(type "KiCad")(uri "${KICAD9_SYMBOL_DIR}/Device.kicad_sym")(options "")(descr ""))
+  (lib (name "power")(type "KiCad")(uri "${KICAD9_SYMBOL_DIR}/power.kicad_sym")(options "")(descr ""))
+)
+"""
+
+
+# -- resolve_uri ---
+
+
+def test_resolve_uri_substitutes_variable(kicad_env: KiCadEnvironment):
+    uri = "${KICAD9_FOOTPRINT_DIR}/Resistor_SMD.pretty"
+    result = resolve_uri(uri, kicad_env)
+    expected = kicad_env.variables["KICAD9_FOOTPRINT_DIR"] / "Resistor_SMD.pretty"
+    assert result == expected
+
+
+def test_resolve_uri_leaves_unknown_variable(kicad_env: KiCadEnvironment):
+    uri = "${UNKNOWN_VAR}/something"
+    result = resolve_uri(uri, kicad_env)
+    assert "${UNKNOWN_VAR}" in str(result)
+
+
+def test_resolve_uri_no_variables(kicad_env: KiCadEnvironment):
+    uri = "/absolute/path/to/lib.pretty"
+    result = resolve_uri(uri, kicad_env)
+    assert result == Path("/absolute/path/to/lib.pretty")
+
+
+def test_resolve_uri_multiple_variables(kicad_env: KiCadEnvironment):
+    uri = "${KICAD9_FOOTPRINT_DIR}/${KICAD9_SYMBOL_DIR}/mixed"
+    result = resolve_uri(uri, kicad_env)
+    # Both variables should be resolved
+    assert "${KICAD9_FOOTPRINT_DIR}" not in str(result)
+    assert "${KICAD9_SYMBOL_DIR}" not in str(result)
+    assert str(result).endswith("/mixed")
+
+
+# -- parse_lib_table ---
+
+
+def test_parse_fp_lib_table(tmp_path: Path):
+    table_path = tmp_path / "fp-lib-table"
+    table_path.write_text(FP_LIB_TABLE)
+
+    entries = parse_lib_table(table_path)
+    assert len(entries) == 2
+    assert entries[0] == LibTableEntry(
+        name="Resistor_SMD",
+        uri="${KICAD9_FOOTPRINT_DIR}/Resistor_SMD.pretty",
+        lib_type="KiCad",
+    )
+    assert entries[1].name == "Capacitor_SMD"
+
+
+def test_parse_sym_lib_table(tmp_path: Path):
+    table_path = tmp_path / "sym-lib-table"
+    table_path.write_text(SYM_LIB_TABLE)
+
+    entries = parse_lib_table(table_path)
+    assert len(entries) == 2
+    assert entries[0].name == "Device"
+    assert entries[1].name == "power"
+    assert "${KICAD9_SYMBOL_DIR}" in entries[0].uri
+
+
+def test_parse_lib_table_missing_file(tmp_path: Path):
+    missing = tmp_path / "nonexistent"
+    assert parse_lib_table(missing) == []
+
+
+def test_parse_lib_table_empty(tmp_path: Path):
+    table_path = tmp_path / "fp-lib-table"
+    table_path.write_text("(fp_lib_table\n  (version 7)\n)\n")
+    entries = parse_lib_table(table_path)
+    assert entries == []
+
+
+# -- detect_kicad ---
+
+
+def test_detect_kicad_finds_highest_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """detect_kicad picks the highest versioned subdir."""
+    config_base = tmp_path / "config"
+    data_base = tmp_path / "data"
+
+    # Create two version dirs
+    (config_base / "8.0").mkdir(parents=True)
+    (config_base / "9.0").mkdir(parents=True)
+
+    monkeypatch.setattr("platformdirs.user_config_dir", lambda app: str(config_base))
+    monkeypatch.setattr("platformdirs.user_data_dir", lambda app: str(data_base))
+
+    env = detect_kicad()
+    assert env is not None
+    assert env.version == "9.0"
+    assert env.config_dir == config_base / "9.0"
+    assert env.data_dir == data_base / "9.0"
+
+
+def test_detect_kicad_returns_none_when_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """detect_kicad returns None when no KiCad config dir exists."""
+    empty = tmp_path / "empty"
+    monkeypatch.setattr("platformdirs.user_config_dir", lambda app: str(empty))
+    monkeypatch.setattr("platformdirs.user_data_dir", lambda app: str(empty))
+
+    assert detect_kicad() is None
+
+
+def test_detect_kicad_builds_variables(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """detect_kicad populates the variable map."""
+    config_base = tmp_path / "config"
+    data_base = tmp_path / "data"
+    (config_base / "9.0").mkdir(parents=True)
+
+    monkeypatch.setattr("platformdirs.user_config_dir", lambda app: str(config_base))
+    monkeypatch.setattr("platformdirs.user_data_dir", lambda app: str(data_base))
+    # Clear any real env vars that might interfere
+    monkeypatch.delenv("KICAD9_FOOTPRINT_DIR", raising=False)
+    monkeypatch.delenv("KICAD9_SYMBOL_DIR", raising=False)
+    monkeypatch.delenv("KICAD9_3DMODEL_DIR", raising=False)
+    monkeypatch.delenv("KICAD9_TEMPLATE_DIR", raising=False)
+
+    env = detect_kicad()
+    assert env is not None
+    assert "KICAD9_FOOTPRINT_DIR" in env.variables
+    assert env.variables["KICAD9_FOOTPRINT_DIR"] == data_base / "9.0" / "footprints"
+    assert env.variables["KICAD9_SYMBOL_DIR"] == data_base / "9.0" / "symbols"
+
+
+def test_detect_kicad_env_var_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Environment variables override default data paths."""
+    config_base = tmp_path / "config"
+    data_base = tmp_path / "data"
+    custom_fp = tmp_path / "custom" / "footprints"
+
+    (config_base / "9.0").mkdir(parents=True)
+
+    monkeypatch.setattr("platformdirs.user_config_dir", lambda app: str(config_base))
+    monkeypatch.setattr("platformdirs.user_data_dir", lambda app: str(data_base))
+    monkeypatch.setenv("KICAD9_FOOTPRINT_DIR", str(custom_fp))
+    # Clear others
+    monkeypatch.delenv("KICAD9_SYMBOL_DIR", raising=False)
+    monkeypatch.delenv("KICAD9_3DMODEL_DIR", raising=False)
+    monkeypatch.delenv("KICAD9_TEMPLATE_DIR", raising=False)
+
+    env = detect_kicad()
+    assert env is not None
+    assert env.variables["KICAD9_FOOTPRINT_DIR"] == custom_fp
+
+
+def test_detect_kicad_ignores_non_version_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Non-version directories like 'scripting' are ignored."""
+    config_base = tmp_path / "config"
+    data_base = tmp_path / "data"
+
+    (config_base / "scripting").mkdir(parents=True)
+    (config_base / "8.0").mkdir(parents=True)
+
+    monkeypatch.setattr("platformdirs.user_config_dir", lambda app: str(config_base))
+    monkeypatch.setattr("platformdirs.user_data_dir", lambda app: str(data_base))
+
+    env = detect_kicad()
+    assert env is not None
+    assert env.version == "8.0"

--- a/tests/kicad/test_indexer.py
+++ b/tests/kicad/test_indexer.py
@@ -1,0 +1,247 @@
+"""Tests for library index builder."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kist.kicad.discovery import KiCadEnvironment
+from kist.kicad.indexer import (
+    LibraryItem,
+    build_footprint_index,
+    build_symbol_index,
+    load_or_build_index,
+)
+from kist.models.config import LibraryConfig
+
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "kicad"
+
+
+# -- Helpers ---
+
+
+def _make_fp_lib_table(config_dir: Path, fp_dir: Path, libraries: list[str]) -> None:
+    """Write an fp-lib-table with entries pointing at *fp_dir*."""
+    entries = []
+    for name in libraries:
+        uri = f"{fp_dir}/{name}.pretty"
+        entries.append(
+            f'  (lib (name "{name}")(type "KiCad")(uri "{uri}")(options "")(descr ""))'
+        )
+    content = "(fp_lib_table\n  (version 7)\n" + "\n".join(entries) + "\n)\n"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "fp-lib-table").write_text(content)
+
+
+def _make_sym_lib_table(config_dir: Path, sym_dir: Path, libraries: list[str]) -> None:
+    """Write a sym-lib-table with entries pointing at *sym_dir*."""
+    entries = []
+    for name in libraries:
+        uri = f"{sym_dir}/{name}.kicad_sym"
+        entries.append(
+            f'  (lib (name "{name}")(type "KiCad")(uri "{uri}")(options "")(descr ""))'
+        )
+    content = "(sym_lib_table\n  (version 7)\n" + "\n".join(entries) + "\n)\n"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "sym-lib-table").write_text(content)
+
+
+def _make_pretty_dir(base: Path, lib_name: str, footprints: list[str]) -> None:
+    """Create a .pretty directory with empty .kicad_mod files."""
+    pretty = base / f"{lib_name}.pretty"
+    pretty.mkdir(parents=True, exist_ok=True)
+    for fp in footprints:
+        (pretty / f"{fp}.kicad_mod").touch()
+
+
+# -- Fixtures ---
+
+
+@pytest.fixture()
+def kicad_env(tmp_path: Path) -> KiCadEnvironment:
+    """Minimal KiCadEnvironment for testing."""
+    config_dir = tmp_path / "config" / "kicad" / "9.0"
+    data_dir = tmp_path / "data" / "kicad" / "9.0"
+    fp_dir = data_dir / "footprints"
+    sym_dir = data_dir / "symbols"
+    config_dir.mkdir(parents=True)
+    fp_dir.mkdir(parents=True)
+    sym_dir.mkdir(parents=True)
+    return KiCadEnvironment(
+        version="9.0",
+        config_dir=config_dir,
+        data_dir=data_dir,
+        variables={
+            "KICAD9_FOOTPRINT_DIR": fp_dir,
+            "KICAD9_SYMBOL_DIR": sym_dir,
+        },
+    )
+
+
+# -- LibraryItem ---
+
+
+def test_library_item_reference():
+    item = LibraryItem(library="Resistor_SMD", name="R_0603_1608Metric", source="kicad")
+    assert item.reference == "Resistor_SMD:R_0603_1608Metric"
+
+
+# -- build_footprint_index ---
+
+
+def test_footprint_index_from_global_libs(kicad_env: KiCadEnvironment):
+    fp_dir = kicad_env.variables["KICAD9_FOOTPRINT_DIR"]
+    _make_pretty_dir(fp_dir, "Resistor_SMD", ["R_0603_1608Metric", "R_0805_2012Metric"])
+    _make_pretty_dir(fp_dir, "Capacitor_SMD", ["C_0402_1005Metric"])
+    _make_fp_lib_table(
+        kicad_env.config_dir,
+        fp_dir,
+        ["Resistor_SMD", "Capacitor_SMD"],
+    )
+
+    items = build_footprint_index(kicad_env)
+    assert len(items) == 3
+    refs = [i.reference for i in items]
+    assert "Resistor_SMD:R_0603_1608Metric" in refs
+    assert "Resistor_SMD:R_0805_2012Metric" in refs
+    assert "Capacitor_SMD:C_0402_1005Metric" in refs
+    assert all(i.source == "kicad" for i in items)
+
+
+def test_footprint_index_empty_when_no_lib_table(kicad_env: KiCadEnvironment):
+    items = build_footprint_index(kicad_env)
+    assert items == []
+
+
+def test_footprint_index_includes_kist_footprints(
+    kicad_env: KiCadEnvironment, tmp_path: Path
+):
+    kist_root = tmp_path / "kist-lib"
+    fp_dir = kist_root / "footprints"
+    _make_pretty_dir(fp_dir, "00k-Resistors", ["R_Custom"])
+    config = LibraryConfig(footprints_dir="footprints")
+
+    items = build_footprint_index(kicad_env, kist_root=kist_root, config=config)
+    assert len(items) == 1
+    assert items[0].reference == "00k-Resistors:R_Custom"
+    assert items[0].source == "kist"
+
+
+def test_footprint_index_skips_missing_dirs(kicad_env: KiCadEnvironment):
+    """Libraries in the table whose dirs don't exist are silently skipped."""
+    fp_dir = kicad_env.variables["KICAD9_FOOTPRINT_DIR"]
+    _make_fp_lib_table(kicad_env.config_dir, fp_dir, ["Missing_Lib"])
+    items = build_footprint_index(kicad_env)
+    assert items == []
+
+
+# -- build_symbol_index ---
+
+
+def test_symbol_index_from_global_libs(kicad_env: KiCadEnvironment):
+    """Index symbols from a real fixture file via the sym-lib-table."""
+    sym_dir = kicad_env.variables["KICAD9_SYMBOL_DIR"]
+
+    # Copy fixture file into the test sym dir
+    fixture = FIXTURES / "Device_RCL.kicad_sym"
+    (sym_dir / "Device_RCL.kicad_sym").write_text(fixture.read_text())
+
+    _make_sym_lib_table(kicad_env.config_dir, sym_dir, ["Device_RCL"])
+
+    items = build_symbol_index(kicad_env)
+    refs = [i.reference for i in items]
+    assert "Device_RCL:C" in refs
+    assert "Device_RCL:L" in refs
+    assert "Device_RCL:R" in refs
+    assert all(i.source == "kicad" for i in items)
+
+
+def test_symbol_index_empty_when_no_lib_table(kicad_env: KiCadEnvironment):
+    items = build_symbol_index(kicad_env)
+    assert items == []
+
+
+def test_symbol_index_includes_kist_symbols(
+    kicad_env: KiCadEnvironment, tmp_path: Path
+):
+    kist_root = tmp_path / "kist-lib"
+    sym_dir = kist_root / "symbols"
+    sym_dir.mkdir(parents=True)
+
+    # Copy fixture as a kist symbol library
+    fixture = FIXTURES / "Device_RCL.kicad_sym"
+    (sym_dir / "00k-Passives.kicad_sym").write_text(fixture.read_text())
+
+    config = LibraryConfig(symbols_dir="symbols")
+
+    items = build_symbol_index(kicad_env, kist_root=kist_root, config=config)
+    assert len(items) == 3
+    assert all(i.source == "kist" for i in items)
+    assert all(i.library == "00k-Passives" for i in items)
+
+
+def test_symbol_index_skips_unparseable_files(kicad_env: KiCadEnvironment):
+    """Corrupted symbol files are logged and skipped, not fatal."""
+    sym_dir = kicad_env.variables["KICAD9_SYMBOL_DIR"]
+    (sym_dir / "bad.kicad_sym").write_text("not valid sexpr content {{{}}")
+    _make_sym_lib_table(kicad_env.config_dir, sym_dir, ["bad"])
+
+    items = build_symbol_index(kicad_env)
+    assert items == []
+
+
+# -- load_or_build_index ---
+
+
+def test_load_or_build_creates_cache(kicad_env: KiCadEnvironment, tmp_path: Path):
+    fp_dir = kicad_env.variables["KICAD9_FOOTPRINT_DIR"]
+    _make_pretty_dir(fp_dir, "Test_Lib", ["FP_A"])
+    _make_fp_lib_table(kicad_env.config_dir, fp_dir, ["Test_Lib"])
+
+    cache_dir = tmp_path / "cache"
+    index = load_or_build_index(kicad_env, cache_dir=cache_dir)
+
+    assert len(index.footprints) == 1
+    assert index.footprints[0].reference == "Test_Lib:FP_A"
+
+    # Cache file should exist
+    cache_files = list(cache_dir.glob("library_index_*.json"))
+    assert len(cache_files) == 1
+
+
+def test_load_or_build_uses_cache(kicad_env: KiCadEnvironment, tmp_path: Path):
+    fp_dir = kicad_env.variables["KICAD9_FOOTPRINT_DIR"]
+    _make_pretty_dir(fp_dir, "Test_Lib", ["FP_A"])
+    _make_fp_lib_table(kicad_env.config_dir, fp_dir, ["Test_Lib"])
+
+    cache_dir = tmp_path / "cache"
+
+    # Build first time
+    index1 = load_or_build_index(kicad_env, cache_dir=cache_dir)
+    assert len(index1.footprints) == 1
+
+    # Add another footprint file (but don't update lib table mtime)
+    (fp_dir / "Test_Lib.pretty" / "FP_B.kicad_mod").touch()
+
+    # Second call should return cached version (still 1 footprint)
+    index2 = load_or_build_index(kicad_env, cache_dir=cache_dir)
+    assert len(index2.footprints) == 1
+
+
+def test_load_or_build_both_types(kicad_env: KiCadEnvironment, tmp_path: Path):
+    fp_dir = kicad_env.variables["KICAD9_FOOTPRINT_DIR"]
+    sym_dir = kicad_env.variables["KICAD9_SYMBOL_DIR"]
+
+    _make_pretty_dir(fp_dir, "Resistor_SMD", ["R_0603"])
+    _make_fp_lib_table(kicad_env.config_dir, fp_dir, ["Resistor_SMD"])
+
+    fixture = FIXTURES / "Device_RCL.kicad_sym"
+    (sym_dir / "Device_RCL.kicad_sym").write_text(fixture.read_text())
+    _make_sym_lib_table(kicad_env.config_dir, sym_dir, ["Device_RCL"])
+
+    cache_dir = tmp_path / "cache"
+    index = load_or_build_index(kicad_env, cache_dir=cache_dir)
+
+    assert len(index.footprints) == 1
+    assert len(index.symbols) == 3

--- a/tests/kicad/test_indexer.py
+++ b/tests/kicad/test_indexer.py
@@ -245,3 +245,35 @@ def test_load_or_build_both_types(kicad_env: KiCadEnvironment, tmp_path: Path):
 
     assert len(index.footprints) == 1
     assert len(index.symbols) == 3
+
+
+def test_load_or_build_refreshes_on_kist_symbol_changes(
+    kicad_env: KiCadEnvironment, tmp_path: Path
+):
+    """Kist symbol file changes invalidate the cache key."""
+    kist_root = tmp_path / "kist-lib"
+    sym_dir = kist_root / "symbols"
+    sym_dir.mkdir(parents=True)
+    config = LibraryConfig(symbols_dir="symbols")
+
+    fixture = FIXTURES / "Device_RCL.kicad_sym"
+    (sym_dir / "A.kicad_sym").write_text(fixture.read_text())
+
+    cache_dir = tmp_path / "cache"
+    index1 = load_or_build_index(
+        kicad_env,
+        kist_root=kist_root,
+        config=config,
+        cache_dir=cache_dir,
+    )
+    assert len(index1.symbols) == 3
+
+    # Add a second symbol library without touching KiCad lib-table files.
+    (sym_dir / "B.kicad_sym").write_text(fixture.read_text())
+    index2 = load_or_build_index(
+        kicad_env,
+        kist_root=kist_root,
+        config=config,
+        cache_dir=cache_dir,
+    )
+    assert len(index2.symbols) == 6

--- a/tests/tui/test_add_screen.py
+++ b/tests/tui/test_add_screen.py
@@ -16,6 +16,8 @@ from kist.tui.app import KistApp
 from kist.tui.screens.add import AddScreen
 from kist.tui.widgets.part_form import PartForm
 
+pytestmark = pytest.mark.slow
+
 
 class AddScreenApp(KistApp):
     """Minimal app for testing AddScreen in isolation."""

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -3,7 +3,8 @@
 import pytest
 
 from kist.core.config import save_global_config
-from kist.models.config import GlobalConfig
+from kist.kicad.indexer import LibraryIndex
+from kist.models.config import GlobalConfig, LibraryConfig
 from kist.tui.app import KistApp
 from kist.tui.screens.add import AddScreen
 from kist.tui.screens.browse import BrowseScreen
@@ -118,3 +119,14 @@ async def test_saved_theme_applied_on_startup(tmp_path, monkeypatch):
     app = KistApp()
     async with app.run_test():
         assert app.theme == "nord"
+
+
+def test_update_library_config_invalidates_library_index(tmp_path, monkeypatch):
+    app = KistApp()
+    app.library_path = tmp_path
+    app._library_index = LibraryIndex(footprints=[], symbols=[])  # type: ignore[attr-defined]
+    monkeypatch.setattr("kist.tui.app._save_library_config", lambda *args, **kwargs: None)
+
+    app.update_library_config(LibraryConfig())
+
+    assert app._library_index is None  # type: ignore[attr-defined]

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -3,6 +3,7 @@
 import pytest
 
 from kist.core.config import save_global_config
+from kist.kicad.discovery import KiCadEnvironment
 from kist.kicad.indexer import LibraryIndex
 from kist.models.config import GlobalConfig, LibraryConfig
 from kist.tui.app import KistApp
@@ -130,3 +131,43 @@ def test_update_library_config_invalidates_library_index(tmp_path, monkeypatch):
     app.update_library_config(LibraryConfig())
 
     assert app._library_index is None  # type: ignore[attr-defined]
+
+
+def test_get_library_index_warns_when_kicad_missing(monkeypatch):
+    app = KistApp()
+    notices: list[tuple[str, str]] = []
+
+    monkeypatch.setattr("kist.tui.app.detect_kicad", lambda: None)
+    monkeypatch.setattr(
+        app,
+        "notify",
+        lambda msg, severity="information", **kwargs: notices.append((msg, severity)),
+    )
+
+    assert app.get_library_index() is None
+    assert notices == [("KiCad not found -- cannot browse libraries", "warning")]
+
+
+def test_get_library_index_warns_when_index_build_fails(tmp_path, monkeypatch):
+    app = KistApp()
+    notices: list[tuple[str, str]] = []
+    env = KiCadEnvironment(
+        version="9.0",
+        config_dir=tmp_path / "config",
+        data_dir=tmp_path / "data",
+        variables={},
+    )
+
+    monkeypatch.setattr("kist.tui.app.detect_kicad", lambda: env)
+    monkeypatch.setattr(
+        "kist.tui.app.load_or_build_index",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("bad fp-lib-table")),
+    )
+    monkeypatch.setattr(
+        app,
+        "notify",
+        lambda msg, severity="information", **kwargs: notices.append((msg, severity)),
+    )
+
+    assert app.get_library_index() is None
+    assert notices == [("Failed to read KiCad library tables: bad fp-lib-table", "warning")]

--- a/tests/tui/test_detail_modal.py
+++ b/tests/tui/test_detail_modal.py
@@ -16,6 +16,8 @@ from kist.tui.screens.browse import BrowseScreen
 from kist.tui.screens.detail import ConfirmModal, DetailModal
 from kist.tui.widgets.part_form import PartForm
 
+pytestmark = pytest.mark.slow
+
 
 def _make_proprietary_part() -> ProprietaryPart:
     return ProprietaryPart(

--- a/tests/tui/test_library_search_modal.py
+++ b/tests/tui/test_library_search_modal.py
@@ -1,5 +1,7 @@
 """LibrarySearchModal tests -- search, filter, select, and cancel."""
 
+import asyncio
+
 from textual.app import App
 from textual.widgets import DataTable, Input, Label
 
@@ -38,13 +40,19 @@ async def test_modal_shows_status_text():
         assert "6 footprints" in str(status.content)
 
 
+async def _wait_debounce(pilot) -> None:
+    """Wait long enough for the search debounce timer to fire."""
+    await asyncio.sleep(0.25)
+    await pilot.pause()
+
+
 async def test_modal_filters_by_search():
     app = ModalApp()
     async with app.run_test() as pilot:
         await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS, title="Footprints"))
         search = app.screen.query_one("#libsearch-input", Input)
         search.value = "0603"
-        await pilot.pause()
+        await _wait_debounce(pilot)
         table = app.screen.query_one("#libsearch-table", DataTable)
         assert table.row_count == 2  # R_0603 and C_0603
 
@@ -55,7 +63,7 @@ async def test_modal_filter_updates_status():
         await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS, title="Footprints"))
         search = app.screen.query_one("#libsearch-input", Input)
         search.value = "QFP"
-        await pilot.pause()
+        await _wait_debounce(pilot)
         status = app.screen.query_one("#libsearch-status", Label)
         assert "1 / 6" in str(status.content)
 
@@ -66,7 +74,7 @@ async def test_modal_filter_case_insensitive():
         await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS, title="Footprints"))
         search = app.screen.query_one("#libsearch-input", Input)
         search.value = "capacitor"
-        await pilot.pause()
+        await _wait_debounce(pilot)
         table = app.screen.query_one("#libsearch-table", DataTable)
         assert table.row_count == 2
 
@@ -112,12 +120,12 @@ async def test_modal_clear_search_restores_all():
         await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS, title="Footprints"))
         search = app.screen.query_one("#libsearch-input", Input)
         search.value = "QFP"
-        await pilot.pause()
+        await _wait_debounce(pilot)
         table = app.screen.query_one("#libsearch-table", DataTable)
         assert table.row_count == 1
         # Clear search
         search.value = ""
-        await pilot.pause()
+        await _wait_debounce(pilot)
         assert table.row_count == 6
 
 

--- a/tests/tui/test_library_search_modal.py
+++ b/tests/tui/test_library_search_modal.py
@@ -1,0 +1,129 @@
+"""LibrarySearchModal tests -- search, filter, select, and cancel."""
+
+from textual.app import App
+from textual.widgets import DataTable, Input, Label
+
+from kist.kicad.indexer import LibraryItem
+from kist.tui.modals.library_search import LibrarySearchModal
+
+SAMPLE_ITEMS = [
+    LibraryItem(library="Resistor_SMD", name="R_0402_1005Metric", source="kicad"),
+    LibraryItem(library="Resistor_SMD", name="R_0603_1608Metric", source="kicad"),
+    LibraryItem(library="Resistor_SMD", name="R_0805_2012Metric", source="kicad"),
+    LibraryItem(library="Capacitor_SMD", name="C_0402_1005Metric", source="kicad"),
+    LibraryItem(library="Capacitor_SMD", name="C_0603_1608Metric", source="kicad"),
+    LibraryItem(library="QFP", name="LQFP-48_7x7mm_P0.5mm", source="kicad"),
+]
+
+
+class ModalApp(App):
+    """Minimal app for testing modals."""
+
+    CSS = ""
+
+
+async def test_modal_shows_all_items():
+    app = ModalApp()
+    async with app.run_test():
+        await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS, title="Footprints"))
+        table = app.screen.query_one("#libsearch-table", DataTable)
+        assert table.row_count == 6
+
+
+async def test_modal_shows_status_text():
+    app = ModalApp()
+    async with app.run_test():
+        await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS, title="Footprints"))
+        status = app.screen.query_one("#libsearch-status", Label)
+        assert "6 footprints" in str(status.content)
+
+
+async def test_modal_filters_by_search():
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS, title="Footprints"))
+        search = app.screen.query_one("#libsearch-input", Input)
+        search.value = "0603"
+        await pilot.pause()
+        table = app.screen.query_one("#libsearch-table", DataTable)
+        assert table.row_count == 2  # R_0603 and C_0603
+
+
+async def test_modal_filter_updates_status():
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS, title="Footprints"))
+        search = app.screen.query_one("#libsearch-input", Input)
+        search.value = "QFP"
+        await pilot.pause()
+        status = app.screen.query_one("#libsearch-status", Label)
+        assert "1 / 6" in str(status.content)
+
+
+async def test_modal_filter_case_insensitive():
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS, title="Footprints"))
+        search = app.screen.query_one("#libsearch-input", Input)
+        search.value = "capacitor"
+        await pilot.pause()
+        table = app.screen.query_one("#libsearch-table", DataTable)
+        assert table.row_count == 2
+
+
+async def test_modal_escape_dismisses():
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        results = []
+        await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS), callback=results.append)
+        assert isinstance(app.screen, LibrarySearchModal)
+        await pilot.press("escape")
+        assert not isinstance(app.screen, LibrarySearchModal)
+        assert results == [None]
+
+
+async def test_modal_row_select_returns_reference():
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        results = []
+        await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS), callback=results.append)
+        table = app.screen.query_one("#libsearch-table", DataTable)
+        # Move to first row and select it
+        table.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        assert len(results) == 1
+        assert results[0] == "Resistor_SMD:R_0402_1005Metric"
+
+
+async def test_modal_empty_items():
+    app = ModalApp()
+    async with app.run_test():
+        await app.push_screen(LibrarySearchModal([], title="Symbols"))
+        table = app.screen.query_one("#libsearch-table", DataTable)
+        assert table.row_count == 0
+        status = app.screen.query_one("#libsearch-status", Label)
+        assert "0 symbols" in str(status.content)
+
+
+async def test_modal_clear_search_restores_all():
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS, title="Footprints"))
+        search = app.screen.query_one("#libsearch-input", Input)
+        search.value = "QFP"
+        await pilot.pause()
+        table = app.screen.query_one("#libsearch-table", DataTable)
+        assert table.row_count == 1
+        # Clear search
+        search.value = ""
+        await pilot.pause()
+        assert table.row_count == 6
+
+
+async def test_modal_border_title():
+    app = ModalApp()
+    async with app.run_test():
+        await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS, title="Symbols"))
+        container = app.screen.query_one("#libsearch-container")
+        assert container.border_title == "Symbols"


### PR DESCRIPTION
## Summary

When adding parts, users must manually type footprint/symbol references like
`Resistor_SMD:R_0603_1608Metric` into text inputs. This adds a library indexer
that discovers all available footprints and symbols from KiCad's installed
libraries, and an fzf-style search modal in the TUI for selecting from the index.

## Changes

- **KiCad discovery** (`kicad/discovery.py`): detect KiCad config/data dirs by
  probing for versioned subdirs, resolve `${KICAD9_FOOTPRINT_DIR}` style
  variables, parse global `fp-lib-table` / `sym-lib-table` files. Handles
  Nix-managed installs by extracting paths from the wrapper script.
- **Library indexer** (`kicad/indexer.py`): build searchable catalog of
  footprints (dir listing, ~0.1s) and symbols (regex name scan, ~1.5s). JSON
  cache keyed on lib-table mtimes + resolved variable paths.
- **Search modal** (`tui/modals/library_search.py`): fzf-style modal with
  debounced input, substring matching, capped at 200 displayed rows.
- **Part form integration**: browse buttons next to symbol/footprint inputs,
  app lazily builds and caches index on first use.

## Test plan

- 39 new unit tests covering discovery (17), indexing (12), and modal (10)
- Full suite passes (570 tests)
- Manual: open add screen, click browse next to footprint, type "0603", select
  result, verify input populated with `Library:Footprint` string

## Notes

- Substring matching only for now; fuzzy matching (rapidfuzz) can be added
  later without changing the architecture
- Symbol indexing uses a regex scan (`^\t\(symbol "NAME"`) instead of full
  S-expression parsing -- 48x faster (73s -> 1.5s for 225 libraries)
- Nix detection is conservative: only triggers when default data dirs are
  empty AND the kicad binary resolves to a Nix store path