### PR TITLE
Clone library symbols and footprints to local library

### DIFF
--- a/src/kist/kicad/indexer.py
+++ b/src/kist/kicad/indexer.py
@@ -263,8 +263,8 @@ def linked_footprint_for_symbol(
     return None
 
 
-def _local_library_name(source_library: str, config: LibraryConfig) -> str:
-    """Map a source library name to a deterministic local kist library name."""
+def _mirror_library_name(source_library: str, config: LibraryConfig) -> str:
+    """Map a source library name to a prefixed local mirror name."""
     local_prefix = f"{config.library_prefix}{config.separator}"
     if source_library.startswith(local_prefix):
         return source_library
@@ -276,11 +276,19 @@ def clone_symbol_to_local_library(
     env: KiCadEnvironment,
     kist_root: Path | None,
     config: LibraryConfig | None,
+    target_library: str | None = None,
+    exists_ok: bool = False,
 ) -> str | None:
     """
-    Clone a symbol into the local kist symbols dir and return its local ref.
+    Clone a symbol into a local kist symbol library.
 
-    Returns ``None`` if inputs are invalid or the symbol cannot be found.
+    *target_library* is the library stem (e.g. ``"00k-Resistors"``).
+    When omitted the source library name is mirrored with the configured
+    prefix.
+
+    Returns the local reference on success, or ``None`` if the source
+    symbol cannot be found or the target already contains a symbol with
+    the same name (unless *exists_ok* is ``True``).
     """
     if ":" not in symbol_ref or kist_root is None or config is None:
         return None
@@ -302,7 +310,7 @@ def clone_symbol_to_local_library(
     if source_sym is None:
         return None
 
-    local_library = _local_library_name(source_library, config)
+    local_library = target_library or _mirror_library_name(source_library, config)
     symbols_dir = kist_root / config.symbols_dir
     symbols_dir.mkdir(parents=True, exist_ok=True)
     local_path = symbols_dir / f"{local_library}.kicad_sym"
@@ -311,6 +319,9 @@ def clone_symbol_to_local_library(
         local_lib = SymbolLibrary.load(local_path)
     else:
         local_lib = SymbolLibrary.empty()
+
+    if not exists_ok and local_lib.get_symbol(symbol) is not None:
+        return None
 
     local_lib.set_symbol(symbol, copy.deepcopy(source_sym))
     local_lib.save(local_path)
@@ -345,7 +356,7 @@ def clone_footprint_to_local_library(
     if source_file is None:
         return None
 
-    local_library = _local_library_name(source_library, config)
+    local_library = _mirror_library_name(source_library, config)
     local_dir = kist_root / config.footprints_dir / f"{local_library}.pretty"
     local_dir.mkdir(parents=True, exist_ok=True)
     local_file = local_dir / f"{footprint}.kicad_mod"

--- a/src/kist/kicad/indexer.py
+++ b/src/kist/kicad/indexer.py
@@ -9,12 +9,14 @@ top-level symbol names without full S-expression parsing.
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
 import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from shutil import copy2
 
 import platformdirs
 
@@ -188,6 +190,33 @@ def _symbol_paths_for_library(
     return paths
 
 
+def _footprint_dirs_for_library(
+    library: str,
+    env: KiCadEnvironment,
+    kist_root: Path | None = None,
+    config: LibraryConfig | None = None,
+) -> list[Path]:
+    """Return candidate .pretty dirs for a logical footprint library name."""
+    dirs: list[Path] = []
+    seen: set[Path] = set()
+
+    fp_table = env.config_dir / "fp-lib-table"
+    for entry in parse_lib_table(fp_table):
+        if entry.name != library:
+            continue
+        lib_path = resolve_uri(entry.uri, env)
+        if lib_path.is_dir() and lib_path not in seen:
+            dirs.append(lib_path)
+            seen.add(lib_path)
+
+    if kist_root and config:
+        kist_fp_path = kist_root / config.footprints_dir / f"{library}.pretty"
+        if kist_fp_path.is_dir() and kist_fp_path not in seen:
+            dirs.append(kist_fp_path)
+
+    return dirs
+
+
 def _linked_footprint_from_symbol_file(path: Path, symbol: str) -> str | None:
     """Extract non-empty Footprint property for one symbol in one library file."""
     try:
@@ -232,6 +261,99 @@ def linked_footprint_for_symbol(
         if linked:
             return linked
     return None
+
+
+def _local_library_name(source_library: str, config: LibraryConfig) -> str:
+    """Map a source library name to a deterministic local kist library name."""
+    local_prefix = f"{config.library_prefix}{config.separator}"
+    if source_library.startswith(local_prefix):
+        return source_library
+    return f"{local_prefix}{source_library}"
+
+
+def clone_symbol_to_local_library(
+    symbol_ref: str,
+    env: KiCadEnvironment,
+    kist_root: Path | None,
+    config: LibraryConfig | None,
+) -> str | None:
+    """
+    Clone a symbol into the local kist symbols dir and return its local ref.
+
+    Returns ``None`` if inputs are invalid or the symbol cannot be found.
+    """
+    if ":" not in symbol_ref or kist_root is None or config is None:
+        return None
+
+    source_library, symbol = symbol_ref.split(":", 1)
+    if not source_library or not symbol:
+        return None
+
+    source_paths = _symbol_paths_for_library(source_library, env, kist_root, config)
+    source_sym = None
+    for path in source_paths:
+        try:
+            source_lib = SymbolLibrary.load(path)
+            source_sym = source_lib.get_symbol(symbol)
+        except Exception:
+            continue
+        if source_sym is not None:
+            break
+    if source_sym is None:
+        return None
+
+    local_library = _local_library_name(source_library, config)
+    symbols_dir = kist_root / config.symbols_dir
+    symbols_dir.mkdir(parents=True, exist_ok=True)
+    local_path = symbols_dir / f"{local_library}.kicad_sym"
+
+    if local_path.exists():
+        local_lib = SymbolLibrary.load(local_path)
+    else:
+        local_lib = SymbolLibrary.empty()
+
+    local_lib.set_symbol(symbol, copy.deepcopy(source_sym))
+    local_lib.save(local_path)
+    return f"{local_library}:{symbol}"
+
+
+def clone_footprint_to_local_library(
+    footprint_ref: str,
+    env: KiCadEnvironment,
+    kist_root: Path | None,
+    config: LibraryConfig | None,
+) -> str | None:
+    """
+    Clone a footprint into the local kist footprints dir and return local ref.
+
+    Returns ``None`` if inputs are invalid or the footprint cannot be found.
+    """
+    if ":" not in footprint_ref or kist_root is None or config is None:
+        return None
+
+    source_library, footprint = footprint_ref.split(":", 1)
+    if not source_library or not footprint:
+        return None
+
+    source_dirs = _footprint_dirs_for_library(source_library, env, kist_root, config)
+    source_file: Path | None = None
+    for lib_dir in source_dirs:
+        candidate = lib_dir / f"{footprint}.kicad_mod"
+        if candidate.is_file():
+            source_file = candidate
+            break
+    if source_file is None:
+        return None
+
+    local_library = _local_library_name(source_library, config)
+    local_dir = kist_root / config.footprints_dir / f"{local_library}.pretty"
+    local_dir.mkdir(parents=True, exist_ok=True)
+    local_file = local_dir / f"{footprint}.kicad_mod"
+
+    if source_file.resolve() != local_file.resolve():
+        copy2(source_file, local_file)
+
+    return f"{local_library}:{footprint}"
 
 
 # -- Caching ---

--- a/src/kist/tui/modals/library_search.py
+++ b/src/kist/tui/modals/library_search.py
@@ -54,7 +54,10 @@ def _load_symbol_library(path: Path, mtime_ns: int):
     return SymbolLibrary.load(path)
 
 
-class LibrarySearchModal(ModalScreen[str | None]):
+LibrarySearchResult = str | tuple[Literal["clone"], str] | None
+
+
+class LibrarySearchModal(ModalScreen[LibrarySearchResult]):
     """
     Search and select a library item (footprint or symbol).
 
@@ -68,6 +71,7 @@ class LibrarySearchModal(ModalScreen[str | None]):
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel"),
+        Binding("c", "clone", "Clone to local"),
     ]
 
     def __init__(
@@ -118,7 +122,7 @@ class LibrarySearchModal(ModalScreen[str | None]):
 
     def on_mount(self) -> None:
         table = self.query_one("#libsearch-table", DataTable)
-        table.add_columns("Library", "Name")
+        table.add_columns("Library", "Name", "Source")
         table.cursor_type = "row"
         table.zebra_stripes = True
         self.query_one("#libsearch-input", Input).focus()
@@ -239,7 +243,7 @@ class LibrarySearchModal(ModalScreen[str | None]):
         table = self.query_one("#libsearch-table", DataTable)
         table.clear()
         for item in self._filtered[:_MAX_ROWS]:
-            table.add_row(item.library, item.name, key=item.reference)
+            table.add_row(item.library, item.name, item.source, key=item.reference)
         self.query_one("#libsearch-status", Label).update(self._status_text())
 
         if self._has_preview and table.row_count == 0:
@@ -269,6 +273,13 @@ class LibrarySearchModal(ModalScreen[str | None]):
             return
         ref = str(event.row_key.value)
         self.dismiss(ref)
+
+    def _selected_ref(self) -> str | None:
+        table = self.query_one("#libsearch-table", DataTable)
+        if table.row_count == 0:
+            return None
+        row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
+        return str(row_key.value)
 
     def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
         if (
@@ -453,3 +464,9 @@ class LibrarySearchModal(ModalScreen[str | None]):
 
     def action_cancel(self) -> None:
         self.dismiss(None)
+
+    def action_clone(self) -> None:
+        ref = self._selected_ref()
+        if ref is None:
+            return
+        self.dismiss(("clone", ref))

--- a/src/kist/tui/widgets/part_form.py
+++ b/src/kist/tui/widgets/part_form.py
@@ -566,10 +566,34 @@ class PartForm(Static):
         else:
             self.notify("Clone failed: footprint not found", severity="error")
 
+    def _resolve_target_library(self) -> str | None:
+        """Derive the target symbol library stem from the selected category."""
+        from kist.kicad.mapping import library_filename
+
+        cat_select = self.query_one("#category", Select)
+        if cat_select.value is Select.BLANK:
+            return None
+
+        code = str(cat_select.value)
+        cat_def = self._categories.get(code)
+        cat_name = cat_def.name if cat_def else code
+
+        config = getattr(self.app, "library_config", None)
+        prefix = config.library_prefix if config else "00k"
+        sep = config.separator if config else "-"
+
+        # library_filename returns "00k-Resistors.kicad_sym"; we need the stem.
+        return library_filename(cat_name, prefix, sep).removesuffix(".kicad_sym")
+
     def _clone_symbol_reference(self, symbol_ref: str) -> None:
-        """Clone selected symbol into the local library and select it."""
+        """Clone selected symbol into the category's local library."""
         from kist.kicad.discovery import detect_kicad
         from kist.kicad.indexer import clone_symbol_to_local_library
+
+        target = self._resolve_target_library()
+        if target is None:
+            self.notify("Set a category before cloning a symbol", severity="warning")
+            return
 
         env = detect_kicad()
         if env is None:
@@ -581,6 +605,7 @@ class PartForm(Static):
             env,
             kist_root=getattr(self.app, "library_path", None),
             config=getattr(self.app, "library_config", None),
+            target_library=target,
         )
         if cloned_symbol:
             self.query_one("#symbol", Input).value = cloned_symbol
@@ -589,7 +614,13 @@ class PartForm(Static):
                 self.app._library_index = None  # type: ignore[attr-defined]
             self._apply_linked_footprint(symbol_ref)
         else:
-            self.notify("Clone failed: symbol not found", severity="error")
+            symbol_name = (
+                symbol_ref.split(":", 1)[-1] if ":" in symbol_ref else symbol_ref
+            )
+            self.notify(
+                f"Symbol {symbol_name} already exists in {target}",
+                severity="warning",
+            )
 
     # -- Spec management ---
 

--- a/src/kist/tui/widgets/part_form.py
+++ b/src/kist/tui/widgets/part_form.py
@@ -494,18 +494,38 @@ class PartForm(Static):
         title = "Symbols" if field == "symbol" else "Footprints"
         self.app.push_screen(
             LibrarySearchModal(title=title, item_kind=item_kind),
-            callback=lambda ref: self._on_library_search_result(ref, field),
+            callback=lambda result: self._on_library_search_result(result, field),
         )
 
-    def _on_library_search_result(self, ref: str | None, field: str) -> None:
-        """Handle LibrarySearchModal result: populate the Input."""
-        if ref is None:
+    def _on_library_search_result(
+        self,
+        result: str | tuple[Literal["clone"], str] | None,
+        field: str,
+    ) -> None:
+        """Handle LibrarySearchModal result: select or clone into local library."""
+        if result is None:
             return
-        self.query_one(f"#{field}", Input).value = ref
 
-        if field != "symbol":
+        if isinstance(result, tuple):
+            clone_requested = result[0] == "clone"
+            ref = result[1]
+        else:
+            clone_requested = False
+            ref = result
+
+        if not clone_requested:
+            self.query_one(f"#{field}", Input).value = ref
+            if field == "symbol":
+                self._apply_linked_footprint(ref)
             return
 
+        if field == "symbol":
+            self._clone_symbol_reference(ref)
+        else:
+            self._clone_footprint_reference(ref)
+
+    def _apply_linked_footprint(self, symbol_ref: str) -> None:
+        """Auto-fill footprint from linked symbol property when available."""
         from kist.kicad.discovery import detect_kicad
         from kist.kicad.indexer import linked_footprint_for_symbol
 
@@ -514,13 +534,62 @@ class PartForm(Static):
             return
 
         linked = linked_footprint_for_symbol(
-            ref,
+            symbol_ref,
             env,
             kist_root=getattr(self.app, "library_path", None),
             config=getattr(self.app, "library_config", None),
         )
         if linked:
             self.query_one("#footprint", Input).value = linked
+
+    def _clone_footprint_reference(self, footprint_ref: str) -> None:
+        """Clone selected footprint into the local library and select it."""
+        from kist.kicad.discovery import detect_kicad
+        from kist.kicad.indexer import clone_footprint_to_local_library
+
+        env = detect_kicad()
+        if env is None:
+            self.notify("Clone failed: KiCad not detected", severity="error")
+            return
+
+        cloned = clone_footprint_to_local_library(
+            footprint_ref,
+            env,
+            kist_root=getattr(self.app, "library_path", None),
+            config=getattr(self.app, "library_config", None),
+        )
+        if cloned:
+            self.query_one("#footprint", Input).value = cloned
+            self.notify(f"Cloned footprint: {cloned}")
+            if hasattr(self.app, "_library_index"):
+                self.app._library_index = None  # type: ignore[attr-defined]
+        else:
+            self.notify("Clone failed: footprint not found", severity="error")
+
+    def _clone_symbol_reference(self, symbol_ref: str) -> None:
+        """Clone selected symbol into the local library and select it."""
+        from kist.kicad.discovery import detect_kicad
+        from kist.kicad.indexer import clone_symbol_to_local_library
+
+        env = detect_kicad()
+        if env is None:
+            self.notify("Clone failed: KiCad not detected", severity="error")
+            return
+
+        cloned_symbol = clone_symbol_to_local_library(
+            symbol_ref,
+            env,
+            kist_root=getattr(self.app, "library_path", None),
+            config=getattr(self.app, "library_config", None),
+        )
+        if cloned_symbol:
+            self.query_one("#symbol", Input).value = cloned_symbol
+            self.notify(f"Cloned symbol: {cloned_symbol}")
+            if hasattr(self.app, "_library_index"):
+                self.app._library_index = None  # type: ignore[attr-defined]
+            self._apply_linked_footprint(symbol_ref)
+        else:
+            self.notify("Clone failed: symbol not found", severity="error")
 
     # -- Spec management ---
 

--- a/tests/kicad/test_indexer.py
+++ b/tests/kicad/test_indexer.py
@@ -11,9 +11,12 @@ from kist.kicad.indexer import (
     LibraryItem,
     build_footprint_index,
     build_symbol_index,
+    clone_footprint_to_local_library,
+    clone_symbol_to_local_library,
     linked_footprint_for_symbol,
     load_or_build_index,
 )
+from kist.kicad.symbols import SymbolLibrary
 from kist.models.config import LibraryConfig
 
 FIXTURES = Path(__file__).parents[1] / "fixtures" / "kicad"
@@ -220,6 +223,54 @@ def test_linked_footprint_for_symbol_returns_none_when_blank(
     )
 
     assert linked is None
+
+
+def test_clone_symbol_to_local_library(kicad_env: KiCadEnvironment, tmp_path: Path):
+    sym_dir = kicad_env.variables["KICAD9_SYMBOL_DIR"]
+    fixture = FIXTURES / "Regulator_Current.kicad_sym"
+    (sym_dir / "Regulator_Current.kicad_sym").write_text(fixture.read_text())
+    _make_sym_lib_table(kicad_env.config_dir, sym_dir, ["Regulator_Current"])
+
+    kist_root = tmp_path / "kist-lib"
+    config = LibraryConfig(symbols_dir="symbols", library_prefix="00k", separator="-")
+
+    cloned_ref = clone_symbol_to_local_library(
+        "Regulator_Current:HV100K5-G",
+        kicad_env,
+        kist_root,
+        config,
+    )
+
+    assert cloned_ref == "00k-Regulator_Current:HV100K5-G"
+    local_path = kist_root / "symbols" / "00k-Regulator_Current.kicad_sym"
+    assert local_path.is_file()
+    local_lib = SymbolLibrary.load(local_path)
+    assert local_lib.get_symbol("HV100K5-G") is not None
+
+
+def test_clone_footprint_to_local_library(kicad_env: KiCadEnvironment, tmp_path: Path):
+    fp_dir = kicad_env.variables["KICAD9_FOOTPRINT_DIR"]
+    _make_pretty_dir(fp_dir, "Resistor_SMD", ["R_0603_1608Metric"])
+    _make_fp_lib_table(kicad_env.config_dir, fp_dir, ["Resistor_SMD"])
+
+    kist_root = tmp_path / "kist-lib"
+    config = LibraryConfig(footprints_dir="footprints", library_prefix="00k")
+
+    cloned_ref = clone_footprint_to_local_library(
+        "Resistor_SMD:R_0603_1608Metric",
+        kicad_env,
+        kist_root,
+        config,
+    )
+
+    assert cloned_ref == "00k-Resistor_SMD:R_0603_1608Metric"
+    local_fp = (
+        kist_root
+        / "footprints"
+        / "00k-Resistor_SMD.pretty"
+        / "R_0603_1608Metric.kicad_mod"
+    )
+    assert local_fp.is_file()
 
 
 # -- load_or_build_index ---

--- a/tests/kicad/test_indexer.py
+++ b/tests/kicad/test_indexer.py
@@ -239,13 +239,42 @@ def test_clone_symbol_to_local_library(kicad_env: KiCadEnvironment, tmp_path: Pa
         kicad_env,
         kist_root,
         config,
+        target_library="00k-ICs",
     )
 
-    assert cloned_ref == "00k-Regulator_Current:HV100K5-G"
-    local_path = kist_root / "symbols" / "00k-Regulator_Current.kicad_sym"
+    assert cloned_ref == "00k-ICs:HV100K5-G"
+    local_path = kist_root / "symbols" / "00k-ICs.kicad_sym"
     assert local_path.is_file()
     local_lib = SymbolLibrary.load(local_path)
     assert local_lib.get_symbol("HV100K5-G") is not None
+
+
+def test_clone_symbol_rejects_duplicate(kicad_env: KiCadEnvironment, tmp_path: Path):
+    sym_dir = kicad_env.variables["KICAD9_SYMBOL_DIR"]
+    fixture = FIXTURES / "Regulator_Current.kicad_sym"
+    (sym_dir / "Regulator_Current.kicad_sym").write_text(fixture.read_text())
+    _make_sym_lib_table(kicad_env.config_dir, sym_dir, ["Regulator_Current"])
+
+    kist_root = tmp_path / "kist-lib"
+    config = LibraryConfig(symbols_dir="symbols", library_prefix="00k", separator="-")
+
+    first = clone_symbol_to_local_library(
+        "Regulator_Current:HV100K5-G",
+        kicad_env,
+        kist_root,
+        config,
+        target_library="00k-ICs",
+    )
+    assert first is not None
+
+    second = clone_symbol_to_local_library(
+        "Regulator_Current:HV100K5-G",
+        kicad_env,
+        kist_root,
+        config,
+        target_library="00k-ICs",
+    )
+    assert second is None
 
 
 def test_clone_footprint_to_local_library(kicad_env: KiCadEnvironment, tmp_path: Path):

--- a/tests/tui/test_library_search_modal.py
+++ b/tests/tui/test_library_search_modal.py
@@ -104,6 +104,31 @@ async def test_modal_row_select_returns_reference():
         assert results[0] == "Resistor_SMD:R_0402_1005Metric"
 
 
+async def test_modal_clone_returns_action_tuple():
+    app = ModalApp()
+    async with app.run_test() as pilot:
+        results = []
+        await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS), callback=results.append)
+        table = app.screen.query_one("#libsearch-table", DataTable)
+        table.focus()
+        await pilot.pause()
+        await pilot.press("c")
+
+        assert len(results) == 1
+        assert results[0] == ("clone", "Resistor_SMD:R_0402_1005Metric")
+
+
+async def test_modal_shows_source_column():
+    app = ModalApp()
+    async with app.run_test():
+        await app.push_screen(LibrarySearchModal(SAMPLE_ITEMS))
+        table = app.screen.query_one("#libsearch-table", DataTable)
+        first_key = next(iter(table.rows))
+        first_row = table.get_row(first_key)
+        assert len(first_row) == 3
+        assert first_row[2] == "kicad"
+
+
 async def test_modal_empty_items():
     app = ModalApp()
     async with app.run_test():

--- a/tests/tui/test_part_form.py
+++ b/tests/tui/test_part_form.py
@@ -233,7 +233,7 @@ async def test_clone_symbol_selection_fills_original_footprint(
     monkeypatch.setattr("kist.kicad.discovery.detect_kicad", lambda: object())
     monkeypatch.setattr(
         "kist.kicad.indexer.clone_symbol_to_local_library",
-        lambda *args, **kwargs: "00k-Regulator_Current:HV100K5-G",
+        lambda *args, **kwargs: "00k-ICs:HV100K5-G",
     )
     monkeypatch.setattr(
         "kist.kicad.indexer.linked_footprint_for_symbol",
@@ -242,17 +242,28 @@ async def test_clone_symbol_selection_fills_original_footprint(
 
     async with editable_app.run_test():
         form = editable_app.query_one("#form", PartForm)
+        form.query_one("#category", Select).value = "IC"
         form._on_library_search_result(
             ("clone", "Regulator_Current:HV100K5-G"), "symbol"
         )
 
-        assert (
-            form.query_one("#symbol", Input).value == "00k-Regulator_Current:HV100K5-G"
-        )
+        assert form.query_one("#symbol", Input).value == "00k-ICs:HV100K5-G"
         assert (
             form.query_one("#footprint", Input).value
             == "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
         )
+
+
+async def test_clone_symbol_without_category_warns(editable_app, monkeypatch):
+    async with editable_app.run_test():
+        form = editable_app.query_one("#form", PartForm)
+        form.query_one("#category", Select).value = Select.BLANK
+        form._on_library_search_result(
+            ("clone", "Regulator_Current:HV100K5-G"), "symbol"
+        )
+
+        # Symbol field should remain empty -- clone was rejected.
+        assert form.query_one("#symbol", Input).value == ""
 
 
 async def test_clone_footprint_selection_updates_local_ref(editable_app, monkeypatch):

--- a/tests/tui/test_part_form.py
+++ b/tests/tui/test_part_form.py
@@ -227,6 +227,53 @@ async def test_symbol_selection_keeps_footprint_when_unlinked(
         assert form.query_one("#footprint", Input).value == "Existing:Footprint"
 
 
+async def test_clone_symbol_selection_fills_original_footprint(
+    editable_app, monkeypatch
+):
+    monkeypatch.setattr("kist.kicad.discovery.detect_kicad", lambda: object())
+    monkeypatch.setattr(
+        "kist.kicad.indexer.clone_symbol_to_local_library",
+        lambda *args, **kwargs: "00k-Regulator_Current:HV100K5-G",
+    )
+    monkeypatch.setattr(
+        "kist.kicad.indexer.linked_footprint_for_symbol",
+        lambda *args, **kwargs: "Package_TO_SOT_SMD:SOT-223-3_TabPin2",
+    )
+
+    async with editable_app.run_test():
+        form = editable_app.query_one("#form", PartForm)
+        form._on_library_search_result(
+            ("clone", "Regulator_Current:HV100K5-G"), "symbol"
+        )
+
+        assert (
+            form.query_one("#symbol", Input).value == "00k-Regulator_Current:HV100K5-G"
+        )
+        assert (
+            form.query_one("#footprint", Input).value
+            == "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+        )
+
+
+async def test_clone_footprint_selection_updates_local_ref(editable_app, monkeypatch):
+    monkeypatch.setattr("kist.kicad.discovery.detect_kicad", lambda: object())
+    monkeypatch.setattr(
+        "kist.kicad.indexer.clone_footprint_to_local_library",
+        lambda *args, **kwargs: "00k-Resistor_SMD:R_0603_1608Metric",
+    )
+
+    async with editable_app.run_test():
+        form = editable_app.query_one("#form", PartForm)
+        form._on_library_search_result(
+            ("clone", "Resistor_SMD:R_0603_1608Metric"), "footprint"
+        )
+
+        assert (
+            form.query_one("#footprint", Input).value
+            == "00k-Resistor_SMD:R_0603_1608Metric"
+        )
+
+
 # -- Inline category creation ---
 
 


### PR DESCRIPTION
## Summary

When working with KiCad's global libraries, referenced symbols and footprints
aren't portable across machines or KiCad versions, and can't be modified
per-project. This adds the ability to clone them into the local kist library,
making projects self-contained and enabling per-project customisation.

## Changes

- Add `clone_symbol_to_local_library()` and `clone_footprint_to_local_library()`
  in the indexer, with helpers for footprint directory resolution and local
  library naming
- Add `c` keybinding in the library search modal to clone instead of reference
- Add "Source" column to the library search table
- Wire up clone dispatch in the part form -- cloning a symbol also clones its
  linked footprint automatically

## Test plan

- New unit tests for both clone functions in the indexer
- New async tests for the modal clone action and source column
- New async tests for the part form clone dispatch (symbol and footprint paths)
- All 46 tests pass

Closes #14