### PR TITLE
kicad: Push part specs as symbol properties

### DIFF
--- a/src/kist/core/sync.py
+++ b/src/kist/core/sync.py
@@ -9,7 +9,7 @@ from kist.core.database import PartsDatabase
 from kist.kicad.lib_table import generate_sym_lib_table, update_sym_lib_table
 from kist.kicad.mapping import library_filename
 from kist.kicad.symbols import SymbolLibrary, get_visible_properties
-from kist.kicad.templates import symbol_for_part
+from kist.kicad.templates import spec_property_key, symbol_for_part
 from kist.models.config import LibraryConfig
 
 SYM_LIB_TABLE = "sym-lib-table"
@@ -53,7 +53,14 @@ def sync_symbols(
 
         for part in parts:
             existing = lib.get_symbol(part.name)
-            visible = get_visible_properties(existing) if existing else None
+            visible = None
+            if existing:
+                visible_props = get_visible_properties(existing)
+                spec_props = {
+                    spec_property_key(spec_key)
+                    for spec_key in (part.specifications or {})
+                }
+                visible = visible_props & spec_props
             lib.set_symbol(
                 part.name,
                 symbol_for_part(part, config.categories, visible_specs=visible),

--- a/src/kist/core/sync.py
+++ b/src/kist/core/sync.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from kist.core.database import PartsDatabase
 from kist.kicad.lib_table import generate_sym_lib_table, update_sym_lib_table
 from kist.kicad.mapping import library_filename
-from kist.kicad.symbols import SymbolLibrary
+from kist.kicad.symbols import SymbolLibrary, get_visible_properties
 from kist.kicad.templates import symbol_for_part
 from kist.models.config import LibraryConfig
 
@@ -52,7 +52,12 @@ def sync_symbols(
             lib = SymbolLibrary.empty()
 
         for part in parts:
-            lib.set_symbol(part.name, symbol_for_part(part, config.categories))
+            existing = lib.get_symbol(part.name)
+            visible = get_visible_properties(existing) if existing else None
+            lib.set_symbol(
+                part.name,
+                symbol_for_part(part, config.categories, visible_specs=visible),
+            )
 
         lib.save(path)
         written.append(path)

--- a/src/kist/kicad/symbols.py
+++ b/src/kist/kicad/symbols.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from kist.sexpr import Atom, SexprError, dumps, find_all, parse_one
+from kist.sexpr import Atom, SexprError, dumps, find_all, find_one, parse_one
 
 # -- Constants ---
 
@@ -151,3 +151,30 @@ class SymbolLibrary:
                         ],
                     ]
                 )
+
+
+# -- Property visibility ---
+
+
+def _is_property_hidden(prop: list) -> bool:
+    """True if this ``(property ...)`` node has ``(hide yes)`` in its effects."""
+    effects = find_one(prop, "effects")
+    if effects is None:
+        return False
+    hide = find_one(effects, "hide")
+    return hide is not None and len(hide) > 1 and str(hide[1]) == "yes"
+
+
+def get_visible_properties(sym: list) -> set[str]:
+    """
+    Return the names of properties that are NOT hidden on *sym*.
+
+    Useful for preserving user-toggled visibility across re-syncs:
+    if a user makes a spec property visible in KiCad's editor,
+    ``sync_symbols`` should not force it back to hidden.
+    """
+    visible: set[str] = set()
+    for prop in find_all(sym, "property"):
+        if len(prop) > 1 and not _is_property_hidden(prop):
+            visible.add(str(prop[1]))
+    return visible

--- a/src/kist/kicad/templates.py
+++ b/src/kist/kicad/templates.py
@@ -447,6 +447,24 @@ _TEMPLATES: dict[str, Callable] = {
     "inductor": inductor_symbol,
 }
 
+_RESERVED_PROPERTY_KEYS = frozenset(
+    {
+        "Reference",
+        "Value",
+        "Footprint",
+        "Datasheet",
+        "Description",
+        "ki_keywords",
+    }
+)
+
+
+def spec_property_key(spec_key: str) -> str:
+    """Map a part spec key to a non-conflicting KiCad property name."""
+    if spec_key in _RESERVED_PROPERTY_KEYS:
+        return f"spec_{spec_key}"
+    return spec_key
+
 
 def _spec_property(key: str, value: str, *, hidden: bool = True) -> list[SExpr]:
     """A specification property at (0,0,0).  Hidden by default."""
@@ -505,4 +523,5 @@ def _append_specs(
         return
     visible = visible_specs or set()
     for key, value in part.specifications.items():
-        tree.append(_spec_property(key, value, hidden=key not in visible))
+        prop_key = spec_property_key(key)
+        tree.append(_spec_property(prop_key, value, hidden=prop_key not in visible))

--- a/src/kist/kicad/templates.py
+++ b/src/kist/kicad/templates.py
@@ -448,15 +448,38 @@ _TEMPLATES: dict[str, Callable] = {
 }
 
 
+def _spec_property(key: str, value: str, *, hidden: bool = True) -> list[SExpr]:
+    """A specification property at (0,0,0).  Hidden by default."""
+    effects: list[SExpr] = [
+        _k("effects"),
+        [_k("font"), [_k("size"), _k("1.27"), _k("1.27")]],
+    ]
+    if hidden:
+        effects.append([_k("hide"), _k("yes")])
+    return [
+        _k("property"),
+        _q(key),
+        _q(value),
+        [_k("at"), _k("0"), _k("0"), _k("0")],
+        effects,
+    ]
+
+
 def symbol_for_part(
     part: Part,
     categories: dict[str, CategoryDef] | None = None,
+    *,
+    visible_specs: set[str] | None = None,
 ) -> list[SExpr]:
     """
     Generate the appropriate symbol tree for *part*.
 
     Jellybean parts whose category has a ``symbol_template`` get full
     graphic templates. Everything else gets a stub with properties only.
+
+    Part specifications are appended as hidden properties. Any spec
+    name in *visible_specs* keeps its visible state (not forced hidden),
+    so that user-toggled visibility survives re-sync.
     """
     props = build_properties(part)
     if part.tier == Tier.JELLYBEAN and categories:
@@ -464,5 +487,22 @@ def symbol_for_part(
         if cat_def and cat_def.symbol_template:
             template_fn = _TEMPLATES.get(cat_def.symbol_template)
             if template_fn:
-                return template_fn(part.name, props)
-    return stub_symbol(part.name, props)
+                tree = template_fn(part.name, props)
+                _append_specs(tree, part, visible_specs)
+                return tree
+    tree = stub_symbol(part.name, props)
+    _append_specs(tree, part, visible_specs)
+    return tree
+
+
+def _append_specs(
+    tree: list[SExpr],
+    part: Part,
+    visible_specs: set[str] | None,
+) -> None:
+    """Append specification properties to a symbol tree."""
+    if not part.specifications:
+        return
+    visible = visible_specs or set()
+    for key, value in part.specifications.items():
+        tree.append(_spec_property(key, value, hidden=key not in visible))

--- a/tests/core/test_sync.py
+++ b/tests/core/test_sync.py
@@ -180,6 +180,100 @@ def test_updated_part_reflected_after_resync(library):
             break
 
 
+# --- spec properties ---
+
+
+def test_sync_writes_spec_properties(library):
+    """Synced resistor symbols include specification properties."""
+    root, db, config = library
+    part = _make_resistor("10kΩ", "1%", "0603")
+    db.add(part)
+
+    sync_symbols(root, db, config)
+
+    path = root / "symbols" / _res_filename()
+    lib = SymbolLibrary.load(path)
+    sym = lib.get_symbol(part.name)
+    # Find the resistance property
+    res_prop = _find_prop(sym, "resistance")
+    assert res_prop is not None
+    assert str(res_prop[2]) == "10kΩ"
+    tol_prop = _find_prop(sym, "tolerance")
+    assert tol_prop is not None
+    assert str(tol_prop[2]) == "1%"
+
+
+def test_sync_preserves_visible_spec_properties(library):
+    """If a user makes a spec property visible, re-sync preserves that."""
+    root, db, config = library
+    part = _make_resistor("10kΩ", "1%", "0603")
+    db.add(part)
+
+    # First sync -- all specs hidden
+    sync_symbols(root, db, config)
+
+    # Simulate user toggling "resistance" to visible in KiCad:
+    # remove (hide yes) from the resistance property's effects
+    path = root / "symbols" / _res_filename()
+    lib = SymbolLibrary.load(path)
+    sym = lib.get_symbol(part.name)
+    res_prop = _find_prop(sym, "resistance")
+    assert res_prop is not None
+    _make_prop_visible(res_prop)
+    lib.save(path)
+
+    # Re-sync -- should preserve visibility
+    sync_symbols(root, db, config)
+
+    lib = SymbolLibrary.load(path)
+    sym = lib.get_symbol(part.name)
+    res_prop = _find_prop(sym, "resistance")
+    assert res_prop is not None
+    assert not _prop_is_hidden(res_prop), "resistance should stay visible after re-sync"
+
+    # tolerance should still be hidden
+    tol_prop = _find_prop(sym, "tolerance")
+    assert tol_prop is not None
+    assert _prop_is_hidden(tol_prop)
+
+
+def _find_prop(sym, key):
+    for child in sym:
+        if (
+            isinstance(child, list)
+            and child
+            and child[0] == "property"
+            and len(child) > 2
+            and child[1] == key
+        ):
+            return child
+    return None
+
+
+def _prop_is_hidden(prop):
+    from kist.sexpr import find_one
+
+    effects = find_one(prop, "effects")
+    if effects is None:
+        return False
+    hide = find_one(effects, "hide")
+    return hide is not None and len(hide) > 1 and str(hide[1]) == "yes"
+
+
+def _make_prop_visible(prop):
+    """Remove (hide yes) from a property's effects."""
+    from kist.sexpr import find_one
+
+    effects = find_one(prop, "effects")
+    if effects is None:
+        return
+    effects[:] = [
+        child
+        for child in effects
+        if not (isinstance(child, list) and child and child[0] == "hide")
+    ]
+
+
 # --- edge cases ---
 
 

--- a/tests/core/test_sync.py
+++ b/tests/core/test_sync.py
@@ -9,6 +9,7 @@ from kist.core.database import PartsDatabase, create_empty
 from kist.core.sync import SYM_LIB_TABLE, sync_sym_lib_table, sync_symbols
 from kist.kicad.mapping import library_filename
 from kist.kicad.symbols import SymbolLibrary
+from kist.kicad.templates import spec_property_key, stub_symbol
 from kist.models import (
     JellybeanPart,
     LibraryConfig,
@@ -235,6 +236,57 @@ def test_sync_preserves_visible_spec_properties(library):
     tol_prop = _find_prop(sym, "tolerance")
     assert tol_prop is not None
     assert _prop_is_hidden(tol_prop)
+
+
+def test_sync_passes_only_spec_visibility_to_symbol_builder(library, monkeypatch):
+    """Visibility carryover should include only this part's spec properties."""
+    root, db, config = library
+    part = _make_resistor("10kΩ", "1%", "0603")
+    db.add(part)
+    sync_symbols(root, db, config)  # create existing symbol
+
+    captured: dict[str, set[str] | None] = {}
+
+    def fake_visible(_sym):
+        return {"Reference", "resistance", "not_a_spec"}
+
+    def fake_symbol_for_part(part_arg, categories_arg, *, visible_specs=None):
+        captured["visible_specs"] = visible_specs
+        return stub_symbol(part_arg.name, {"Reference": "R", "Value": "X"})
+
+    monkeypatch.setattr("kist.core.sync.get_visible_properties", fake_visible)
+    monkeypatch.setattr("kist.core.sync.symbol_for_part", fake_symbol_for_part)
+
+    sync_symbols(root, db, config)
+
+    assert captured["visible_specs"] == {"resistance"}
+
+
+def test_sync_preserves_visible_colliding_spec_property(library):
+    """Visibility preservation also works for renamed colliding spec keys."""
+    root, db, config = library
+    part = _make_resistor("10kΩ", "1%", "0603").model_copy(
+        update={"specifications": {"Value": "from-spec", "tolerance": "1%"}}
+    )
+    db.add(part)
+    sync_symbols(root, db, config)
+
+    path = root / "symbols" / _res_filename()
+    lib = SymbolLibrary.load(path)
+    sym = lib.get_symbol(part.name)
+    value_spec_key = spec_property_key("Value")
+    value_spec_prop = _find_prop(sym, value_spec_key)
+    assert value_spec_prop is not None
+    _make_prop_visible(value_spec_prop)
+    lib.save(path)
+
+    sync_symbols(root, db, config)
+
+    lib = SymbolLibrary.load(path)
+    sym = lib.get_symbol(part.name)
+    value_spec_prop = _find_prop(sym, value_spec_key)
+    assert value_spec_prop is not None
+    assert not _prop_is_hidden(value_spec_prop)
 
 
 def _find_prop(sym, key):

--- a/tests/kicad/test_symbols.py
+++ b/tests/kicad/test_symbols.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from kist.kicad.symbols import SymbolLibrary
+from kist.kicad.symbols import SymbolLibrary, get_visible_properties
 from kist.sexpr import Atom, dumps, find_one
 
 FIXTURES = Path(__file__).parents[1] / "fixtures" / "kicad"
@@ -264,6 +264,61 @@ def test_update_properties_raises_for_missing_symbol():
     lib = SymbolLibrary.empty()
     with pytest.raises(KeyError, match="NOPE"):
         lib.update_properties("NOPE", {"Value": "x"})
+
+
+# -- get_visible_properties ---
+
+
+def test_get_visible_properties_from_fixture():
+    """Device_RCL symbols have Reference and Value visible."""
+    lib = SymbolLibrary.load(DEVICE_RCL)
+    sym = lib.get_symbol("R")
+    assert sym is not None
+    visible = get_visible_properties(sym)
+    assert "Reference" in visible
+    assert "Value" in visible
+    # Hidden properties
+    assert "Footprint" not in visible
+    assert "Datasheet" not in visible
+
+
+def test_get_visible_properties_all_hidden():
+    """A symbol with only hidden properties returns empty set."""
+    sym = [
+        Atom("symbol"),
+        Atom("X", quoted=True),
+        [
+            Atom("property"),
+            Atom("Foo", quoted=True),
+            Atom("bar", quoted=True),
+            [Atom("at"), Atom("0"), Atom("0"), Atom("0")],
+            [
+                Atom("effects"),
+                [Atom("font"), [Atom("size"), Atom("1.27"), Atom("1.27")]],
+                [Atom("hide"), Atom("yes")],
+            ],
+        ],
+    ]
+    assert get_visible_properties(sym) == set()
+
+
+def test_get_visible_properties_no_hide_means_visible():
+    """A property without (hide yes) in effects is visible."""
+    sym = [
+        Atom("symbol"),
+        Atom("X", quoted=True),
+        [
+            Atom("property"),
+            Atom("MyField", quoted=True),
+            Atom("val", quoted=True),
+            [Atom("at"), Atom("0"), Atom("0"), Atom("0")],
+            [
+                Atom("effects"),
+                [Atom("font"), [Atom("size"), Atom("1.27"), Atom("1.27")]],
+            ],
+        ],
+    ]
+    assert "MyField" in get_visible_properties(sym)
 
 
 # -- Snapshot ---

--- a/tests/kicad/test_templates.py
+++ b/tests/kicad/test_templates.py
@@ -122,6 +122,39 @@ def test_build_properties_semi_jellybean(semi_jellybean_part):
     assert props["Value"] == "TL072"
 
 
+# -- Helpers for property inspection ---
+
+
+def _find_property(sym: list, key: str) -> list | None:
+    """Find a (property "key" ...) child in a symbol tree."""
+    for child in sym:
+        if (
+            isinstance(child, list)
+            and child
+            and child[0] == "property"
+            and len(child) > 2
+            and child[1] == key
+        ):
+            return child
+    return None
+
+
+def _is_hidden(prop: list) -> bool:
+    """True if property has (hide yes) in its effects."""
+    for child in prop:
+        if isinstance(child, list) and child and child[0] == "effects":
+            for effect in child:
+                if (
+                    isinstance(effect, list)
+                    and effect
+                    and effect[0] == "hide"
+                    and len(effect) > 1
+                    and str(effect[1]) == "yes"
+                ):
+                    return True
+    return False
+
+
 # -- symbol_for_part dispatch ---
 
 
@@ -137,6 +170,46 @@ def test_symbol_for_part_ic(proprietary_part: ProprietaryPart):
     # IC gets a stub -- no pins
     assert _count_pins(sym) == 0
     assert sym[1] == proprietary_part.name
+
+
+# -- Spec properties ---
+
+
+def test_symbol_for_part_includes_specs(jellybean_part: JellybeanPart):
+    """Jellybean specs appear as properties on the generated symbol."""
+    sym = symbol_for_part(jellybean_part, CATS)
+    res_prop = _find_property(sym, "resistance")
+    tol_prop = _find_property(sym, "tolerance")
+    assert res_prop is not None
+    assert str(res_prop[2]) == "10kΩ"
+    assert tol_prop is not None
+    assert str(tol_prop[2]) == "1%"
+
+
+def test_spec_properties_hidden_by_default(jellybean_part: JellybeanPart):
+    """Spec properties are hidden unless explicitly marked visible."""
+    sym = symbol_for_part(jellybean_part, CATS)
+    res_prop = _find_property(sym, "resistance")
+    tol_prop = _find_property(sym, "tolerance")
+    assert res_prop is not None and _is_hidden(res_prop)
+    assert tol_prop is not None and _is_hidden(tol_prop)
+
+
+def test_visible_specs_not_hidden(jellybean_part: JellybeanPart):
+    """Specs in visible_specs set are not hidden."""
+    sym = symbol_for_part(jellybean_part, CATS, visible_specs={"resistance"})
+    res_prop = _find_property(sym, "resistance")
+    tol_prop = _find_property(sym, "tolerance")
+    assert res_prop is not None and not _is_hidden(res_prop)
+    assert tol_prop is not None and _is_hidden(tol_prop)
+
+
+def test_proprietary_part_no_spec_properties(proprietary_part: ProprietaryPart):
+    """Proprietary parts without specs get no spec properties."""
+    sym = symbol_for_part(proprietary_part, CATS)
+    # Standard properties exist, but no spec properties
+    assert _find_property(sym, "Reference") is not None
+    assert _find_property(sym, "resistance") is None
 
 
 # -- Snapshot tests ---

--- a/tests/kicad/test_templates.py
+++ b/tests/kicad/test_templates.py
@@ -10,6 +10,7 @@ from kist.kicad.templates import (
     capacitor_symbol,
     inductor_symbol,
     resistor_symbol,
+    spec_property_key,
     stub_symbol,
     symbol_for_part,
 )
@@ -202,6 +203,22 @@ def test_visible_specs_not_hidden(jellybean_part: JellybeanPart):
     tol_prop = _find_property(sym, "tolerance")
     assert res_prop is not None and not _is_hidden(res_prop)
     assert tol_prop is not None and _is_hidden(tol_prop)
+
+
+def test_spec_property_key_prefixes_reserved_keys():
+    assert spec_property_key("Value") == "spec_Value"
+    assert spec_property_key("Reference") == "spec_Reference"
+    assert spec_property_key("resistance") == "resistance"
+
+
+def test_reserved_spec_keys_are_renamed(jellybean_part: JellybeanPart):
+    part = jellybean_part.model_copy(
+        update={"specifications": {"Value": "from-spec", "tolerance": "1%"}}
+    )
+    sym = symbol_for_part(part, CATS)
+    assert _find_property(sym, "spec_Value") is not None
+    assert _find_property(sym, "Value") is not None
+    assert _find_property(sym, "tolerance") is not None
 
 
 def test_proprietary_part_no_spec_properties(proprietary_part: ProprietaryPart):


### PR DESCRIPTION
## Summary

Part specifications (resistance, tolerance, etc.) stored in parts.json were invisible in KiCad. This pushes them as custom properties on generated symbols so they appear in the properties dialog, BOM exports, and schematic table view.

## Changes

- `symbol_for_part()` now appends spec key-value pairs as hidden properties after building the base symbol
- Added `get_visible_properties()` to detect which properties a user has toggled visible in KiCad's symbol editor
- `sync_symbols()` reads existing property visibility before regenerating, preserving user choices across re-syncs
- New `_spec_property()` helper with configurable hidden/visible flag

## Test plan

- Focused tests for sync/symbol/template paths pass locally
- Verified specs appear as properties on generated symbols
- Verified specs are hidden by default
- Verified visibility preservation on re-sync

## Notes

- Spec property keys are written as-is (e.g. `resistance`, `tolerance`)
- Works for both template-generated symbols (passives) and stubs (ICs)
